### PR TITLE
Add refund service: domain, state machine, repository, handler, migration, integration test

### DIFF
--- a/cmd/api-gateway/main.go
+++ b/cmd/api-gateway/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sanskarpan/PayGate/internal/merchant"
 	"github.com/sanskarpan/PayGate/internal/order"
 	"github.com/sanskarpan/PayGate/internal/payment"
+	"github.com/sanskarpan/PayGate/internal/refund"
 )
 
 func main() {
@@ -85,6 +86,10 @@ func run() error {
 	paymentHandler := payment.NewHandler(paymentSvc)
 	checkoutHandler := gateway.NewCheckoutHandler(paymentSvc, orderSvc)
 
+	refundRepo := refund.NewPostgresRepository(db, ledgerSvc)
+	refundSvc := refund.NewService(refundRepo)
+	refundHandler := refund.NewHandler(refundSvc)
+
 	go order.NewExpirySweeper(orderSvc, time.Minute, l).Start(ctx)
 	go payment.NewSweeper(paymentSvc, 30*time.Second, l).Start(ctx)
 
@@ -132,6 +137,7 @@ func run() error {
 	}
 	orderHandler.RegisterRoutesWithAuth(mux, protected)
 	paymentHandler.RegisterRoutesWithAuth(mux, protected)
+	refundHandler.RegisterRoutesWithAuth(mux, protected)
 	merchantHandler.RegisterProtectedRoutes(mux, protected)
 	checkoutHandler.RegisterRoutes(mux)
 

--- a/internal/refund/domain.go
+++ b/internal/refund/domain.go
@@ -1,0 +1,91 @@
+package refund
+
+import (
+	"errors"
+	"time"
+)
+
+// RefundState is the explicit state machine type for refunds.
+type RefundState string
+
+// RefundEvent drives transitions in the refund state machine.
+type RefundEvent string
+
+const (
+	StateCreated    RefundState = "created"
+	StateProcessing RefundState = "processing"
+	StateProcessed  RefundState = "processed"
+	StateFailed     RefundState = "failed"
+)
+
+const (
+	EventInitiate RefundEvent = "initiate"   // created → processing
+	EventSuccess  RefundEvent = "success"    // processing → processed
+	EventFailure  RefundEvent = "failure"    // processing → failed
+)
+
+var (
+	ErrInvalidTransition  = errors.New("invalid refund state transition")
+	ErrRefundNotFound     = errors.New("refund not found")
+	ErrPaymentNotCaptured = errors.New("refund requires a captured payment")
+	ErrRefundAmountExceedsRefundable = errors.New("refund amount exceeds refundable balance")
+	ErrZeroRefundAmount   = errors.New("refund amount must be greater than zero")
+)
+
+// Transition returns the next state given the current state and event,
+// or ErrInvalidTransition if the event is not valid from the current state.
+func Transition(from RefundState, ev RefundEvent) (RefundState, error) {
+	table := map[RefundState]map[RefundEvent]RefundState{
+		StateCreated: {
+			EventInitiate: StateProcessing,
+		},
+		StateProcessing: {
+			EventSuccess: StateProcessed,
+			EventFailure: StateFailed,
+		},
+	}
+	m, ok := table[from]
+	if !ok {
+		return "", ErrInvalidTransition
+	}
+	next, ok := m[ev]
+	if !ok {
+		return "", ErrInvalidTransition
+	}
+	return next, nil
+}
+
+// Refund is the core domain entity.
+type Refund struct {
+	ID              string
+	PaymentID       string
+	OrderID         string
+	MerchantID      string
+	Amount          int64
+	Currency        string
+	Reason          string
+	Status          RefundState
+	GatewayRefundID string
+	Notes           map[string]any
+	ProcessedAt     *time.Time
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+}
+
+// PaymentSnapshot carries the payment fields needed for eligibility checks.
+type PaymentSnapshot struct {
+	ID                    string
+	OrderID               string
+	MerchantID            string
+	Amount                int64
+	Currency              string
+	Status                string
+	AmountRefunded        int64
+	AmountRefundedPending int64
+}
+
+// RefundableBalance returns how much of the payment can still be refunded,
+// accounting for already-confirmed refunds and pending reservations.
+func (p PaymentSnapshot) RefundableBalance() int64 {
+	return p.Amount - p.AmountRefunded - p.AmountRefundedPending
+}

--- a/internal/refund/domain_test.go
+++ b/internal/refund/domain_test.go
@@ -1,0 +1,81 @@
+package refund
+
+import (
+	"testing"
+)
+
+func TestTransition(t *testing.T) {
+	tests := []struct {
+		name    string
+		from    RefundState
+		event   RefundEvent
+		want    RefundState
+		wantErr bool
+	}{
+		// Valid transitions
+		{name: "created+initiate→processing", from: StateCreated, event: EventInitiate, want: StateProcessing},
+		{name: "processing+success→processed", from: StateProcessing, event: EventSuccess, want: StateProcessed},
+		{name: "processing+failure→failed", from: StateProcessing, event: EventFailure, want: StateFailed},
+
+		// Invalid transitions
+		{name: "created+success is invalid", from: StateCreated, event: EventSuccess, wantErr: true},
+		{name: "created+failure is invalid", from: StateCreated, event: EventFailure, wantErr: true},
+		{name: "processed+anything is terminal", from: StateProcessed, event: EventInitiate, wantErr: true},
+		{name: "failed+anything is terminal", from: StateFailed, event: EventInitiate, wantErr: true},
+		{name: "processing+initiate is invalid", from: StateProcessing, event: EventInitiate, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Transition(tc.from, tc.event)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got state %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestPaymentSnapshotRefundableBalance(t *testing.T) {
+	tests := []struct {
+		name    string
+		snap    PaymentSnapshot
+		want    int64
+	}{
+		{
+			name: "no refunds yet",
+			snap: PaymentSnapshot{Amount: 10000, AmountRefunded: 0, AmountRefundedPending: 0},
+			want: 10000,
+		},
+		{
+			name: "partial confirmed refund",
+			snap: PaymentSnapshot{Amount: 10000, AmountRefunded: 3000, AmountRefundedPending: 0},
+			want: 7000,
+		},
+		{
+			name: "pending reservation reduces balance",
+			snap: PaymentSnapshot{Amount: 10000, AmountRefunded: 2000, AmountRefundedPending: 3000},
+			want: 5000,
+		},
+		{
+			name: "fully refunded",
+			snap: PaymentSnapshot{Amount: 10000, AmountRefunded: 10000, AmountRefundedPending: 0},
+			want: 0,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.snap.RefundableBalance()
+			if got != tc.want {
+				t.Fatalf("expected %d, got %d", tc.want, got)
+			}
+		})
+	}
+}

--- a/internal/refund/handler.go
+++ b/internal/refund/handler.go
@@ -1,0 +1,128 @@
+package refund
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	httpx "github.com/sanskarpan/PayGate/internal/common/http"
+	"github.com/sanskarpan/PayGate/internal/merchant"
+)
+
+// Handler exposes the refund HTTP endpoints.
+type Handler struct {
+	svc *Service
+}
+
+// NewHandler creates a Handler.
+func NewHandler(svc *Service) *Handler {
+	return &Handler{svc: svc}
+}
+
+// RegisterRoutesWithAuth wires the refund endpoints into mux under auth.
+func (h *Handler) RegisterRoutesWithAuth(mux *http.ServeMux, wrap func(scope merchant.APIKeyScope, next http.Handler) http.Handler) {
+	mux.Handle("POST /v1/payments/{paymentID}/refunds", wrap(merchant.APIKeyScopeWrite, http.HandlerFunc(h.create)))
+	mux.Handle("GET /v1/refunds/{refundID}", wrap(merchant.APIKeyScopeRead, http.HandlerFunc(h.get)))
+	mux.Handle("GET /v1/payments/{paymentID}/refunds", wrap(merchant.APIKeyScopeRead, http.HandlerFunc(h.listByPayment)))
+}
+
+func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	var req struct {
+		Amount int64          `json:"amount"`
+		Reason string         `json:"reason"`
+		Notes  map[string]any `json:"notes"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpx.WriteError(w, http.StatusBadRequest, httpx.APIError{Code: "BAD_REQUEST_ERROR", Description: "invalid request body"})
+		return
+	}
+	ref, err := h.svc.Initiate(r.Context(), CreateInput{
+		PaymentID:  r.PathValue("paymentID"),
+		MerchantID: p.MerchantID,
+		Amount:     req.Amount,
+		Reason:     req.Reason,
+		Notes:      req.Notes,
+	})
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+	httpx.WriteJSON(w, http.StatusCreated, present(ref))
+}
+
+func (h *Handler) get(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	ref, err := h.svc.Get(r.Context(), p.MerchantID, r.PathValue("refundID"))
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+	httpx.WriteJSON(w, http.StatusOK, present(ref))
+}
+
+func (h *Handler) listByPayment(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	refs, err := h.svc.ListByPayment(r.Context(), p.MerchantID, r.PathValue("paymentID"))
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+	items := make([]map[string]any, 0, len(refs))
+	for _, ref := range refs {
+		items = append(items, present(ref))
+	}
+	httpx.WriteJSON(w, http.StatusOK, map[string]any{
+		"entity": "collection",
+		"count":  len(items),
+		"items":  items,
+	})
+}
+
+func present(ref Refund) map[string]any {
+	var processedAt int64
+	if ref.ProcessedAt != nil {
+		processedAt = ref.ProcessedAt.Unix()
+	}
+	return map[string]any{
+		"id":          ref.ID,
+		"entity":      "refund",
+		"payment_id":  ref.PaymentID,
+		"amount":      ref.Amount,
+		"currency":    ref.Currency,
+		"reason":      ref.Reason,
+		"status":      ref.Status,
+		"notes":       ref.Notes,
+		"processed_at": processedAt,
+		"created_at":  ref.CreatedAt.Unix(),
+		"created_at_rfc": ref.CreatedAt.Format(time.RFC3339),
+	}
+}
+
+func handleError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrRefundNotFound):
+		httpx.WriteError(w, http.StatusNotFound, httpx.APIError{Code: "NOT_FOUND", Description: err.Error()})
+	case errors.Is(err, ErrPaymentNotCaptured),
+		errors.Is(err, ErrRefundAmountExceedsRefundable),
+		errors.Is(err, ErrZeroRefundAmount):
+		httpx.WriteError(w, http.StatusBadRequest, httpx.APIError{Code: "BAD_REQUEST_ERROR", Description: err.Error()})
+	case errors.Is(err, ErrInvalidTransition):
+		httpx.WriteError(w, http.StatusUnprocessableEntity, httpx.APIError{Code: "INVALID_STATE", Description: err.Error()})
+	default:
+		httpx.WriteError(w, http.StatusInternalServerError, httpx.APIError{Code: "SERVER_ERROR", Description: "internal server error"})
+	}
+}

--- a/internal/refund/postgres.go
+++ b/internal/refund/postgres.go
@@ -1,0 +1,305 @@
+package refund
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sanskarpan/PayGate/internal/common/idgen"
+	"github.com/sanskarpan/PayGate/internal/ledger"
+	"github.com/sanskarpan/PayGate/internal/outbox"
+)
+
+// PostgresRepository implements Repository using pgxpool.
+type PostgresRepository struct {
+	db     *pgxpool.Pool
+	ledger *ledger.Service
+	outbox *outbox.Writer
+}
+
+// NewPostgresRepository creates a new PostgresRepository.
+func NewPostgresRepository(db *pgxpool.Pool, ledgerSvc *ledger.Service) *PostgresRepository {
+	return &PostgresRepository{db: db, ledger: ledgerSvc, outbox: outbox.NewWriter()}
+}
+
+// CreateRefund validates eligibility, reserves amount_refunded_pending,
+// inserts the refund as 'created', immediately initiates processing (sets
+// status to 'processing'), and writes an outbox event — all in one transaction.
+func (r *PostgresRepository) CreateRefund(ctx context.Context, in CreateInput) (Refund, error) {
+	if in.Amount <= 0 {
+		return Refund{}, ErrZeroRefundAmount
+	}
+
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return Refund{}, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Lock the payment row to prevent concurrent over-refunding.
+	var snap PaymentSnapshot
+	err = tx.QueryRow(ctx, `
+SELECT id, order_id, merchant_id, amount, currency, status,
+       amount_refunded, amount_refunded_pending
+FROM paygate_payments.payments
+WHERE id = $1 AND merchant_id = $2
+FOR UPDATE
+`, in.PaymentID, in.MerchantID).Scan(
+		&snap.ID, &snap.OrderID, &snap.MerchantID,
+		&snap.Amount, &snap.Currency, &snap.Status,
+		&snap.AmountRefunded, &snap.AmountRefundedPending,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Refund{}, ErrRefundNotFound
+		}
+		return Refund{}, err
+	}
+
+	if snap.Status != "captured" {
+		return Refund{}, ErrPaymentNotCaptured
+	}
+	if in.Amount > snap.RefundableBalance() {
+		return Refund{}, ErrRefundAmountExceedsRefundable
+	}
+
+	refundID := idgen.New("rfnd")
+	notesJSON, _ := json.Marshal(in.Notes)
+
+	// Insert as 'processing' directly (simulator resolves synchronously).
+	if _, err := tx.Exec(ctx, `
+INSERT INTO paygate_payments.refunds
+(id, payment_id, order_id, merchant_id, amount, currency, reason, status, notes)
+VALUES ($1,$2,$3,$4,$5,$6,$7,'processing',$8)
+`, refundID, in.PaymentID, snap.OrderID, in.MerchantID, in.Amount, snap.Currency, in.Reason, notesJSON); err != nil {
+		return Refund{}, err
+	}
+
+	// Reserve the pending refund amount on the payment.
+	if _, err := tx.Exec(ctx, `
+UPDATE paygate_payments.payments
+SET amount_refunded_pending = amount_refunded_pending + $1,
+    refund_status = CASE
+        WHEN amount_refunded + $1 >= amount THEN 'full'
+        ELSE 'partial'
+    END,
+    updated_at = NOW()
+WHERE id = $2
+`, in.Amount, in.PaymentID); err != nil {
+		return Refund{}, err
+	}
+
+	if err := r.outbox.WriteTx(ctx, tx, outbox.Event{
+		AggregateType: "refund",
+		AggregateID:   refundID,
+		EventType:     "refund.created",
+		MerchantID:    in.MerchantID,
+		Payload: map[string]any{
+			"refund_id":  refundID,
+			"payment_id": in.PaymentID,
+			"amount":     in.Amount,
+			"currency":   snap.Currency,
+		},
+	}); err != nil {
+		return Refund{}, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return Refund{}, err
+	}
+
+	return r.GetRefund(ctx, in.MerchantID, refundID)
+}
+
+// ProcessRefund transitions processing → processed, writes ledger reversal
+// entries (Dr. MERCHANT_PAYABLE / Cr. REFUND_CLEARING), moves amount from
+// pending to confirmed, and writes an outbox event.
+func (r *PostgresRepository) ProcessRefund(ctx context.Context, refundID string) (Refund, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return Refund{}, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var ref Refund
+	var notesRaw []byte
+	err = tx.QueryRow(ctx, `
+SELECT id, payment_id, order_id, merchant_id, amount, currency, reason, status
+FROM paygate_payments.refunds
+WHERE id = $1
+FOR UPDATE
+`, refundID).Scan(&ref.ID, &ref.PaymentID, &ref.OrderID, &ref.MerchantID, &ref.Amount, &ref.Currency, &ref.Reason, &ref.Status)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Refund{}, ErrRefundNotFound
+		}
+		return Refund{}, err
+	}
+	_ = notesRaw
+
+	if _, err := Transition(ref.Status, EventSuccess); err != nil {
+		return Refund{}, err
+	}
+
+	now := time.Now().UTC()
+	if _, err := tx.Exec(ctx, `
+UPDATE paygate_payments.refunds
+SET status = 'processed', processed_at = $2, updated_at = $2
+WHERE id = $1
+`, refundID, now); err != nil {
+		return Refund{}, err
+	}
+
+	// Move amount from pending to confirmed on the payment.
+	if _, err := tx.Exec(ctx, `
+UPDATE paygate_payments.payments
+SET amount_refunded         = amount_refunded + $1,
+    amount_refunded_pending = amount_refunded_pending - $1,
+    updated_at = NOW()
+WHERE id = $2
+`, ref.Amount, ref.PaymentID); err != nil {
+		return Refund{}, err
+	}
+
+	// Ledger reversal: Dr. MERCHANT_PAYABLE / Cr. REFUND_CLEARING
+	if _, err := r.ledger.CreateEntriesTx(ctx, tx, ref.MerchantID, "refund", refundID, "refund processed", []ledger.Entry{
+		{AccountCode: "MERCHANT_PAYABLE", DebitAmount: ref.Amount, Currency: ref.Currency, Description: "refund debit"},
+		{AccountCode: "REFUND_CLEARING", CreditAmount: ref.Amount, Currency: ref.Currency, Description: "refund clearing credit"},
+	}); err != nil {
+		return Refund{}, err
+	}
+
+	if err := r.outbox.WriteTx(ctx, tx, outbox.Event{
+		AggregateType: "refund",
+		AggregateID:   refundID,
+		EventType:     "refund.processed",
+		MerchantID:    ref.MerchantID,
+		Payload:       map[string]any{"refund_id": refundID, "payment_id": ref.PaymentID, "amount": ref.Amount},
+	}); err != nil {
+		return Refund{}, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return Refund{}, err
+	}
+
+	ref.Status = StateProcessed
+	ref.ProcessedAt = &now
+	return ref, nil
+}
+
+// FailRefund transitions processing → failed and releases amount_refunded_pending.
+func (r *PostgresRepository) FailRefund(ctx context.Context, refundID string) (Refund, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return Refund{}, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var ref Refund
+	err = tx.QueryRow(ctx, `
+SELECT id, payment_id, merchant_id, amount, currency, status
+FROM paygate_payments.refunds WHERE id = $1 FOR UPDATE
+`, refundID).Scan(&ref.ID, &ref.PaymentID, &ref.MerchantID, &ref.Amount, &ref.Currency, &ref.Status)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Refund{}, ErrRefundNotFound
+		}
+		return Refund{}, err
+	}
+
+	if _, err := Transition(ref.Status, EventFailure); err != nil {
+		return Refund{}, err
+	}
+
+	if _, err := tx.Exec(ctx, `UPDATE paygate_payments.refunds SET status='failed', updated_at=NOW() WHERE id=$1`, refundID); err != nil {
+		return Refund{}, err
+	}
+
+	// Release the pending reservation.
+	if _, err := tx.Exec(ctx, `
+UPDATE paygate_payments.payments
+SET amount_refunded_pending = amount_refunded_pending - $1, updated_at = NOW()
+WHERE id = $2
+`, ref.Amount, ref.PaymentID); err != nil {
+		return Refund{}, err
+	}
+
+	if err := r.outbox.WriteTx(ctx, tx, outbox.Event{
+		AggregateType: "refund",
+		AggregateID:   refundID,
+		EventType:     "refund.failed",
+		MerchantID:    ref.MerchantID,
+		Payload:       map[string]any{"refund_id": refundID, "payment_id": ref.PaymentID},
+	}); err != nil {
+		return Refund{}, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return Refund{}, err
+	}
+	ref.Status = StateFailed
+	return ref, nil
+}
+
+// GetRefund fetches a single refund by ID and merchantID.
+func (r *PostgresRepository) GetRefund(ctx context.Context, merchantID, refundID string) (Refund, error) {
+	var ref Refund
+	var notesRaw []byte
+	err := r.db.QueryRow(ctx, `
+SELECT id, payment_id, order_id, merchant_id, amount, currency,
+       reason, status, gateway_refund_id, notes, processed_at, created_at, updated_at
+FROM paygate_payments.refunds
+WHERE id = $1 AND merchant_id = $2
+`, refundID, merchantID).Scan(
+		&ref.ID, &ref.PaymentID, &ref.OrderID, &ref.MerchantID, &ref.Amount, &ref.Currency,
+		&ref.Reason, &ref.Status, &ref.GatewayRefundID, &notesRaw, &ref.ProcessedAt,
+		&ref.CreatedAt, &ref.UpdatedAt,
+	)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return Refund{}, ErrRefundNotFound
+		}
+		return Refund{}, err
+	}
+	if len(notesRaw) > 0 {
+		_ = json.Unmarshal(notesRaw, &ref.Notes)
+	}
+	return ref, nil
+}
+
+// ListRefunds returns all refunds for a payment, scoped to merchantID.
+func (r *PostgresRepository) ListRefunds(ctx context.Context, merchantID, paymentID string) ([]Refund, error) {
+	rows, err := r.db.Query(ctx, `
+SELECT id, payment_id, order_id, merchant_id, amount, currency,
+       reason, status, gateway_refund_id, notes, processed_at, created_at, updated_at
+FROM paygate_payments.refunds
+WHERE merchant_id = $1 AND payment_id = $2
+ORDER BY created_at DESC
+`, merchantID, paymentID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []Refund
+	for rows.Next() {
+		var ref Refund
+		var notesRaw []byte
+		if err := rows.Scan(
+			&ref.ID, &ref.PaymentID, &ref.OrderID, &ref.MerchantID, &ref.Amount, &ref.Currency,
+			&ref.Reason, &ref.Status, &ref.GatewayRefundID, &notesRaw, &ref.ProcessedAt,
+			&ref.CreatedAt, &ref.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		if len(notesRaw) > 0 {
+			_ = json.Unmarshal(notesRaw, &ref.Notes)
+		}
+		out = append(out, ref)
+	}
+	return out, rows.Err()
+}

--- a/internal/refund/repository.go
+++ b/internal/refund/repository.go
@@ -1,0 +1,36 @@
+package refund
+
+import "context"
+
+// Repository is the persistence interface for the refund domain.
+// The Postgres implementation lives in postgres.go.
+type Repository interface {
+	// CreateRefund opens a transaction, validates eligibility (SELECT FOR UPDATE on
+	// the payment row), reserves amount_refunded_pending, inserts the refund record
+	// as 'created', writes an outbox event, and returns the new Refund.
+	CreateRefund(ctx context.Context, in CreateInput) (Refund, error)
+
+	// ProcessRefund transitions a refund from processing → processed, writes ledger
+	// reversal entries, updates payment.amount_refunded / clears pending, and writes
+	// outbox event — all in one transaction.
+	ProcessRefund(ctx context.Context, refundID string) (Refund, error)
+
+	// FailRefund transitions a refund from processing → failed, releases the
+	// amount_refunded_pending reservation, and writes an outbox event.
+	FailRefund(ctx context.Context, refundID string) (Refund, error)
+
+	// GetRefund fetches a refund by ID, scoped to merchantID.
+	GetRefund(ctx context.Context, merchantID, refundID string) (Refund, error)
+
+	// ListRefunds returns all refunds for a payment, scoped to merchantID.
+	ListRefunds(ctx context.Context, merchantID, paymentID string) ([]Refund, error)
+}
+
+// CreateInput carries the caller-supplied fields for a new refund.
+type CreateInput struct {
+	PaymentID  string
+	MerchantID string
+	Amount     int64
+	Reason     string
+	Notes      map[string]any
+}

--- a/internal/refund/service.go
+++ b/internal/refund/service.go
@@ -1,0 +1,36 @@
+package refund
+
+import "context"
+
+// Service orchestrates refund use-cases.
+// For the simulated gateway, ProcessRefund is called immediately after
+// CreateRefund — the simulator always succeeds.
+type Service struct {
+	repo Repository
+}
+
+// NewService creates a new Service.
+func NewService(repo Repository) *Service {
+	return &Service{repo: repo}
+}
+
+// Initiate creates a new refund and immediately processes it via the simulator.
+// Returns the processed Refund on success.
+func (s *Service) Initiate(ctx context.Context, in CreateInput) (Refund, error) {
+	ref, err := s.repo.CreateRefund(ctx, in)
+	if err != nil {
+		return Refund{}, err
+	}
+	// Simulator always succeeds; call ProcessRefund synchronously.
+	return s.repo.ProcessRefund(ctx, ref.ID)
+}
+
+// Get returns a single refund scoped to the merchant.
+func (s *Service) Get(ctx context.Context, merchantID, refundID string) (Refund, error) {
+	return s.repo.GetRefund(ctx, merchantID, refundID)
+}
+
+// ListByPayment returns all refunds for a payment, scoped to the merchant.
+func (s *Service) ListByPayment(ctx context.Context, merchantID, paymentID string) ([]Refund, error) {
+	return s.repo.ListRefunds(ctx, merchantID, paymentID)
+}

--- a/migrations/000006_create_refunds.down.sql
+++ b/migrations/000006_create_refunds.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS paygate_payments.refunds;

--- a/migrations/000006_create_refunds.up.sql
+++ b/migrations/000006_create_refunds.up.sql
@@ -1,0 +1,19 @@
+CREATE TABLE IF NOT EXISTS paygate_payments.refunds (
+    id                TEXT PRIMARY KEY,
+    payment_id        TEXT NOT NULL REFERENCES paygate_payments.payments(id),
+    order_id          TEXT NOT NULL,
+    merchant_id       TEXT NOT NULL,
+    amount            BIGINT NOT NULL CHECK (amount > 0),
+    currency          TEXT NOT NULL,
+    reason            TEXT,
+    status            TEXT NOT NULL DEFAULT 'created'
+                          CHECK (status IN ('created', 'processing', 'processed', 'failed')),
+    gateway_refund_id TEXT,
+    notes             JSONB DEFAULT '{}',
+    processed_at      TIMESTAMPTZ,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_refunds_payment  ON paygate_payments.refunds(payment_id);
+CREATE INDEX IF NOT EXISTS idx_refunds_merchant ON paygate_payments.refunds(merchant_id, status);

--- a/tests/integration/backend_hardening_integration_test.go
+++ b/tests/integration/backend_hardening_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sanskarpan/PayGate/internal/order"
 	"github.com/sanskarpan/PayGate/internal/outbox"
 	"github.com/sanskarpan/PayGate/internal/payment"
+	"github.com/sanskarpan/PayGate/internal/refund"
 )
 
 func TestIntegrationIdempotentOrderCreateReplaysResponse(t *testing.T) {
@@ -283,10 +284,12 @@ func buildGatewayMux(db *pgxpool.Pool) (*http.ServeMux, *merchant.Service, *orde
 	orderSvc := order.NewService(order.NewPostgresRepository(db))
 	ledgerSvc := ledger.NewService(ledger.NewRepository(db))
 	paymentSvc := payment.NewService(payment.NewPostgresRepository(db, ledgerSvc, orderSvc), gateway.NewSimulator())
+	refundSvc := refund.NewService(refund.NewPostgresRepository(db, ledgerSvc))
 
 	merchantHandler := merchant.NewHandler(merchantSvc)
 	orderHandler := order.NewHandler(orderSvc)
 	paymentHandler := payment.NewHandler(paymentSvc)
+	refundHandler := refund.NewHandler(refundSvc)
 
 	protected := func(scope merchant.APIKeyScope, next http.Handler) http.Handler {
 		return authMw.RequireScope(scope, idemMw.Wrap(next))
@@ -297,6 +300,7 @@ func buildGatewayMux(db *pgxpool.Pool) (*http.ServeMux, *merchant.Service, *orde
 	merchantHandler.RegisterProtectedRoutes(mux, protected)
 	orderHandler.RegisterRoutesWithAuth(mux, protected)
 	paymentHandler.RegisterRoutesWithAuth(mux, protected)
+	refundHandler.RegisterRoutesWithAuth(mux, protected)
 	mux.Handle("GET /v1/merchants/me", authMw.RequireScope(merchant.APIKeyScopeRead, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		p, _ := httpx.PrincipalFromContext(r.Context())
 		httpx.WriteJSON(w, http.StatusOK, map[string]any{"merchant_id": p.MerchantID})

--- a/tests/integration/refund_integration_test.go
+++ b/tests/integration/refund_integration_test.go
@@ -1,0 +1,157 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sanskarpan/PayGate/internal/merchant"
+	"github.com/sanskarpan/PayGate/internal/order"
+	"github.com/sanskarpan/PayGate/internal/payment"
+)
+
+func TestIntegrationRefundCapturedPayment(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	mux, merchantSvc, orderSvc, paymentSvc := buildGatewayMux(db)
+	ctx := context.Background()
+
+	// Set up merchant and API key.
+	createdMerchant, err := merchantSvc.CreateMerchant(ctx, merchant.CreateMerchantInput{
+		Name: "Refund Merchant", Email: "refund@test.com", BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+	key, err := merchantSvc.CreateAPIKey(ctx, createdMerchant.ID, merchant.CreateAPIKeyInput{
+		Mode: merchant.APIKeyModeTest, Scope: merchant.APIKeyScopeWrite,
+	})
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+	authHeader := basicAuth(key.KeyID, key.KeySecret)
+
+	// Create order.
+	createdOrder, err := orderSvc.Create(ctx, order.CreateInput{
+		MerchantID: createdMerchant.ID, Amount: 9900, Currency: "INR", Receipt: "refund-test",
+	})
+	if err != nil {
+		t.Fatalf("create order: %v", err)
+	}
+
+	// Authorize and capture payment.
+	authorized, err := paymentSvc.Authorize(ctx, payment.AuthorizeInput{
+		MerchantID: createdMerchant.ID, OrderID: createdOrder.ID,
+		Amount: createdOrder.Amount, Currency: createdOrder.Currency, Method: "card",
+	})
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	if _, err := paymentSvc.CaptureForMerchant(ctx, createdMerchant.ID, authorized.PaymentID, createdOrder.Amount); err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+
+	t.Run("full refund", func(t *testing.T) {
+		body, _ := json.Marshal(map[string]any{"amount": 9900, "reason": "customer request"})
+		req := httptest.NewRequest(http.MethodPost, "/v1/payments/"+authorized.PaymentID+"/refunds", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Basic "+authHeader)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusCreated {
+			t.Fatalf("expected 201, got %d body=%s", rec.Code, rec.Body.String())
+		}
+		var resp map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode response: %v", err)
+		}
+		if resp["status"] != "processed" {
+			t.Fatalf("expected status=processed, got %v", resp["status"])
+		}
+		if resp["amount"] != float64(9900) {
+			t.Fatalf("expected amount=9900, got %v", resp["amount"])
+		}
+
+		// Verify ledger entries were written.
+		var count int
+		if err := db.QueryRow(ctx,
+			`SELECT COUNT(*) FROM paygate_ledger.ledger_entries WHERE source_id = $1`,
+			resp["id"],
+		).Scan(&count); err != nil {
+			t.Fatalf("query ledger entries: %v", err)
+		}
+		if count != 2 {
+			t.Fatalf("expected 2 ledger entries for refund, got %d", count)
+		}
+	})
+
+	t.Run("over-refund is rejected", func(t *testing.T) {
+		// Create a second payment to try over-refunding.
+		createdOrder2, _ := orderSvc.Create(ctx, order.CreateInput{
+			MerchantID: createdMerchant.ID, Amount: 5000, Currency: "INR", Receipt: "refund-test-2",
+		})
+		authorized2, _ := paymentSvc.Authorize(ctx, payment.AuthorizeInput{
+			MerchantID: createdMerchant.ID, OrderID: createdOrder2.ID,
+			Amount: createdOrder2.Amount, Currency: createdOrder2.Currency, Method: "card",
+		})
+		_, _ = paymentSvc.CaptureForMerchant(ctx, createdMerchant.ID, authorized2.PaymentID, createdOrder2.Amount)
+
+		// Try to refund more than captured.
+		body, _ := json.Marshal(map[string]any{"amount": 9999})
+		req := httptest.NewRequest(http.MethodPost, "/v1/payments/"+authorized2.PaymentID+"/refunds", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Basic "+authHeader)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for over-refund, got %d body=%s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("refund of uncaptured payment is rejected", func(t *testing.T) {
+		createdOrder3, _ := orderSvc.Create(ctx, order.CreateInput{
+			MerchantID: createdMerchant.ID, Amount: 3000, Currency: "INR", Receipt: "refund-test-3",
+		})
+		authorized3, _ := paymentSvc.Authorize(ctx, payment.AuthorizeInput{
+			MerchantID: createdMerchant.ID, OrderID: createdOrder3.ID,
+			Amount: createdOrder3.Amount, Currency: createdOrder3.Currency, Method: "card",
+		})
+		// Do NOT capture — payment is still 'authorized'.
+		body, _ := json.Marshal(map[string]any{"amount": 3000})
+		req := httptest.NewRequest(http.MethodPost, "/v1/payments/"+authorized3.PaymentID+"/refunds", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Basic "+authHeader)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusBadRequest {
+			t.Fatalf("expected 400 for non-captured refund, got %d body=%s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("list refunds for payment", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/payments/"+authorized.PaymentID+"/refunds", nil)
+		req.Header.Set("Authorization", "Basic "+authHeader)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+		}
+		var resp map[string]any
+		if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		if resp["count"].(float64) < 1 {
+			t.Fatalf("expected at least 1 refund, got %v", resp["count"])
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Adds Phase 2 refund service with explicit state machine (`created → processing → processed/failed`)
- Double-entry ledger entries on process (Dr. MERCHANT_PAYABLE / Cr. REFUND_CLEARING); `amount_refunded_pending` reservation pattern prevents concurrent over-refunding via `SELECT FOR UPDATE`
- REST endpoints: `POST /v1/payments/{id}/refunds`, `GET /v1/refunds/{id}`, `GET /v1/payments/{id}/refunds`
- Transactional outbox events: `refund.created`, `refund.processed`, `refund.failed`
- Integration tests: full refund, over-refund rejection, uncaptured-payment rejection, list-by-payment

Closes #269

## Test plan
- [ ] `go test -v -tags integration ./tests/integration/... -run TestIntegrationRefundCapturedPayment`
- [ ] Full refund returns 201 with `status=processed` and 2 ledger entries
- [ ] Over-refund returns 400
- [ ] Refunding uncaptured payment returns 400
- [ ] List refunds returns 200 with count ≥ 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)