### PR TITLE
Run golang-migrate up before integration tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,5 +61,9 @@ jobs:
         with:
           go-version-file: go.mod
           cache: true
+      - name: Install golang-migrate
+        run: go install github.com/golang-migrate/migrate/v4/cmd/migrate@v4.19.1
+      - name: Run database migrations
+        run: migrate -path ./migrations -database "$PAYGATE_TEST_DB_URL" up
       - name: Integration tests
         run: go test -tags=integration ./...


### PR DESCRIPTION
Closes #4

## Summary
- CI `integration` job now installs `golang-migrate` CLI (`v4.19.1`) and runs `migrate up` against the ephemeral Postgres service before running tests
- Ensures the test database always reflects the latest schema in `migrations/`

## Test plan
- [ ] CI integration job passes with migration step
- [ ] Adding a new migration file causes the next CI run to apply it automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)