### PR TITLE
Fix gosec G404 false positive in sweeper jitter

### DIFF
--- a/internal/order/sweeper.go
+++ b/internal/order/sweeper.go
@@ -23,7 +23,7 @@ func NewExpirySweeper(svc *Service, interval time.Duration, logger *slog.Logger)
 func (s *ExpirySweeper) Start(ctx context.Context) {
 	// Random jitter up to one full interval so concurrent sweeper instances
 	// started simultaneously do not all tick at the same wall-clock time.
-	jitter := time.Duration(rand.Int64N(int64(s.interval)))
+	jitter := time.Duration(rand.Int64N(int64(s.interval))) //nolint:gosec // jitter is non-security, weak RNG is fine
 	select {
 	case <-ctx.Done():
 		return

--- a/internal/payment/sweeper.go
+++ b/internal/payment/sweeper.go
@@ -23,7 +23,7 @@ func NewSweeper(svc *Service, interval time.Duration, logger *slog.Logger) *Swee
 func (s *Sweeper) Start(ctx context.Context) {
 	// Random jitter up to one full interval so multiple sweeper instances
 	// started simultaneously do not all tick at the same wall-clock time.
-	jitter := time.Duration(rand.Int64N(int64(s.interval)))
+	jitter := time.Duration(rand.Int64N(int64(s.interval))) //nolint:gosec // jitter is non-security, weak RNG is fine
 	select {
 	case <-ctx.Done():
 		return


### PR DESCRIPTION
## Summary
Adds `//nolint:gosec` to both sweeper files where `math/rand/v2` is used for jitter. Jitter is not a security-sensitive operation — gosec G404 is a false positive here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code quality checks to improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->