### PR TITLE
Add API key rotation endpoint POST /v1/merchants/me/api-keys/{keyID}/rotate

### DIFF
--- a/internal/merchant/handler.go
+++ b/internal/merchant/handler.go
@@ -33,6 +33,7 @@ func (h *Handler) RegisterProtectedRoutes(mux *http.ServeMux, wrap func(scope AP
 	mux.Handle("GET /v1/merchants/me/api-keys", wrap(APIKeyScopeRead, http.HandlerFunc(h.listOwnAPIKeys)))
 	mux.Handle("POST /v1/merchants/me/api-keys", wrap(APIKeyScopeAdmin, http.HandlerFunc(h.createOwnAPIKey)))
 	mux.Handle("DELETE /v1/merchants/me/api-keys/{keyID}", wrap(APIKeyScopeAdmin, http.HandlerFunc(h.revokeOwnAPIKey)))
+	mux.Handle("POST /v1/merchants/me/api-keys/{keyID}/rotate", wrap(APIKeyScopeAdmin, http.HandlerFunc(h.rotateOwnAPIKey)))
 }
 
 func (h *Handler) createMerchant(w http.ResponseWriter, r *http.Request) {
@@ -333,6 +334,25 @@ func (h *Handler) revokeOwnAPIKey(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	httpx.WriteJSON(w, http.StatusOK, map[string]string{"status": "revoked"})
+}
+
+func (h *Handler) rotateOwnAPIKey(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	created, err := h.svc.RotateAPIKey(r.Context(), p.MerchantID, r.PathValue("keyID"))
+	if err != nil {
+		handleMerchantError(w, err, "api_key_rotation")
+		return
+	}
+	httpx.WriteJSON(w, http.StatusCreated, map[string]any{
+		"key_id":     created.KeyID,
+		"key_secret": created.KeySecret,
+		"mode":       created.Mode,
+		"scope":      created.Scope,
+	})
 }
 
 func (h *Handler) authorizeAPIKeyMutation(r *http.Request, merchantID string) (bool, error) {

--- a/internal/merchant/service.go
+++ b/internal/merchant/service.go
@@ -141,6 +141,38 @@ func (s *Service) RevokeAPIKey(ctx context.Context, merchantID, keyID string) er
 	return s.repo.RevokeAPIKey(ctx, merchantID, keyID)
 }
 
+// RotateAPIKey revokes the existing key and issues a replacement with the same
+// mode and scope. The new secret is returned once; it cannot be retrieved again.
+func (s *Service) RotateAPIKey(ctx context.Context, merchantID, keyID string) (GeneratedAPIKey, error) {
+	if strings.TrimSpace(merchantID) == "" || strings.TrimSpace(keyID) == "" {
+		return GeneratedAPIKey{}, ErrAPIKeyNotFound
+	}
+	existing, err := s.repo.GetAPIKeyByID(ctx, keyID)
+	if err != nil {
+		return GeneratedAPIKey{}, err
+	}
+	if existing.MerchantID != merchantID {
+		return GeneratedAPIKey{}, ErrAPIKeyNotFound
+	}
+	if existing.Status != APIKeyStatusActive {
+		return GeneratedAPIKey{}, ErrAPIKeyNotActive
+	}
+
+	created, err := s.CreateAPIKey(ctx, merchantID, CreateAPIKeyInput{
+		Mode:  existing.Mode,
+		Scope: existing.Scope,
+	})
+	if err != nil {
+		return GeneratedAPIKey{}, err
+	}
+
+	if err := s.repo.RevokeAPIKey(ctx, merchantID, keyID); err != nil {
+		return GeneratedAPIKey{}, err
+	}
+
+	return created, nil
+}
+
 func (s *Service) AuthenticateAPIKey(ctx context.Context, keyID, keySecret string, requiredScope APIKeyScope) (APIKey, error) {
 	key, err := s.repo.GetAPIKeyByID(ctx, keyID)
 	if err != nil {


### PR DESCRIPTION
Closes #13

## Summary
- `RotateAPIKey(ctx, merchantID, keyID)` in `merchant/service.go`: validates ownership, creates replacement key with same mode/scope, then revokes the old key
- `POST /v1/merchants/me/api-keys/{keyID}/rotate` in `merchant/handler.go`: requires `admin` scope, returns `201` with new `key_id`/`key_secret`
- Returns `404` if key doesn't belong to merchant, `403` if already revoked

## Test plan
- [ ] `go build ./...` passes
- [ ] `POST /v1/merchants/me/api-keys/{keyID}/rotate` with admin-scoped session returns new key credentials
- [ ] Old key is rejected on the next request
- [ ] Rotation on an already-revoked key returns an error

🤖 Generated with [Claude Code](https://claude.com/claude-code)