### PR TITLE
Return codes.AlreadyExists for duplicate ledger source in gRPC

### DIFF
--- a/internal/ledger/grpc_server.go
+++ b/internal/ledger/grpc_server.go
@@ -2,7 +2,9 @@ package ledger
 
 import (
 	"context"
+	"errors"
 
+	"github.com/jackc/pgconn"
 	ledgerpb "github.com/sanskarpan/PayGate/internal/ledger/pb"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -30,6 +32,12 @@ func (s *GRPCServer) CreateEntries(ctx context.Context, req *ledgerpb.CreateEntr
 	}
 	txnID, err := s.svc.CreateEntries(ctx, req.MerchantId, req.SourceType, req.SourceId, "grpc create entries", entries)
 	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			// Duplicate (source_type, source_id) — idempotent replay; return AlreadyExists
+			// so callers can distinguish a genuine duplicate from a data-validation error.
+			return nil, status.Errorf(codes.AlreadyExists, "ledger entries already exist for source %s/%s", req.SourceType, req.SourceId)
+		}
 		return nil, status.Errorf(codes.InvalidArgument, "create entries: %v", err)
 	}
 	return &ledgerpb.CreateEntriesResponse{TransactionId: txnID}, nil


### PR DESCRIPTION
Closes #20

## Summary
- `CreateEntries` in `grpc_server.go` now unwraps `pgconn.PgError` and checks for code `23505` (unique_violation)
- Duplicate `(source_type, source_id)` returns `codes.AlreadyExists` so callers can handle idempotent replays separately from input errors

## Test plan
- [ ] `go build ./internal/ledger/...` passes
- [ ] Calling `CreateEntries` twice with same `source_type`/`source_id` returns gRPC `AlreadyExists` on second call

🤖 Generated with [Claude Code](https://claude.com/claude-code)