### PR TITLE
Add Config.Validate() and production startup safety check

### DIFF
--- a/cmd/api-gateway/main.go
+++ b/cmd/api-gateway/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"net/http"
+	"os"
 	"os/signal"
 	"syscall"
 	"time"
@@ -32,6 +33,11 @@ func main() {
 
 func run() error {
 	cfg := config.FromEnv()
+	if os.Getenv("APP_ENV") == "production" {
+		if err := cfg.Validate(); err != nil {
+			return err
+		}
+	}
 	l := logger.New("api-gateway")
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)

--- a/internal/common/config/config.go
+++ b/internal/common/config/config.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"strings"
 )
@@ -43,6 +45,23 @@ func FromEnv() Config {
 		KafkaBrokers:           splitCSV(kafkaBrokers),
 		DashboardSessionSecret: sessionSecret,
 	}
+}
+
+// Validate checks that all production-critical env vars have been set to
+// non-default values. Call this at startup when APP_ENV=production to prevent
+// running with insecure development defaults.
+func (c Config) Validate() error {
+	var errs []error
+	if c.DatabaseURL == "" {
+		errs = append(errs, fmt.Errorf("DATABASE_URL is required"))
+	}
+	if c.DashboardSessionSecret == "paygate-dev-dashboard-session-secret" {
+		errs = append(errs, fmt.Errorf("DASHBOARD_SESSION_SECRET must be changed from the default in production"))
+	}
+	if len(c.DashboardSessionSecret) < 32 {
+		errs = append(errs, fmt.Errorf("DASHBOARD_SESSION_SECRET must be at least 32 characters"))
+	}
+	return errors.Join(errs...)
 }
 
 func splitCSV(raw string) []string {


### PR DESCRIPTION
Closes #9

## Summary
- `config.Validate()` checks `DATABASE_URL` is set and `DASHBOARD_SESSION_SECRET` is neither the dev default nor shorter than 32 chars
- `cmd/api-gateway/main.go` calls `Validate()` at startup when `APP_ENV=production`, failing fast with a descriptive error

## Test plan
- [ ] `go build ./...` passes
- [ ] Running with `APP_ENV=production` and default secrets returns an error
- [ ] Running with `APP_ENV=production` and proper secrets starts normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)