### PR TITLE
Add webhook service: subscription CRUD, HMAC delivery, retry engine, integration tests

### DIFF
--- a/cmd/api-gateway/main.go
+++ b/cmd/api-gateway/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sanskarpan/PayGate/internal/order"
 	"github.com/sanskarpan/PayGate/internal/payment"
 	"github.com/sanskarpan/PayGate/internal/refund"
+	"github.com/sanskarpan/PayGate/internal/webhook"
 )
 
 func main() {
@@ -90,6 +91,10 @@ func run() error {
 	refundSvc := refund.NewService(refundRepo)
 	refundHandler := refund.NewHandler(refundSvc)
 
+	webhookRepo := webhook.NewPostgresRepository(db)
+	webhookSvc := webhook.NewService(webhookRepo)
+	webhookHandler := webhook.NewHandler(webhookSvc)
+
 	go order.NewExpirySweeper(orderSvc, time.Minute, l).Start(ctx)
 	go payment.NewSweeper(paymentSvc, 30*time.Second, l).Start(ctx)
 
@@ -138,6 +143,7 @@ func run() error {
 	orderHandler.RegisterRoutesWithAuth(mux, protected)
 	paymentHandler.RegisterRoutesWithAuth(mux, protected)
 	refundHandler.RegisterRoutesWithAuth(mux, protected)
+	webhookHandler.RegisterRoutesWithAuth(mux, protected)
 	merchantHandler.RegisterProtectedRoutes(mux, protected)
 	checkoutHandler.RegisterRoutes(mux)
 

--- a/internal/webhook/deliverer.go
+++ b/internal/webhook/deliverer.go
@@ -1,0 +1,86 @@
+package webhook
+
+import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+const (
+	deliveryTimeout    = 10 * time.Second
+	signatureHeader    = "X-PayGate-Signature"
+	timestampHeader    = "X-PayGate-Timestamp"
+	eventTypeHeader    = "X-PayGate-Event"
+)
+
+// DeliveryResult holds the outcome of a single HTTP delivery attempt.
+type DeliveryResult struct {
+	StatusCode   int
+	ResponseBody string
+	Error        string
+	Succeeded    bool
+}
+
+// Deliverer sends signed HTTP POST requests to webhook endpoints.
+type Deliverer struct {
+	client *http.Client
+}
+
+// NewDeliverer creates a Deliverer with a 10-second per-request timeout.
+func NewDeliverer() *Deliverer {
+	return &Deliverer{
+		client: &http.Client{Timeout: deliveryTimeout},
+	}
+}
+
+// Deliver signs payload with HMAC-SHA256 and POSTs it to url.
+// It returns the delivery result regardless of HTTP status code.
+// Only network/IO errors set result.Error; a 5xx response is a failed delivery,
+// not an error.
+func (d *Deliverer) Deliver(ctx context.Context, url, secret, eventType string, payload []byte) DeliveryResult {
+	sig := sign(secret, payload)
+	ts := fmt.Sprintf("%d", time.Now().Unix())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(payload))
+	if err != nil {
+		return DeliveryResult{Error: err.Error()}
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(signatureHeader, "sha256="+sig)
+	req.Header.Set(timestampHeader, ts)
+	req.Header.Set(eventTypeHeader, eventType)
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return DeliveryResult{Error: err.Error()}
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	succeeded := resp.StatusCode >= 200 && resp.StatusCode < 300
+	return DeliveryResult{
+		StatusCode:   resp.StatusCode,
+		ResponseBody: string(body),
+		Succeeded:    succeeded,
+	}
+}
+
+// sign returns the HMAC-SHA256 hex digest of payload using secret as the key.
+func sign(secret string, payload []byte) string {
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write(payload)
+	return hex.EncodeToString(mac.Sum(nil))
+}
+
+// Verify reports whether the given signature matches the expected signature
+// for payload signed with secret. Uses constant-time comparison.
+func Verify(secret string, payload []byte, signature string) bool {
+	expected := "sha256=" + sign(secret, payload)
+	return hmac.Equal([]byte(signature), []byte(expected))
+}

--- a/internal/webhook/deliverer.go
+++ b/internal/webhook/deliverer.go
@@ -60,7 +60,7 @@ func (d *Deliverer) Deliver(ctx context.Context, url, secret, eventType string, 
 	if err != nil {
 		return DeliveryResult{Error: err.Error()}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 	succeeded := resp.StatusCode >= 200 && resp.StatusCode < 300

--- a/internal/webhook/deliverer_test.go
+++ b/internal/webhook/deliverer_test.go
@@ -1,0 +1,98 @@
+package webhook
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestSignAndVerify(t *testing.T) {
+	secret := "test-secret-abc123"
+	payload := []byte(`{"event_type":"payment.captured","payment_id":"pay_abc"}`)
+
+	sig := "sha256=" + sign(secret, payload)
+
+	// Correct signature verifies.
+	if !Verify(secret, payload, sig) {
+		t.Fatal("expected signature to verify")
+	}
+
+	// Tampered payload fails.
+	if Verify(secret, []byte("tampered"), sig) {
+		t.Fatal("expected tampered payload to fail verification")
+	}
+
+	// Wrong secret fails.
+	if Verify("wrong-secret", payload, sig) {
+		t.Fatal("expected wrong secret to fail verification")
+	}
+
+	// Empty signature fails.
+	if Verify(secret, payload, "") {
+		t.Fatal("expected empty signature to fail verification")
+	}
+}
+
+func TestDelivererSuccessfulDelivery(t *testing.T) {
+	received := make(chan []byte, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("expected application/json content type")
+		}
+		sig := r.Header.Get(signatureHeader)
+		if sig == "" {
+			t.Error("expected X-PayGate-Signature header")
+		}
+		payload := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(payload)
+		received <- payload
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"received":true}`))
+	}))
+	defer server.Close()
+
+	d := NewDeliverer()
+	payload, _ := json.Marshal(map[string]any{"event_type": "payment.captured"})
+	result := d.Deliver(t.Context(), server.URL, "my-secret", "payment.captured", payload)
+
+	if !result.Succeeded {
+		t.Fatalf("expected successful delivery, got error=%q code=%d", result.Error, result.StatusCode)
+	}
+	if result.StatusCode != http.StatusOK {
+		t.Errorf("expected 200, got %d", result.StatusCode)
+	}
+}
+
+func TestDelivererFailsOn4xx5xx(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	d := NewDeliverer()
+	result := d.Deliver(t.Context(), server.URL, "secret", "payment.captured", []byte(`{}`))
+
+	if result.Succeeded {
+		t.Fatal("expected failed delivery on 500")
+	}
+	if result.StatusCode != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", result.StatusCode)
+	}
+}
+
+func TestDelivererNetworkError(t *testing.T) {
+	d := NewDeliverer()
+	// Use a port that is not listening.
+	result := d.Deliver(t.Context(), "http://127.0.0.1:19999/webhook", "secret", "payment.captured", []byte(`{}`))
+
+	if result.Succeeded {
+		t.Fatal("expected network error to fail delivery")
+	}
+	if result.Error == "" {
+		t.Error("expected non-empty error message on network failure")
+	}
+}

--- a/internal/webhook/domain.go
+++ b/internal/webhook/domain.go
@@ -124,7 +124,7 @@ func RetryDelay(attemptNumber int) time.Duration {
 	if attemptNumber <= 0 || attemptNumber > len(delays) {
 		return 1 * time.Hour
 	}
-	return delays[attemptNumber-1]
+	return delays[attemptNumber-1] //nolint:gosec // bounds are checked on the line above
 }
 
 // MatchesEvent reports whether the subscription is subscribed to the given event type.

--- a/internal/webhook/domain.go
+++ b/internal/webhook/domain.go
@@ -1,0 +1,159 @@
+package webhook
+
+import (
+	"errors"
+	"time"
+)
+
+// SubscriptionStatus is the explicit state machine type for webhook subscriptions.
+type SubscriptionStatus string
+
+// SubscriptionEvent drives transitions in the subscription state machine.
+type SubscriptionEvent string
+
+const (
+	StatusActive   SubscriptionStatus = "active"
+	StatusDisabled SubscriptionStatus = "disabled"
+	StatusDeleted  SubscriptionStatus = "deleted"
+)
+
+const (
+	EventEnable  SubscriptionEvent = "enable"
+	EventDisable SubscriptionEvent = "disable"
+	EventDelete  SubscriptionEvent = "delete"
+)
+
+// DeliveryStatus is the state of a single delivery attempt.
+type DeliveryStatus string
+
+const (
+	DeliveryPending      DeliveryStatus = "pending"
+	DeliverySucceeded    DeliveryStatus = "succeeded"
+	DeliveryFailed       DeliveryStatus = "failed"
+	DeliveryDeadLettered DeliveryStatus = "dead_lettered"
+)
+
+// MaxDeliveryAttempts is the number of attempts before an event is dead-lettered.
+const MaxDeliveryAttempts = 18
+
+var (
+	ErrSubscriptionNotFound    = errors.New("webhook subscription not found")
+	ErrDeliveryAttemptNotFound = errors.New("webhook delivery attempt not found")
+	ErrInvalidTransition       = errors.New("invalid subscription state transition")
+	ErrInvalidURL              = errors.New("webhook URL must use https scheme")
+	ErrNoEvents                = errors.New("at least one event type must be specified")
+)
+
+// Transition returns the next SubscriptionStatus for the given event,
+// or ErrInvalidTransition if the event is not valid from the current state.
+func Transition(from SubscriptionStatus, ev SubscriptionEvent) (SubscriptionStatus, error) {
+	table := map[SubscriptionStatus]map[SubscriptionEvent]SubscriptionStatus{
+		StatusActive: {
+			EventDisable: StatusDisabled,
+			EventDelete:  StatusDeleted,
+		},
+		StatusDisabled: {
+			EventEnable: StatusActive,
+			EventDelete: StatusDeleted,
+		},
+	}
+	m, ok := table[from]
+	if !ok {
+		return "", ErrInvalidTransition
+	}
+	next, ok := m[ev]
+	if !ok {
+		return "", ErrInvalidTransition
+	}
+	return next, nil
+}
+
+// WebhookSubscription is a merchant's registered endpoint for receiving events.
+type WebhookSubscription struct {
+	ID         string
+	MerchantID string
+	URL        string
+	Events     []string // event type patterns subscribed to, e.g. ["payment.captured"]
+	Secret     string   // HMAC-SHA256 signing secret (never returned to client after creation)
+	Status     SubscriptionStatus
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+// WebhookDeliveryAttempt records one HTTP delivery attempt to a subscription.
+type WebhookDeliveryAttempt struct {
+	ID             string
+	EventID        string
+	SubscriptionID string
+	MerchantID     string
+	Status         DeliveryStatus
+	RequestURL     string
+	RequestBody    []byte
+	ResponseCode   int
+	ResponseBody   string
+	ErrorMessage   string
+	AttemptNumber  int
+	NextRetryAt    *time.Time
+	CreatedAt      time.Time
+}
+
+// RetryDelay returns the delay before the next attempt for a given attempt number.
+// Attempt 1 is immediate (0 delay). This function is called for attempt N to get
+// the delay before attempt N+1.
+func RetryDelay(attemptNumber int) time.Duration {
+	delays := []time.Duration{
+		0,             // attempt 1: immediate (no delay before first try)
+		5 * time.Second,
+		10 * time.Second,
+		30 * time.Second,
+		1 * time.Minute,
+		5 * time.Minute,
+		10 * time.Minute,
+		30 * time.Minute,
+		1 * time.Hour,
+		1 * time.Hour,
+		1 * time.Hour,
+		1 * time.Hour,
+		1 * time.Hour,
+		1 * time.Hour,
+		1 * time.Hour,
+		1 * time.Hour,
+		1 * time.Hour,
+		1 * time.Hour,
+	}
+	if attemptNumber <= 0 || attemptNumber > len(delays) {
+		return 1 * time.Hour
+	}
+	return delays[attemptNumber-1]
+}
+
+// MatchesEvent reports whether the subscription is subscribed to the given event type.
+// An exact match or a wildcard prefix (e.g. "payment.*") are both valid.
+func (s *WebhookSubscription) MatchesEvent(eventType string) bool {
+	for _, pattern := range s.Events {
+		if pattern == eventType {
+			return true
+		}
+		// Wildcard: "payment.*" matches "payment.captured"
+		if len(pattern) > 1 && pattern[len(pattern)-1] == '*' {
+			prefix := pattern[:len(pattern)-1]
+			if len(eventType) >= len(prefix) && eventType[:len(prefix)] == prefix {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// CreateInput carries validated fields for creating a new subscription.
+type CreateInput struct {
+	MerchantID string
+	URL        string
+	Events     []string
+}
+
+// UpdateInput carries mutable fields for updating a subscription.
+type UpdateInput struct {
+	URL    string
+	Events []string
+}

--- a/internal/webhook/domain_test.go
+++ b/internal/webhook/domain_test.go
@@ -1,0 +1,98 @@
+package webhook
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSubscriptionTransition(t *testing.T) {
+	tests := []struct {
+		from    SubscriptionStatus
+		event   SubscriptionEvent
+		want    SubscriptionStatus
+		wantErr bool
+	}{
+		{StatusActive, EventDisable, StatusDisabled, false},
+		{StatusActive, EventDelete, StatusDeleted, false},
+		{StatusDisabled, EventEnable, StatusActive, false},
+		{StatusDisabled, EventDelete, StatusDeleted, false},
+		// Invalid transitions
+		{StatusActive, EventEnable, "", true},
+		{StatusDisabled, EventDisable, "", true},
+		{StatusDeleted, EventEnable, "", true},
+		{StatusDeleted, EventDisable, "", true},
+		{StatusDeleted, EventDelete, "", true},
+	}
+
+	for _, tc := range tests {
+		got, err := Transition(tc.from, tc.event)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("Transition(%s, %s): expected error, got %s", tc.from, tc.event, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("Transition(%s, %s): unexpected error: %v", tc.from, tc.event, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("Transition(%s, %s) = %s, want %s", tc.from, tc.event, got, tc.want)
+		}
+	}
+}
+
+func TestMatchesEvent(t *testing.T) {
+	sub := &WebhookSubscription{
+		Events: []string{"payment.captured", "refund.*", "order.created"},
+	}
+
+	tests := []struct {
+		eventType string
+		want      bool
+	}{
+		{"payment.captured", true},
+		{"payment.failed", false},
+		{"refund.created", true},
+		{"refund.processed", true},
+		{"refund.failed", true},
+		{"order.created", true},
+		{"order.expired", false},
+		{"settlement.processed", false},
+		{"", false},
+	}
+
+	for _, tc := range tests {
+		got := sub.MatchesEvent(tc.eventType)
+		if got != tc.want {
+			t.Errorf("MatchesEvent(%q) = %v, want %v", tc.eventType, got, tc.want)
+		}
+	}
+}
+
+func TestRetryDelay(t *testing.T) {
+	tests := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{1, 0},
+		{2, 5 * time.Second},
+		{3, 10 * time.Second},
+		{4, 30 * time.Second},
+		{5, 1 * time.Minute},
+		{6, 5 * time.Minute},
+		{7, 10 * time.Minute},
+		{8, 30 * time.Minute},
+		{9, 1 * time.Hour},
+		{18, 1 * time.Hour},
+		{19, 1 * time.Hour}, // beyond table → clamp to 1h
+		{0, 1 * time.Hour},  // invalid → clamp
+	}
+
+	for _, tc := range tests {
+		got := RetryDelay(tc.attempt)
+		if got != tc.want {
+			t.Errorf("RetryDelay(%d) = %v, want %v", tc.attempt, got, tc.want)
+		}
+	}
+}

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -1,0 +1,241 @@
+package webhook
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	httpx "github.com/sanskarpan/PayGate/internal/common/http"
+	"github.com/sanskarpan/PayGate/internal/merchant"
+)
+
+// Handler exposes the webhook HTTP endpoints.
+type Handler struct {
+	svc *Service
+}
+
+// NewHandler creates a Handler.
+func NewHandler(svc *Service) *Handler {
+	return &Handler{svc: svc}
+}
+
+// RegisterRoutesWithAuth wires webhook endpoints into mux under auth.
+func (h *Handler) RegisterRoutesWithAuth(mux *http.ServeMux, wrap func(scope merchant.APIKeyScope, next http.Handler) http.Handler) {
+	mux.Handle("POST /v1/webhooks", wrap(merchant.APIKeyScopeWrite, http.HandlerFunc(h.create)))
+	mux.Handle("GET /v1/webhooks", wrap(merchant.APIKeyScopeRead, http.HandlerFunc(h.list)))
+	mux.Handle("GET /v1/webhooks/{webhookID}", wrap(merchant.APIKeyScopeRead, http.HandlerFunc(h.get)))
+	mux.Handle("PATCH /v1/webhooks/{webhookID}", wrap(merchant.APIKeyScopeWrite, http.HandlerFunc(h.update)))
+	mux.Handle("DELETE /v1/webhooks/{webhookID}", wrap(merchant.APIKeyScopeWrite, http.HandlerFunc(h.delete)))
+	mux.Handle("POST /v1/webhooks/{webhookID}/enable", wrap(merchant.APIKeyScopeWrite, http.HandlerFunc(h.enable)))
+	mux.Handle("POST /v1/webhooks/{webhookID}/disable", wrap(merchant.APIKeyScopeWrite, http.HandlerFunc(h.disable)))
+	mux.Handle("GET /v1/webhooks/{webhookID}/deliveries", wrap(merchant.APIKeyScopeRead, http.HandlerFunc(h.listDeliveries)))
+}
+
+func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	var req struct {
+		URL    string   `json:"url"`
+		Events []string `json:"events"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpx.WriteError(w, http.StatusBadRequest, httpx.APIError{Code: "BAD_REQUEST_ERROR", Description: "invalid request body"})
+		return
+	}
+	sub, err := h.svc.CreateSubscription(r.Context(), CreateInput{
+		MerchantID: p.MerchantID,
+		URL:        req.URL,
+		Events:     req.Events,
+	})
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+	// Return secret only on creation — never again.
+	httpx.WriteJSON(w, http.StatusCreated, presentWithSecret(sub))
+}
+
+func (h *Handler) list(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	subs, err := h.svc.ListSubscriptions(r.Context(), p.MerchantID)
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+	items := make([]map[string]any, 0, len(subs))
+	for _, sub := range subs {
+		items = append(items, present(sub))
+	}
+	httpx.WriteJSON(w, http.StatusOK, map[string]any{
+		"entity": "collection",
+		"count":  len(items),
+		"items":  items,
+	})
+}
+
+func (h *Handler) get(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	sub, err := h.svc.GetSubscription(r.Context(), p.MerchantID, r.PathValue("webhookID"))
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+	httpx.WriteJSON(w, http.StatusOK, present(sub))
+}
+
+func (h *Handler) update(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	var req struct {
+		URL    string   `json:"url"`
+		Events []string `json:"events"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpx.WriteError(w, http.StatusBadRequest, httpx.APIError{Code: "BAD_REQUEST_ERROR", Description: "invalid request body"})
+		return
+	}
+	sub, err := h.svc.UpdateSubscription(r.Context(), p.MerchantID, r.PathValue("webhookID"), UpdateInput{
+		URL:    req.URL,
+		Events: req.Events,
+	})
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+	httpx.WriteJSON(w, http.StatusOK, present(sub))
+}
+
+func (h *Handler) delete(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	if err := h.svc.DeleteSubscription(r.Context(), p.MerchantID, r.PathValue("webhookID")); err != nil {
+		handleError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *Handler) enable(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	sub, err := h.svc.EnableSubscription(r.Context(), p.MerchantID, r.PathValue("webhookID"))
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+	httpx.WriteJSON(w, http.StatusOK, present(sub))
+}
+
+func (h *Handler) disable(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	sub, err := h.svc.DisableSubscription(r.Context(), p.MerchantID, r.PathValue("webhookID"))
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+	httpx.WriteJSON(w, http.StatusOK, present(sub))
+}
+
+func (h *Handler) listDeliveries(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	attempts, err := h.svc.ListDeliveryAttempts(r.Context(), p.MerchantID, r.PathValue("webhookID"))
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+	items := make([]map[string]any, 0, len(attempts))
+	for _, a := range attempts {
+		items = append(items, presentAttempt(a))
+	}
+	httpx.WriteJSON(w, http.StatusOK, map[string]any{
+		"entity": "collection",
+		"count":  len(items),
+		"items":  items,
+	})
+}
+
+func present(sub WebhookSubscription) map[string]any {
+	return map[string]any{
+		"id":          sub.ID,
+		"entity":      "webhook",
+		"merchant_id": sub.MerchantID,
+		"url":         sub.URL,
+		"events":      sub.Events,
+		"status":      sub.Status,
+		"created_at":  sub.CreatedAt.Unix(),
+		"updated_at":  sub.UpdatedAt.Unix(),
+	}
+}
+
+func presentWithSecret(sub WebhookSubscription) map[string]any {
+	m := present(sub)
+	m["secret"] = sub.Secret
+	return m
+}
+
+func presentAttempt(a WebhookDeliveryAttempt) map[string]any {
+	var nextRetryAt *int64
+	if a.NextRetryAt != nil {
+		ts := a.NextRetryAt.Unix()
+		nextRetryAt = &ts
+	}
+	return map[string]any{
+		"id":              a.ID,
+		"entity":          "webhook_delivery",
+		"event_id":        a.EventID,
+		"subscription_id": a.SubscriptionID,
+		"status":          a.Status,
+		"request_url":     a.RequestURL,
+		"response_code":   a.ResponseCode,
+		"response_body":   a.ResponseBody,
+		"error":           a.ErrorMessage,
+		"attempt_number":  a.AttemptNumber,
+		"next_retry_at":   nextRetryAt,
+		"created_at":      a.CreatedAt.Unix(),
+		"created_at_rfc":  a.CreatedAt.Format(time.RFC3339),
+	}
+}
+
+func handleError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrSubscriptionNotFound):
+		httpx.WriteError(w, http.StatusNotFound, httpx.APIError{Code: "NOT_FOUND", Description: err.Error()})
+	case errors.Is(err, ErrDeliveryAttemptNotFound):
+		httpx.WriteError(w, http.StatusNotFound, httpx.APIError{Code: "NOT_FOUND", Description: err.Error()})
+	case errors.Is(err, ErrInvalidTransition):
+		httpx.WriteError(w, http.StatusUnprocessableEntity, httpx.APIError{Code: "INVALID_STATE", Description: err.Error()})
+	case errors.Is(err, ErrInvalidURL), errors.Is(err, ErrNoEvents):
+		httpx.WriteError(w, http.StatusBadRequest, httpx.APIError{Code: "BAD_REQUEST_ERROR", Description: err.Error()})
+	default:
+		httpx.WriteError(w, http.StatusInternalServerError, httpx.APIError{Code: "SERVER_ERROR", Description: "internal server error"})
+	}
+}

--- a/internal/webhook/postgres.go
+++ b/internal/webhook/postgres.go
@@ -1,0 +1,300 @@
+package webhook
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sanskarpan/PayGate/internal/common/idgen"
+)
+
+// PostgresRepository implements Repository using pgxpool.
+type PostgresRepository struct {
+	db *pgxpool.Pool
+}
+
+// NewPostgresRepository creates a new PostgresRepository.
+func NewPostgresRepository(db *pgxpool.Pool) *PostgresRepository {
+	return &PostgresRepository{db: db}
+}
+
+func (r *PostgresRepository) CreateSubscription(ctx context.Context, in CreateInput) (WebhookSubscription, error) {
+	if in.URL == "" {
+		return WebhookSubscription{}, ErrInvalidURL
+	}
+	if len(in.Events) == 0 {
+		return WebhookSubscription{}, ErrNoEvents
+	}
+
+	secret, err := generateSecret()
+	if err != nil {
+		return WebhookSubscription{}, err
+	}
+
+	sub := WebhookSubscription{
+		ID:         idgen.New("whs"),
+		MerchantID: in.MerchantID,
+		URL:        in.URL,
+		Events:     in.Events,
+		Secret:     secret,
+		Status:     StatusActive,
+	}
+
+	_, err = r.db.Exec(ctx, `
+INSERT INTO paygate_webhooks.webhook_subscriptions
+    (id, merchant_id, url, events, secret, status)
+VALUES ($1, $2, $3, $4, $5, $6)
+`, sub.ID, sub.MerchantID, sub.URL, sub.Events, sub.Secret, sub.Status)
+	if err != nil {
+		return WebhookSubscription{}, err
+	}
+
+	return r.GetSubscription(ctx, in.MerchantID, sub.ID)
+}
+
+func (r *PostgresRepository) GetSubscription(ctx context.Context, merchantID, id string) (WebhookSubscription, error) {
+	var sub WebhookSubscription
+	err := r.db.QueryRow(ctx, `
+SELECT id, merchant_id, url, events, secret, status, created_at, updated_at
+FROM paygate_webhooks.webhook_subscriptions
+WHERE id = $1 AND merchant_id = $2 AND status != 'deleted'
+`, id, merchantID).Scan(
+		&sub.ID, &sub.MerchantID, &sub.URL, &sub.Events, &sub.Secret,
+		&sub.Status, &sub.CreatedAt, &sub.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return WebhookSubscription{}, ErrSubscriptionNotFound
+	}
+	return sub, err
+}
+
+func (r *PostgresRepository) ListSubscriptions(ctx context.Context, merchantID string) ([]WebhookSubscription, error) {
+	rows, err := r.db.Query(ctx, `
+SELECT id, merchant_id, url, events, secret, status, created_at, updated_at
+FROM paygate_webhooks.webhook_subscriptions
+WHERE merchant_id = $1 AND status != 'deleted'
+ORDER BY created_at DESC
+`, merchantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var subs []WebhookSubscription
+	for rows.Next() {
+		var sub WebhookSubscription
+		if err := rows.Scan(&sub.ID, &sub.MerchantID, &sub.URL, &sub.Events, &sub.Secret,
+			&sub.Status, &sub.CreatedAt, &sub.UpdatedAt); err != nil {
+			return nil, err
+		}
+		subs = append(subs, sub)
+	}
+	return subs, rows.Err()
+}
+
+func (r *PostgresRepository) UpdateSubscription(ctx context.Context, merchantID, id string, in UpdateInput) (WebhookSubscription, error) {
+	// Verify it exists and is accessible.
+	if _, err := r.GetSubscription(ctx, merchantID, id); err != nil {
+		return WebhookSubscription{}, err
+	}
+
+	_, err := r.db.Exec(ctx, `
+UPDATE paygate_webhooks.webhook_subscriptions
+SET url = COALESCE(NULLIF($1, ''), url),
+    events = CASE WHEN $2::text[] IS NOT NULL AND array_length($2::text[], 1) > 0 THEN $2 ELSE events END,
+    updated_at = NOW()
+WHERE id = $3 AND merchant_id = $4
+`, in.URL, in.Events, id, merchantID)
+	if err != nil {
+		return WebhookSubscription{}, err
+	}
+	return r.GetSubscription(ctx, merchantID, id)
+}
+
+func (r *PostgresRepository) TransitionSubscription(ctx context.Context, merchantID, id string, ev SubscriptionEvent) (WebhookSubscription, error) {
+	sub, err := r.GetSubscription(ctx, merchantID, id)
+	if err != nil {
+		return WebhookSubscription{}, err
+	}
+	next, err := Transition(sub.Status, ev)
+	if err != nil {
+		return WebhookSubscription{}, err
+	}
+	_, err = r.db.Exec(ctx, `
+UPDATE paygate_webhooks.webhook_subscriptions
+SET status = $1, updated_at = NOW()
+WHERE id = $2 AND merchant_id = $3
+`, next, id, merchantID)
+	if err != nil {
+		return WebhookSubscription{}, err
+	}
+	sub.Status = next
+	return sub, nil
+}
+
+func (r *PostgresRepository) DeleteSubscription(ctx context.Context, merchantID, id string) error {
+	_, err := r.TransitionSubscription(ctx, merchantID, id, EventDelete)
+	return err
+}
+
+func (r *PostgresRepository) FindActiveSubscriptions(ctx context.Context, merchantID, eventType string) ([]WebhookSubscription, error) {
+	rows, err := r.db.Query(ctx, `
+SELECT id, merchant_id, url, events, secret, status, created_at, updated_at
+FROM paygate_webhooks.webhook_subscriptions
+WHERE merchant_id = $1 AND status = 'active'
+`, merchantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var matches []WebhookSubscription
+	for rows.Next() {
+		var sub WebhookSubscription
+		if err := rows.Scan(&sub.ID, &sub.MerchantID, &sub.URL, &sub.Events, &sub.Secret,
+			&sub.Status, &sub.CreatedAt, &sub.UpdatedAt); err != nil {
+			return nil, err
+		}
+		if sub.MatchesEvent(eventType) {
+			matches = append(matches, sub)
+		}
+	}
+	return matches, rows.Err()
+}
+
+func (r *PostgresRepository) CreateDeliveryAttempt(ctx context.Context, attempt WebhookDeliveryAttempt) (WebhookDeliveryAttempt, error) {
+	if attempt.ID == "" {
+		attempt.ID = idgen.New("wdl")
+	}
+	_, err := r.db.Exec(ctx, `
+INSERT INTO paygate_webhooks.webhook_delivery_attempts
+    (id, event_id, subscription_id, merchant_id, status, request_url, request_body,
+     response_code, response_body, error_message, attempt_number, next_retry_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+`,
+		attempt.ID, attempt.EventID, attempt.SubscriptionID, attempt.MerchantID,
+		attempt.Status, attempt.RequestURL, attempt.RequestBody,
+		attempt.ResponseCode, attempt.ResponseBody, attempt.ErrorMessage,
+		attempt.AttemptNumber, attempt.NextRetryAt,
+	)
+	if err != nil {
+		return WebhookDeliveryAttempt{}, err
+	}
+	return attempt, nil
+}
+
+func (r *PostgresRepository) UpdateDeliveryAttempt(ctx context.Context, id string, status DeliveryStatus, responseCode int, responseBody, errMsg string, nextRetryAt *string) (WebhookDeliveryAttempt, error) {
+	var nextRetry *time.Time
+	if nextRetryAt != nil {
+		t, err := time.Parse(time.RFC3339, *nextRetryAt)
+		if err != nil {
+			return WebhookDeliveryAttempt{}, err
+		}
+		nextRetry = &t
+	}
+	_, err := r.db.Exec(ctx, `
+UPDATE paygate_webhooks.webhook_delivery_attempts
+SET status = $1, response_code = $2, response_body = $3,
+    error_message = $4, next_retry_at = $5
+WHERE id = $6
+`, status, responseCode, responseBody, errMsg, nextRetry, id)
+	if err != nil {
+		return WebhookDeliveryAttempt{}, err
+	}
+	return r.GetDeliveryAttempt(ctx, id)
+}
+
+func (r *PostgresRepository) GetDeliveryAttempt(ctx context.Context, id string) (WebhookDeliveryAttempt, error) {
+	var a WebhookDeliveryAttempt
+	err := r.db.QueryRow(ctx, `
+SELECT id, event_id, subscription_id, merchant_id, status, request_url, request_body,
+       response_code, response_body, error_message, attempt_number, next_retry_at, created_at
+FROM paygate_webhooks.webhook_delivery_attempts
+WHERE id = $1
+`, id).Scan(
+		&a.ID, &a.EventID, &a.SubscriptionID, &a.MerchantID, &a.Status,
+		&a.RequestURL, &a.RequestBody, &a.ResponseCode, &a.ResponseBody, &a.ErrorMessage,
+		&a.AttemptNumber, &a.NextRetryAt, &a.CreatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return WebhookDeliveryAttempt{}, ErrDeliveryAttemptNotFound
+	}
+	return a, err
+}
+
+func (r *PostgresRepository) ListDeliveryAttempts(ctx context.Context, merchantID, subscriptionID string) ([]WebhookDeliveryAttempt, error) {
+	rows, err := r.db.Query(ctx, `
+SELECT id, event_id, subscription_id, merchant_id, status, request_url, request_body,
+       response_code, response_body, error_message, attempt_number, next_retry_at, created_at
+FROM paygate_webhooks.webhook_delivery_attempts
+WHERE merchant_id = $1 AND subscription_id = $2
+ORDER BY created_at DESC
+LIMIT 100
+`, merchantID, subscriptionID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var attempts []WebhookDeliveryAttempt
+	for rows.Next() {
+		var a WebhookDeliveryAttempt
+		if err := rows.Scan(&a.ID, &a.EventID, &a.SubscriptionID, &a.MerchantID, &a.Status,
+			&a.RequestURL, &a.RequestBody, &a.ResponseCode, &a.ResponseBody, &a.ErrorMessage,
+			&a.AttemptNumber, &a.NextRetryAt, &a.CreatedAt); err != nil {
+			return nil, err
+		}
+		attempts = append(attempts, a)
+	}
+	return attempts, rows.Err()
+}
+
+func (r *PostgresRepository) PendingRetries(ctx context.Context, limit int) ([]WebhookDeliveryAttempt, error) {
+	rows, err := r.db.Query(ctx, `
+SELECT id, event_id, subscription_id, merchant_id, status, request_url, request_body,
+       response_code, response_body, error_message, attempt_number, next_retry_at, created_at
+FROM paygate_webhooks.webhook_delivery_attempts
+WHERE status = 'failed' AND next_retry_at IS NOT NULL AND next_retry_at <= NOW()
+ORDER BY next_retry_at
+LIMIT $1
+FOR UPDATE SKIP LOCKED
+`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var attempts []WebhookDeliveryAttempt
+	for rows.Next() {
+		var a WebhookDeliveryAttempt
+		if err := rows.Scan(&a.ID, &a.EventID, &a.SubscriptionID, &a.MerchantID, &a.Status,
+			&a.RequestURL, &a.RequestBody, &a.ResponseCode, &a.ResponseBody, &a.ErrorMessage,
+			&a.AttemptNumber, &a.NextRetryAt, &a.CreatedAt); err != nil {
+			return nil, err
+		}
+		attempts = append(attempts, a)
+	}
+	return attempts, rows.Err()
+}
+
+func (r *PostgresRepository) IsDelivered(ctx context.Context, eventID, subscriptionID string) (bool, error) {
+	var count int
+	err := r.db.QueryRow(ctx, `
+SELECT COUNT(*) FROM paygate_webhooks.webhook_delivery_attempts
+WHERE event_id = $1 AND subscription_id = $2 AND status = 'succeeded'
+`, eventID, subscriptionID).Scan(&count)
+	return count > 0, err
+}
+
+// generateSecret returns a cryptographically random 32-byte hex string.
+func generateSecret() (string, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}

--- a/internal/webhook/repository.go
+++ b/internal/webhook/repository.go
@@ -1,0 +1,29 @@
+package webhook
+
+import "context"
+
+// Repository defines the storage operations for the webhook service.
+type Repository interface {
+	// Subscription CRUD
+	CreateSubscription(ctx context.Context, in CreateInput) (WebhookSubscription, error)
+	GetSubscription(ctx context.Context, merchantID, id string) (WebhookSubscription, error)
+	ListSubscriptions(ctx context.Context, merchantID string) ([]WebhookSubscription, error)
+	UpdateSubscription(ctx context.Context, merchantID, id string, in UpdateInput) (WebhookSubscription, error)
+	TransitionSubscription(ctx context.Context, merchantID, id string, ev SubscriptionEvent) (WebhookSubscription, error)
+	DeleteSubscription(ctx context.Context, merchantID, id string) error
+
+	// Active subscriptions matching a given event type for a given merchant
+	FindActiveSubscriptions(ctx context.Context, merchantID, eventType string) ([]WebhookSubscription, error)
+
+	// Delivery attempt recording
+	CreateDeliveryAttempt(ctx context.Context, attempt WebhookDeliveryAttempt) (WebhookDeliveryAttempt, error)
+	UpdateDeliveryAttempt(ctx context.Context, id string, status DeliveryStatus, responseCode int, responseBody, errMsg string, nextRetryAt *string) (WebhookDeliveryAttempt, error)
+	ListDeliveryAttempts(ctx context.Context, merchantID, subscriptionID string) ([]WebhookDeliveryAttempt, error)
+	GetDeliveryAttempt(ctx context.Context, id string) (WebhookDeliveryAttempt, error)
+
+	// Pending retries: delivery attempts that have failed and have a next_retry_at in the past
+	PendingRetries(ctx context.Context, limit int) ([]WebhookDeliveryAttempt, error)
+
+	// Event deduplication: returns true if the (event_id, subscription_id) pair was already delivered
+	IsDelivered(ctx context.Context, eventID, subscriptionID string) (bool, error)
+}

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -142,11 +142,12 @@ func (s *Service) RetryPendingDeliveries(ctx context.Context, limit int) (int, e
 			nextRetryAt *string
 		)
 
-		if result.Succeeded {
+		switch {
+		case result.Succeeded:
 			status = DeliverySucceeded
-		} else if nextAttempt > MaxDeliveryAttempts {
+		case nextAttempt > MaxDeliveryAttempts:
 			status = DeliveryDeadLettered
-		} else {
+		default:
 			status = DeliveryFailed
 			delay := RetryDelay(nextAttempt)
 			t := time.Now().Add(delay).Format(time.RFC3339)

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -1,0 +1,164 @@
+package webhook
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// Service orchestrates webhook subscription management and event delivery.
+type Service struct {
+	repo      Repository
+	deliverer *Deliverer
+}
+
+// NewService creates a new Service.
+func NewService(repo Repository) *Service {
+	return &Service{repo: repo, deliverer: NewDeliverer()}
+}
+
+// CreateSubscription creates a new webhook subscription.
+func (s *Service) CreateSubscription(ctx context.Context, in CreateInput) (WebhookSubscription, error) {
+	return s.repo.CreateSubscription(ctx, in)
+}
+
+// GetSubscription returns a subscription scoped to the merchant.
+func (s *Service) GetSubscription(ctx context.Context, merchantID, id string) (WebhookSubscription, error) {
+	return s.repo.GetSubscription(ctx, merchantID, id)
+}
+
+// ListSubscriptions returns all active subscriptions for a merchant.
+func (s *Service) ListSubscriptions(ctx context.Context, merchantID string) ([]WebhookSubscription, error) {
+	return s.repo.ListSubscriptions(ctx, merchantID)
+}
+
+// UpdateSubscription updates the URL and/or events of a subscription.
+func (s *Service) UpdateSubscription(ctx context.Context, merchantID, id string, in UpdateInput) (WebhookSubscription, error) {
+	return s.repo.UpdateSubscription(ctx, merchantID, id, in)
+}
+
+// DisableSubscription transitions a subscription from active → disabled.
+func (s *Service) DisableSubscription(ctx context.Context, merchantID, id string) (WebhookSubscription, error) {
+	return s.repo.TransitionSubscription(ctx, merchantID, id, EventDisable)
+}
+
+// EnableSubscription transitions a subscription from disabled → active.
+func (s *Service) EnableSubscription(ctx context.Context, merchantID, id string) (WebhookSubscription, error) {
+	return s.repo.TransitionSubscription(ctx, merchantID, id, EventEnable)
+}
+
+// DeleteSubscription soft-deletes a subscription.
+func (s *Service) DeleteSubscription(ctx context.Context, merchantID, id string) error {
+	return s.repo.DeleteSubscription(ctx, merchantID, id)
+}
+
+// ListDeliveryAttempts returns delivery attempts for a given subscription.
+func (s *Service) ListDeliveryAttempts(ctx context.Context, merchantID, subscriptionID string) ([]WebhookDeliveryAttempt, error) {
+	return s.repo.ListDeliveryAttempts(ctx, merchantID, subscriptionID)
+}
+
+// DeliverEvent finds matching active subscriptions for the event and delivers to each.
+// Each delivery attempt is recorded regardless of outcome. This is the main delivery path
+// called by the Kafka consumer after an outbox event is published.
+func (s *Service) DeliverEvent(ctx context.Context, eventID, merchantID, eventType string, payload map[string]any) error {
+	// Duplicate suppression at subscription level.
+	subs, err := s.repo.FindActiveSubscriptions(ctx, merchantID, eventType)
+	if err != nil {
+		return fmt.Errorf("find subscriptions: %w", err)
+	}
+	if len(subs) == 0 {
+		return nil
+	}
+
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshal webhook payload: %w", err)
+	}
+
+	for _, sub := range subs {
+		// Skip if already delivered to this subscription (idempotency).
+		delivered, err := s.repo.IsDelivered(ctx, eventID, sub.ID)
+		if err != nil {
+			return err
+		}
+		if delivered {
+			continue
+		}
+
+		result := s.deliverer.Deliver(ctx, sub.URL, sub.Secret, eventType, body)
+
+		status := DeliveryFailed
+		if result.Succeeded {
+			status = DeliverySucceeded
+		}
+
+		attempt := WebhookDeliveryAttempt{
+			EventID:        eventID,
+			SubscriptionID: sub.ID,
+			MerchantID:     merchantID,
+			Status:         status,
+			RequestURL:     sub.URL,
+			RequestBody:    body,
+			ResponseCode:   result.StatusCode,
+			ResponseBody:   result.ResponseBody,
+			ErrorMessage:   result.Error,
+			AttemptNumber:  1,
+		}
+
+		if status == DeliveryFailed {
+			delay := RetryDelay(1)
+			nextRetry := time.Now().Add(delay)
+			attempt.NextRetryAt = &nextRetry
+		}
+
+		if _, err := s.repo.CreateDeliveryAttempt(ctx, attempt); err != nil {
+			return fmt.Errorf("record delivery attempt: %w", err)
+		}
+	}
+	return nil
+}
+
+// RetryPendingDeliveries polls for failed delivery attempts with due next_retry_at
+// and re-delivers them. Returns the number of attempts processed.
+func (s *Service) RetryPendingDeliveries(ctx context.Context, limit int) (int, error) {
+	attempts, err := s.repo.PendingRetries(ctx, limit)
+	if err != nil {
+		return 0, fmt.Errorf("poll pending retries: %w", err)
+	}
+
+	for _, attempt := range attempts {
+		sub, err := s.repo.GetSubscription(ctx, attempt.MerchantID, attempt.SubscriptionID)
+		if err != nil {
+			// Subscription may have been deleted; skip.
+			continue
+		}
+
+		result := s.deliverer.Deliver(ctx, sub.URL, sub.Secret, "", attempt.RequestBody)
+
+		nextAttempt := attempt.AttemptNumber + 1
+		var (
+			status      DeliveryStatus
+			nextRetryAt *string
+		)
+
+		if result.Succeeded {
+			status = DeliverySucceeded
+		} else if nextAttempt > MaxDeliveryAttempts {
+			status = DeliveryDeadLettered
+		} else {
+			status = DeliveryFailed
+			delay := RetryDelay(nextAttempt)
+			t := time.Now().Add(delay).Format(time.RFC3339)
+			nextRetryAt = &t
+		}
+
+		if _, err := s.repo.UpdateDeliveryAttempt(
+			ctx, attempt.ID, status,
+			result.StatusCode, result.ResponseBody, result.Error, nextRetryAt,
+		); err != nil {
+			return 0, err
+		}
+	}
+	return len(attempts), nil
+}

--- a/migrations/000007_create_webhook_subscriptions.down.sql
+++ b/migrations/000007_create_webhook_subscriptions.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS paygate_webhooks.webhook_delivery_attempts;
+DROP TABLE IF EXISTS paygate_webhooks.webhook_subscriptions;
+DROP SCHEMA IF EXISTS paygate_webhooks;

--- a/migrations/000007_create_webhook_subscriptions.up.sql
+++ b/migrations/000007_create_webhook_subscriptions.up.sql
@@ -1,0 +1,40 @@
+CREATE SCHEMA IF NOT EXISTS paygate_webhooks;
+
+CREATE TABLE IF NOT EXISTS paygate_webhooks.webhook_subscriptions (
+    id          TEXT PRIMARY KEY,
+    merchant_id TEXT NOT NULL,
+    url         TEXT NOT NULL,
+    events      TEXT[] NOT NULL DEFAULT '{}',
+    secret      TEXT NOT NULL,
+    status      TEXT NOT NULL DEFAULT 'active'
+                    CHECK (status IN ('active', 'disabled', 'deleted')),
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_subscriptions_merchant_status
+    ON paygate_webhooks.webhook_subscriptions (merchant_id, status);
+
+CREATE TABLE IF NOT EXISTS paygate_webhooks.webhook_delivery_attempts (
+    id              TEXT PRIMARY KEY,
+    event_id        TEXT NOT NULL,
+    subscription_id TEXT NOT NULL REFERENCES paygate_webhooks.webhook_subscriptions (id),
+    merchant_id     TEXT NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'pending'
+                        CHECK (status IN ('pending', 'succeeded', 'failed', 'dead_lettered')),
+    request_url     TEXT NOT NULL,
+    request_body    BYTEA,
+    response_code   INTEGER,
+    response_body   TEXT,
+    error_message   TEXT,
+    attempt_number  INTEGER NOT NULL DEFAULT 1,
+    next_retry_at   TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_subscription
+    ON paygate_webhooks.webhook_delivery_attempts (subscription_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_retry
+    ON paygate_webhooks.webhook_delivery_attempts (next_retry_at)
+    WHERE status = 'failed' AND next_retry_at IS NOT NULL;

--- a/tests/integration/backend_hardening_integration_test.go
+++ b/tests/integration/backend_hardening_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sanskarpan/PayGate/internal/outbox"
 	"github.com/sanskarpan/PayGate/internal/payment"
 	"github.com/sanskarpan/PayGate/internal/refund"
+	"github.com/sanskarpan/PayGate/internal/webhook"
 )
 
 func TestIntegrationIdempotentOrderCreateReplaysResponse(t *testing.T) {
@@ -285,11 +286,13 @@ func buildGatewayMux(db *pgxpool.Pool) (*http.ServeMux, *merchant.Service, *orde
 	ledgerSvc := ledger.NewService(ledger.NewRepository(db))
 	paymentSvc := payment.NewService(payment.NewPostgresRepository(db, ledgerSvc, orderSvc), gateway.NewSimulator())
 	refundSvc := refund.NewService(refund.NewPostgresRepository(db, ledgerSvc))
+	webhookSvc := webhook.NewService(webhook.NewPostgresRepository(db))
 
 	merchantHandler := merchant.NewHandler(merchantSvc)
 	orderHandler := order.NewHandler(orderSvc)
 	paymentHandler := payment.NewHandler(paymentSvc)
 	refundHandler := refund.NewHandler(refundSvc)
+	webhookHandler := webhook.NewHandler(webhookSvc)
 
 	protected := func(scope merchant.APIKeyScope, next http.Handler) http.Handler {
 		return authMw.RequireScope(scope, idemMw.Wrap(next))
@@ -301,6 +304,7 @@ func buildGatewayMux(db *pgxpool.Pool) (*http.ServeMux, *merchant.Service, *orde
 	orderHandler.RegisterRoutesWithAuth(mux, protected)
 	paymentHandler.RegisterRoutesWithAuth(mux, protected)
 	refundHandler.RegisterRoutesWithAuth(mux, protected)
+	webhookHandler.RegisterRoutesWithAuth(mux, protected)
 	mux.Handle("GET /v1/merchants/me", authMw.RequireScope(merchant.APIKeyScopeRead, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		p, _ := httpx.PrincipalFromContext(r.Context())
 		httpx.WriteJSON(w, http.StatusOK, map[string]any{"merchant_id": p.MerchantID})

--- a/tests/integration/webhook_integration_test.go
+++ b/tests/integration/webhook_integration_test.go
@@ -1,0 +1,290 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/sanskarpan/PayGate/internal/merchant"
+	"github.com/sanskarpan/PayGate/internal/order"
+	"github.com/sanskarpan/PayGate/internal/payment"
+	"github.com/sanskarpan/PayGate/internal/webhook"
+)
+
+func TestIntegrationWebhookSubscriptionCRUD(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	mux, merchantSvc, _, _ := buildGatewayMux(db)
+	ctx := context.Background()
+
+	createdMerchant, err := merchantSvc.CreateMerchant(ctx, merchant.CreateMerchantInput{
+		Name: "Webhook Merchant", Email: "webhook@test.com", BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+	key, err := merchantSvc.CreateAPIKey(ctx, createdMerchant.ID, merchant.CreateAPIKeyInput{
+		Mode: merchant.APIKeyModeTest, Scope: merchant.APIKeyScopeWrite,
+	})
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+	authHeader := basicAuth(key.KeyID, key.KeySecret)
+
+	// Create a webhook subscription.
+	body, _ := json.Marshal(map[string]any{
+		"url":    "https://example.com/webhook",
+		"events": []string{"payment.captured", "refund.*"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/webhooks", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", authHeader)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var created map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created["id"] == nil || created["id"] == "" {
+		t.Fatal("expected non-empty id")
+	}
+	if created["secret"] == nil || created["secret"] == "" {
+		t.Fatal("expected secret on creation response")
+	}
+	if created["status"] != "active" {
+		t.Fatalf("expected status=active, got %v", created["status"])
+	}
+
+	webhookID := created["id"].(string)
+
+	t.Run("get subscription", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/webhooks/"+webhookID, nil)
+		req.Header.Set("Authorization", authHeader)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+		}
+		var resp map[string]any
+		_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+		// Secret must NOT be returned on GET.
+		if resp["secret"] != nil {
+			t.Fatalf("secret must not be returned on GET, got %v", resp["secret"])
+		}
+	})
+
+	t.Run("list subscriptions", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/webhooks", nil)
+		req.Header.Set("Authorization", authHeader)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+		}
+		var resp map[string]any
+		_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+		if resp["count"].(float64) < 1 {
+			t.Fatalf("expected at least 1 subscription, got %v", resp["count"])
+		}
+	})
+
+	t.Run("disable subscription", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/v1/webhooks/"+webhookID+"/disable", nil)
+		req.Header.Set("Authorization", authHeader)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+		}
+		var resp map[string]any
+		_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+		if resp["status"] != "disabled" {
+			t.Fatalf("expected status=disabled, got %v", resp["status"])
+		}
+	})
+
+	t.Run("re-enable subscription", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodPost, "/v1/webhooks/"+webhookID+"/enable", nil)
+		req.Header.Set("Authorization", authHeader)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+		}
+		var resp map[string]any
+		_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+		if resp["status"] != "active" {
+			t.Fatalf("expected status=active, got %v", resp["status"])
+		}
+	})
+
+	t.Run("delete subscription", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodDelete, "/v1/webhooks/"+webhookID, nil)
+		req.Header.Set("Authorization", authHeader)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNoContent {
+			t.Fatalf("expected 204, got %d body=%s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("get deleted subscription returns 404", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/webhooks/"+webhookID, nil)
+		req.Header.Set("Authorization", authHeader)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusNotFound {
+			t.Fatalf("expected 404, got %d body=%s", rec.Code, rec.Body.String())
+		}
+	})
+}
+
+func TestIntegrationWebhookDelivery(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	ctx := context.Background()
+	_, merchantSvc, orderSvc, paymentSvc := buildGatewayMux(db)
+
+	// Set up a mock HTTP server to receive the webhook.
+	received := make(chan []byte, 10)
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(body)
+		received <- body
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockServer.Close()
+
+	createdMerchant, err := merchantSvc.CreateMerchant(ctx, merchant.CreateMerchantInput{
+		Name: "Delivery Merchant", Email: "delivery@test.com", BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+
+	// Create webhook subscription pointing at mock server.
+	webhookRepo := webhook.NewPostgresRepository(db)
+	webhookSvc := webhook.NewService(webhookRepo)
+	sub, err := webhookSvc.CreateSubscription(ctx, webhook.CreateInput{
+		MerchantID: createdMerchant.ID,
+		URL:        mockServer.URL,
+		Events:     []string{"payment.captured"},
+	})
+	if err != nil {
+		t.Fatalf("create subscription: %v", err)
+	}
+
+	// Create an order + capture a payment.
+	createdOrder, err := orderSvc.Create(ctx, order.CreateInput{
+		MerchantID: createdMerchant.ID, Amount: 5000, Currency: "INR", Receipt: "wh-test",
+	})
+	if err != nil {
+		t.Fatalf("create order: %v", err)
+	}
+	authorized, err := paymentSvc.Authorize(ctx, payment.AuthorizeInput{
+		MerchantID: createdMerchant.ID, OrderID: createdOrder.ID,
+		Amount: createdOrder.Amount, Currency: createdOrder.Currency, Method: "card",
+	})
+	if err != nil {
+		t.Fatalf("authorize: %v", err)
+	}
+	if _, err := paymentSvc.CaptureForMerchant(ctx, createdMerchant.ID, authorized.PaymentID, createdOrder.Amount); err != nil {
+		t.Fatalf("capture: %v", err)
+	}
+
+	// Deliver a payment.captured event via the webhook service.
+	payload := map[string]any{
+		"event_type": "payment.captured",
+		"payment_id": authorized.PaymentID,
+		"amount":     createdOrder.Amount,
+		"currency":   createdOrder.Currency,
+	}
+	if err := webhookSvc.DeliverEvent(ctx, "evt_test_delivery", createdMerchant.ID, "payment.captured", payload); err != nil {
+		t.Fatalf("deliver event: %v", err)
+	}
+
+	// Verify the mock server received the POST.
+	select {
+	case body := <-received:
+		var got map[string]any
+		if err := json.Unmarshal(body, &got); err != nil {
+			t.Fatalf("decode received webhook: %v", err)
+		}
+		if got["event_type"] != "payment.captured" {
+			t.Fatalf("expected event_type=payment.captured, got %v", got["event_type"])
+		}
+	default:
+		t.Fatal("expected webhook to be delivered to mock server")
+	}
+
+	// Verify delivery attempt was recorded in DB.
+	attempts, err := webhookSvc.ListDeliveryAttempts(ctx, createdMerchant.ID, sub.ID)
+	if err != nil {
+		t.Fatalf("list delivery attempts: %v", err)
+	}
+	if len(attempts) != 1 {
+		t.Fatalf("expected 1 delivery attempt, got %d", len(attempts))
+	}
+	if attempts[0].Status != webhook.DeliverySucceeded {
+		t.Fatalf("expected succeeded delivery, got %s", attempts[0].Status)
+	}
+}
+
+func TestIntegrationWebhookIdempotentDelivery(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	ctx := context.Background()
+	createdMerchant, err := merchant.NewService(
+		merchant.NewPostgresRepository(db),
+	).CreateMerchant(ctx, merchant.CreateMerchantInput{
+		Name: "Idem Webhook Merchant", Email: "idem-wh@test.com", BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+
+	deliveryCount := 0
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deliveryCount++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockServer.Close()
+
+	webhookSvc := webhook.NewService(webhook.NewPostgresRepository(db))
+	if _, err := webhookSvc.CreateSubscription(ctx, webhook.CreateInput{
+		MerchantID: createdMerchant.ID,
+		URL:        mockServer.URL,
+		Events:     []string{"payment.captured"},
+	}); err != nil {
+		t.Fatalf("create subscription: %v", err)
+	}
+
+	payload := map[string]any{"event_type": "payment.captured"}
+	const eventID = "evt_idempotent_test"
+
+	// Deliver the same event twice.
+	if err := webhookSvc.DeliverEvent(ctx, eventID, createdMerchant.ID, "payment.captured", payload); err != nil {
+		t.Fatalf("first deliver: %v", err)
+	}
+	if err := webhookSvc.DeliverEvent(ctx, eventID, createdMerchant.ID, "payment.captured", payload); err != nil {
+		t.Fatalf("second deliver: %v", err)
+	}
+
+	// Mock server should have been called exactly once.
+	if deliveryCount != 1 {
+		t.Fatalf("expected 1 delivery (idempotent), got %d", deliveryCount)
+	}
+}


### PR DESCRIPTION
## Summary
- Webhook subscription CRUD with explicit state machine (`active ↔ disabled → deleted`)
- HTTP POST delivery signed with HMAC-SHA256 (`X-PayGate-Signature: sha256=<hex>`) and 10s timeout
- Delivery attempt recording with full request/response stored in Postgres
- Retry schedule: immediate → 5s → 10s → 30s → 1m → 5m → 10m → 30m → 1h×10, dead-lettered after 18 attempts
- Idempotent delivery: skips re-delivery if event+subscription pair already succeeded
- Event pattern matching: exact match or wildcard prefix (e.g. `refund.*`)
- Webhook secret returned only once at creation time, not on subsequent GETs
- Integration tests: subscription CRUD, delivery to mock HTTP server, idempotent delivery

Closes #270

## Test plan
- [ ] `go test -v -tags integration ./tests/integration/... -run TestIntegrationWebhook`
- [ ] Subscription create returns 201 with secret only once
- [ ] GET subscription returns 200 without secret
- [ ] Disable/enable transitions work; double-disable returns 422
- [ ] Delete returns 204; subsequent GET returns 404
- [ ] Delivery to mock server records attempt with `succeeded` status
- [ ] Second delivery of same event ID is idempotent (mock server called once)

🤖 Generated with [Claude Code](https://claude.com/claude-code)