### PR TITLE
Fix golang-migrate CI install missing postgres driver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           go-version-file: go.mod
           cache: true
       - name: Install golang-migrate
-        run: go install github.com/golang-migrate/migrate/v4/cmd/migrate@v4.19.1
+        run: go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@v4.19.1
       - name: Run database migrations
         run: migrate -path ./migrations -database "$PAYGATE_TEST_DB_URL" up
       - name: Integration tests


### PR DESCRIPTION
## Summary
`go install` without `-tags postgres` builds the migrate CLI with no database drivers. Adds `-tags 'postgres'` so the binary can connect to Postgres for migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)