### PR TITLE
Fix CI workflow toolchain mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: ["main", "master"]
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   backend:
     runs-on: ubuntu-latest
@@ -25,14 +28,14 @@ jobs:
     env:
       PAYGATE_TEST_DB_URL: postgres://paygate:paygate@localhost:5432/paygate?sslmode=disable
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
         with:
-          go-version: '1.22'
+          go-version-file: go.mod
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
-          version: v1.61
+          version: v2.11.4
           args: --timeout=5m
       - name: Unit tests
         run: go test ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,5 +13,3 @@ linters:
     - gocritic
     - gosec
     - misspell
-issues:
-  exclude-use-default: false


### PR DESCRIPTION
## Summary
- derive the Go toolchain from `go.mod`
- upgrade checkout/setup-go action majors
- upgrade `golangci-lint-action` and linter version for Go 1.25 compatibility
- opt the workflow into Node 24 action execution

## Validation
- `make lint`
- `go test ./...`
- `go build ./...`

Closes #254


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded CI tooling and workflow configuration: force Node.js 24 for JS actions, source Go version from project manifest, and update linter/tooling versions and settings.
  * Simplified lint configuration by removing an explicit default-exclusion override.

Note: Infrastructure changes only. No user-facing features or behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->