### PR TITLE
Add Architecture Decision Records (ADRs 001-004)

### DIFF
--- a/docs/adr/001-modular-monolith-boundary.md
+++ b/docs/adr/001-modular-monolith-boundary.md
@@ -1,0 +1,39 @@
+# ADR-001: Modular Monolith Boundary Strategy
+
+**Status:** Accepted
+**Date:** 2026-05-01
+
+## Context
+
+PayGate is a payment platform that needs to balance developer velocity, operational simplicity, and future scalability. The choice of architecture—microservices, modular monolith, or monolith—has significant long-term consequences.
+
+Early-stage payment platforms benefit from tight coupling of concerns (orders, payments, ledger, merchants) to avoid distributed transaction complexity. However, long-term scalability requires clear domain boundaries that could be extracted later.
+
+## Decision
+
+Adopt a **modular monolith** where each domain (`merchant`, `order`, `payment`, `ledger`) is a self-contained Go package with:
+
+- Its own `domain.go` (entities, errors, state machine)
+- Its own `repository.go` interface + `postgres.go` implementation
+- Its own `service.go` (business logic, no HTTP/gRPC coupling)
+- Its own `handler.go` (HTTP adapter, no business logic)
+
+Packages **may not** import each other directly except via:
+- Explicit service constructor injection (`payment.NewService(repo, gateway, orderSvc, ledgerSvc)`)
+- Shared infrastructure packages under `internal/common/`
+
+## Consequences
+
+**Positive:**
+- No distributed transactions; all cross-domain writes happen in a single Postgres transaction
+- Clear seams for future microservice extraction without large refactors
+- `go test ./internal/payment/...` is fast and isolated
+
+**Negative:**
+- All code runs in one process—a bug in one domain can affect others
+- Future extraction of a domain requires careful API boundary design
+
+## Alternatives Considered
+
+- **Microservices from day one:** Rejected due to operational overhead and distributed transaction complexity (sagas, 2PC) that is disproportionate for the current team size
+- **Flat monolith:** Rejected because undisciplined cross-package imports create tight coupling that is hard to untangle later

--- a/docs/adr/002-transactional-outbox.md
+++ b/docs/adr/002-transactional-outbox.md
@@ -1,0 +1,47 @@
+# ADR-002: Transactional Outbox for Event Publishing
+
+**Status:** Accepted
+**Date:** 2026-05-01
+
+## Context
+
+PayGate must publish domain events (e.g., `payment.captured`, `order.expired`) to Kafka for downstream consumers (webhooks, analytics, reconciliation). Publishing directly to Kafka inside a business transaction is unsafe: if Kafka is unavailable, the transaction fails; if the DB commits but Kafka publish fails, the event is lost.
+
+## Decision
+
+Use the **transactional outbox pattern**:
+
+1. Within the same Postgres transaction that changes domain state, write an event row to `public.outbox`
+2. A background relay (`outbox.Relay`) polls unpublished rows using `SELECT ... FOR UPDATE SKIP LOCKED` and publishes them to Kafka
+3. Once published, the relay sets `published_at = NOW()`
+
+The outbox table schema:
+```sql
+CREATE TABLE public.outbox (
+    id             BIGSERIAL PRIMARY KEY,
+    aggregate_type TEXT      NOT NULL,
+    aggregate_id   TEXT      NOT NULL,
+    event_type     TEXT      NOT NULL,
+    merchant_id    TEXT      NOT NULL,
+    payload        JSONB     NOT NULL,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    published_at   TIMESTAMPTZ
+);
+```
+
+## Consequences
+
+**Positive:**
+- Atomicity: either the domain state change AND the event record commit together, or neither does
+- At-least-once delivery: the relay retries unpublished rows on restart
+- Kafka outages don't fail business transactions; rows accumulate and drain when Kafka recovers
+
+**Negative:**
+- Events are delivered with eventual consistency (relay poll interval latency, typically < 1s)
+- Relay must handle duplicate publishes idempotently (downstream consumers must be idempotent)
+- The outbox table grows unboundedly without a cleanup job (future work: archive rows older than 30 days)
+
+## Alternatives Considered
+
+- **Publish inside transaction:** Rejected — Kafka publish in a DB transaction creates a distributed transaction; Kafka unavailability fails payment writes
+- **Debezium CDC:** Valid long-term option; rejected for now due to operational complexity of running a CDC connector

--- a/docs/adr/003-double-entry-ledger.md
+++ b/docs/adr/003-double-entry-ledger.md
@@ -1,0 +1,51 @@
+# ADR-003: Double-Entry Ledger Model
+
+**Status:** Accepted
+**Date:** 2026-05-01
+
+## Context
+
+PayGate moves money between parties (customers, merchants, platform). We need an auditable financial record that can reconstruct balances at any point in time, support reconciliation, and detect accounting bugs (unbalanced entries).
+
+## Decision
+
+Implement a **double-entry ledger** where every financial event produces a set of `Entry` rows that satisfy the invariant:
+
+```
+SUM(debit_amount) == SUM(credit_amount)  for any transaction
+```
+
+Account codes used:
+| Code | Meaning |
+|---|---|
+| `CUSTOMER_RECEIVABLE` | Amount owed by the customer |
+| `MERCHANT_PAYABLE` | Amount owed to the merchant |
+| `PLATFORM_FEE_REVENUE` | Platform's retained fee |
+
+Each ledger transaction references `(source_type, source_id)` (e.g., `payment` / `pay_xxx`) and is append-only — rows are never updated or deleted.
+
+The service validates balance before inserting:
+```go
+func ValidateEntries(entries []Entry) error {
+    var debit, credit int64
+    for _, e := range entries { debit += e.DebitAmount; credit += e.CreditAmount }
+    if debit != credit { return ErrUnbalancedEntries }
+    return nil
+}
+```
+
+## Consequences
+
+**Positive:**
+- Any account balance can be computed as `SUM(credit) - SUM(debit)` at any point in time
+- Bugs in entry construction are caught at write time, not at reconciliation time
+- Append-only design makes auditing and compliance straightforward
+
+**Negative:**
+- More complex than a simple payment amount column; requires 2–4 rows per transaction
+- Balance queries require aggregation; an indexed materialized view may be needed at scale
+
+## Alternatives Considered
+
+- **Single-column balance update:** Simple but non-auditable, prone to race conditions on concurrent captures, and cannot reconstruct history
+- **Event sourcing entire ledger:** Technically correct but adds significant complexity for queries and projections

--- a/docs/adr/004-idempotency-posture.md
+++ b/docs/adr/004-idempotency-posture.md
@@ -1,0 +1,42 @@
+# ADR-004: Idempotency Posture for Mutating API Calls
+
+**Status:** Accepted
+**Date:** 2026-05-01
+
+## Context
+
+Payment APIs are called over unreliable networks. Clients retry on timeout or network error, which can cause duplicate charges if the server processed the first request but the response was lost. We must handle the three cases:
+
+1. **Novel request** — process and store result
+2. **Duplicate before processing** — return same result without reprocessing
+3. **Duplicate during processing** — wait or return conflict
+
+## Decision
+
+Require an `Idempotency-Key` header on all mutating payment endpoints (`POST /v1/orders`, `POST /v1/payments/authorize`, `POST /v1/payments/{id}/capture`).
+
+The idempotency store uses a **two-tier architecture**:
+- **Tier 1 (Redis, fast path):** `SET NX PX 30000` — prevents concurrent duplicates within 30 s window
+- **Tier 2 (Postgres, durable):** `INSERT ... ON CONFLICT DO NOTHING` — stores `(merchant_id, key, status_code, response_body)` for replay after Redis expiry
+
+On replay, the middleware:
+1. Sets response status and body to the stored values
+2. Adds `Idempotent-Replayed: true` header
+
+If Redis is unavailable, the store falls back to Postgres-only for durability.
+
+## Consequences
+
+**Positive:**
+- Clients can safely retry any mutation without risk of double-charge
+- Fast in-memory check (< 1ms) on the hot path
+- Durable Postgres fallback survives process restarts and Redis outages
+
+**Negative:**
+- Idempotency keys must be unique per merchant+operation, not globally; clients must generate good keys (UUID or KSUID recommended)
+- Responses are replayed verbatim — a 500 on first try is also replayed, so transient errors "stick" for 30 s
+
+## Alternatives Considered
+
+- **Database-only idempotency:** Simpler but slower (one extra DB round-trip per request on hot path)
+- **No idempotency enforcement:** Rejected — unacceptable for a payment platform where duplicates cause real financial harm


### PR DESCRIPTION
Closes #10

## Summary
Four ADRs covering the core architectural decisions:
- **ADR-001**: Modular monolith boundary strategy (why one process, how domains are isolated)
- **ADR-002**: Transactional outbox for event publishing (atomicity + at-least-once delivery)
- **ADR-003**: Double-entry ledger model (balanced-entry invariant, account codes, append-only)
- **ADR-004**: Idempotency posture (two-tier Redis+Postgres, three-case handling, replay header)

## Test plan
- [ ] Files exist at `docs/adr/001-004-*.md`
- [ ] Content accurately reflects the implemented code

🤖 Generated with [Claude Code](https://claude.com/claude-code)