### PR TITLE
Add webhook retry engine: RetryWorker, replay endpoint, secret rotation

### DIFF
--- a/cmd/api-gateway/main.go
+++ b/cmd/api-gateway/main.go
@@ -96,6 +96,7 @@ func run() error {
 	webhookHandler := webhook.NewHandler(webhookSvc)
 
 	go order.NewExpirySweeper(orderSvc, time.Minute, l).Start(ctx)
+	go webhook.NewRetryWorker(webhookSvc, 30*time.Second, l).Start(ctx)
 	go payment.NewSweeper(paymentSvc, 30*time.Second, l).Start(ctx)
 
 	mux := http.NewServeMux()

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -30,6 +30,8 @@ func (h *Handler) RegisterRoutesWithAuth(mux *http.ServeMux, wrap func(scope mer
 	mux.Handle("POST /v1/webhooks/{webhookID}/enable", wrap(merchant.APIKeyScopeWrite, http.HandlerFunc(h.enable)))
 	mux.Handle("POST /v1/webhooks/{webhookID}/disable", wrap(merchant.APIKeyScopeWrite, http.HandlerFunc(h.disable)))
 	mux.Handle("GET /v1/webhooks/{webhookID}/deliveries", wrap(merchant.APIKeyScopeRead, http.HandlerFunc(h.listDeliveries)))
+	mux.Handle("POST /v1/webhooks/{webhookID}/rotate-secret", wrap(merchant.APIKeyScopeWrite, http.HandlerFunc(h.rotateSecret)))
+	mux.Handle("POST /v1/webhooks/events/{eventID}/replay", wrap(merchant.APIKeyScopeWrite, http.HandlerFunc(h.replay)))
 }
 
 func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
@@ -180,6 +182,39 @@ func (h *Handler) listDeliveries(w http.ResponseWriter, r *http.Request) {
 		"entity": "collection",
 		"count":  len(items),
 		"items":  items,
+	})
+}
+
+func (h *Handler) rotateSecret(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	sub, err := h.svc.RotateSecret(r.Context(), p.MerchantID, r.PathValue("webhookID"))
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+	// Return new secret on rotation.
+	httpx.WriteJSON(w, http.StatusOK, presentWithSecret(sub))
+}
+
+func (h *Handler) replay(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	n, err := h.svc.ReplayEvent(r.Context(), p.MerchantID, r.PathValue("eventID"))
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+	httpx.WriteJSON(w, http.StatusOK, map[string]any{
+		"entity":     "replay",
+		"event_id":   r.PathValue("eventID"),
+		"deliveries": n,
 	})
 }
 

--- a/internal/webhook/postgres.go
+++ b/internal/webhook/postgres.go
@@ -290,6 +290,52 @@ WHERE event_id = $1 AND subscription_id = $2 AND status = 'succeeded'
 	return count > 0, err
 }
 
+func (r *PostgresRepository) FindDeliveryByEvent(ctx context.Context, merchantID, eventID string) ([]WebhookDeliveryAttempt, error) {
+	rows, err := r.db.Query(ctx, `
+SELECT id, event_id, subscription_id, merchant_id, status, request_url, request_body,
+       response_code, response_body, error_message, attempt_number, next_retry_at, created_at
+FROM paygate_webhooks.webhook_delivery_attempts
+WHERE merchant_id = $1 AND event_id = $2
+ORDER BY created_at DESC
+LIMIT 100
+`, merchantID, eventID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var attempts []WebhookDeliveryAttempt
+	for rows.Next() {
+		var a WebhookDeliveryAttempt
+		if err := rows.Scan(&a.ID, &a.EventID, &a.SubscriptionID, &a.MerchantID, &a.Status,
+			&a.RequestURL, &a.RequestBody, &a.ResponseCode, &a.ResponseBody, &a.ErrorMessage,
+			&a.AttemptNumber, &a.NextRetryAt, &a.CreatedAt); err != nil {
+			return nil, err
+		}
+		attempts = append(attempts, a)
+	}
+	return attempts, rows.Err()
+}
+
+func (r *PostgresRepository) RotateSecret(ctx context.Context, merchantID, id string) (WebhookSubscription, error) {
+	if _, err := r.GetSubscription(ctx, merchantID, id); err != nil {
+		return WebhookSubscription{}, err
+	}
+	secret, err := generateSecret()
+	if err != nil {
+		return WebhookSubscription{}, err
+	}
+	_, err = r.db.Exec(ctx, `
+UPDATE paygate_webhooks.webhook_subscriptions
+SET secret = $1, updated_at = NOW()
+WHERE id = $2 AND merchant_id = $3
+`, secret, id, merchantID)
+	if err != nil {
+		return WebhookSubscription{}, err
+	}
+	return r.GetSubscription(ctx, merchantID, id)
+}
+
 // generateSecret returns a cryptographically random 32-byte hex string.
 func generateSecret() (string, error) {
 	b := make([]byte, 32)

--- a/internal/webhook/repository.go
+++ b/internal/webhook/repository.go
@@ -26,4 +26,10 @@ type Repository interface {
 
 	// Event deduplication: returns true if the (event_id, subscription_id) pair was already delivered
 	IsDelivered(ctx context.Context, eventID, subscriptionID string) (bool, error)
+
+	// Replay: find the most recent succeeded delivery attempt for eventID to replay
+	FindDeliveryByEvent(ctx context.Context, merchantID, eventID string) ([]WebhookDeliveryAttempt, error)
+
+	// RotateSecret replaces the signing secret for a subscription.
+	RotateSecret(ctx context.Context, merchantID, id string) (WebhookSubscription, error)
 }

--- a/internal/webhook/retrier.go
+++ b/internal/webhook/retrier.go
@@ -1,0 +1,49 @@
+package webhook
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+// RetryWorker polls for failed delivery attempts due for retry and re-delivers them.
+// It runs as a background goroutine and uses DB-level locking (FOR UPDATE SKIP LOCKED)
+// to safely co-exist with multiple instances.
+type RetryWorker struct {
+	svc      *Service
+	interval time.Duration
+	batchSz  int
+	logger   *slog.Logger
+}
+
+// NewRetryWorker creates a RetryWorker that polls every interval.
+func NewRetryWorker(svc *Service, interval time.Duration, logger *slog.Logger) *RetryWorker {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	return &RetryWorker{svc: svc, interval: interval, batchSz: 50, logger: logger}
+}
+
+// Start runs the retry loop until ctx is cancelled.
+func (w *RetryWorker) Start(ctx context.Context) {
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			n, err := w.svc.RetryPendingDeliveries(ctx, w.batchSz)
+			if err != nil {
+				w.logger.Error("webhook retry batch failed", "error", err)
+				continue
+			}
+			if n > 0 {
+				w.logger.Info("webhook retry batch processed", "count", n)
+			}
+		}
+	}
+}

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -119,6 +119,44 @@ func (s *Service) DeliverEvent(ctx context.Context, eventID, merchantID, eventTy
 	return nil
 }
 
+// RotateSecret generates a new signing secret for the subscription.
+// The new secret is returned in the response. The previous secret is immediately
+// invalidated — callers must update their verification logic before rotating.
+func (s *Service) RotateSecret(ctx context.Context, merchantID, id string) (WebhookSubscription, error) {
+	return s.repo.RotateSecret(ctx, merchantID, id)
+}
+
+// ReplayEvent re-delivers a previously recorded event to its matching subscriptions.
+// It looks up all delivery attempts for the event, picks the request body from the
+// most recent one, and re-calls DeliverEvent (which handles idempotency by checking
+// for succeeded deliveries — so ReplayEvent explicitly clears that gate by using a
+// new synthetic event ID derived from the original).
+func (s *Service) ReplayEvent(ctx context.Context, merchantID, eventID string) (int, error) {
+	attempts, err := s.repo.FindDeliveryByEvent(ctx, merchantID, eventID)
+	if err != nil {
+		return 0, fmt.Errorf("find event deliveries: %w", err)
+	}
+	if len(attempts) == 0 {
+		return 0, ErrDeliveryAttemptNotFound
+	}
+
+	// Use the first attempt's request body (most recent by DESC ordering).
+	body := attempts[0].RequestBody
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return 0, fmt.Errorf("unmarshal replay payload: %w", err)
+	}
+
+	// Use a replay-prefixed event ID so idempotency guard allows re-delivery.
+	replayID := "replay_" + eventID
+	eventType, _ := payload["event_type"].(string)
+
+	if err := s.DeliverEvent(ctx, replayID, merchantID, eventType, payload); err != nil {
+		return 0, err
+	}
+	return 1, nil
+}
+
 // RetryPendingDeliveries polls for failed delivery attempts with due next_retry_at
 // and re-delivers them. Returns the number of attempts processed.
 func (s *Service) RetryPendingDeliveries(ctx context.Context, limit int) (int, error) {

--- a/tests/integration/webhook_retry_integration_test.go
+++ b/tests/integration/webhook_retry_integration_test.go
@@ -1,0 +1,228 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sanskarpan/PayGate/internal/merchant"
+	"github.com/sanskarpan/PayGate/internal/webhook"
+)
+
+func TestIntegrationWebhookSecretRotation(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	mux, merchantSvc, _, _ := buildGatewayMux(db)
+	ctx := context.Background()
+
+	createdMerchant, err := merchantSvc.CreateMerchant(ctx, merchant.CreateMerchantInput{
+		Name: "Rotate Merchant", Email: "rotate@test.com", BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+	key, err := merchantSvc.CreateAPIKey(ctx, createdMerchant.ID, merchant.CreateAPIKeyInput{
+		Mode: merchant.APIKeyModeTest, Scope: merchant.APIKeyScopeWrite,
+	})
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+	authHeader := basicAuth(key.KeyID, key.KeySecret)
+
+	// Create a subscription.
+	body, _ := json.Marshal(map[string]any{
+		"url":    "https://example.com/webhook",
+		"events": []string{"payment.captured"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/webhooks", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", authHeader)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var created map[string]any
+	_ = json.Unmarshal(rec.Body.Bytes(), &created)
+	webhookID := created["id"].(string)
+	originalSecret := created["secret"].(string)
+
+	// Rotate the secret.
+	rotateReq := httptest.NewRequest(http.MethodPost, "/v1/webhooks/"+webhookID+"/rotate-secret", nil)
+	rotateReq.Header.Set("Authorization", authHeader)
+	rotateRec := httptest.NewRecorder()
+	mux.ServeHTTP(rotateRec, rotateReq)
+	if rotateRec.Code != http.StatusOK {
+		t.Fatalf("expected 200 on rotate, got %d body=%s", rotateRec.Code, rotateRec.Body.String())
+	}
+	var rotated map[string]any
+	_ = json.Unmarshal(rotateRec.Body.Bytes(), &rotated)
+
+	newSecret, ok := rotated["secret"].(string)
+	if !ok || newSecret == "" {
+		t.Fatal("expected new secret in rotate response")
+	}
+	if newSecret == originalSecret {
+		t.Fatal("expected new secret to differ from original")
+	}
+}
+
+func TestIntegrationWebhookReplay(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	ctx := context.Background()
+	createdMerchant, err := merchant.NewService(
+		merchant.NewPostgresRepository(db),
+	).CreateMerchant(ctx, merchant.CreateMerchantInput{
+		Name: "Replay Webhook Merchant", Email: "replay-wh@test.com", BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+
+	deliveryCount := 0
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		deliveryCount++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockServer.Close()
+
+	webhookSvc := webhook.NewService(webhook.NewPostgresRepository(db))
+	if _, err := webhookSvc.CreateSubscription(ctx, webhook.CreateInput{
+		MerchantID: createdMerchant.ID,
+		URL:        mockServer.URL,
+		Events:     []string{"payment.captured"},
+	}); err != nil {
+		t.Fatalf("create subscription: %v", err)
+	}
+
+	payload := map[string]any{"event_type": "payment.captured", "payment_id": "pay_replay_test"}
+	const eventID = "evt_replay_test"
+
+	// First delivery.
+	if err := webhookSvc.DeliverEvent(ctx, eventID, createdMerchant.ID, "payment.captured", payload); err != nil {
+		t.Fatalf("first deliver: %v", err)
+	}
+	if deliveryCount != 1 {
+		t.Fatalf("expected 1 delivery after first deliver, got %d", deliveryCount)
+	}
+
+	// Replay: should re-deliver (new replay ID bypasses idempotency).
+	n, err := webhookSvc.ReplayEvent(ctx, createdMerchant.ID, eventID)
+	if err != nil {
+		t.Fatalf("replay event: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 replayed delivery, got %d", n)
+	}
+	if deliveryCount != 2 {
+		t.Fatalf("expected 2 total deliveries after replay, got %d", deliveryCount)
+	}
+}
+
+func TestIntegrationWebhookRetryWorker(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	ctx := context.Background()
+	createdMerchant, err := merchant.NewService(
+		merchant.NewPostgresRepository(db),
+	).CreateMerchant(ctx, merchant.CreateMerchantInput{
+		Name: "Retry Worker Merchant", Email: "retry-worker@test.com", BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+
+	// Start a server that fails on the first call and succeeds on subsequent.
+	callCount := 0
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		if callCount == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockServer.Close()
+
+	webhookSvc := webhook.NewService(webhook.NewPostgresRepository(db))
+	sub, err := webhookSvc.CreateSubscription(ctx, webhook.CreateInput{
+		MerchantID: createdMerchant.ID,
+		URL:        mockServer.URL,
+		Events:     []string{"payment.captured"},
+	})
+	if err != nil {
+		t.Fatalf("create subscription: %v", err)
+	}
+
+	payload := map[string]any{"event_type": "payment.captured"}
+	if err := webhookSvc.DeliverEvent(ctx, "evt_retry_worker_test", createdMerchant.ID, "payment.captured", payload); err != nil {
+		t.Fatalf("deliver event: %v", err)
+	}
+
+	// First delivery should have failed.
+	attempts, err := webhookSvc.ListDeliveryAttempts(ctx, createdMerchant.ID, sub.ID)
+	if err != nil {
+		t.Fatalf("list attempts: %v", err)
+	}
+	if len(attempts) != 1 || attempts[0].Status != webhook.DeliveryFailed {
+		t.Fatalf("expected 1 failed attempt, got %d attempts, status=%v", len(attempts), func() webhook.DeliveryStatus {
+			if len(attempts) > 0 {
+				return attempts[0].Status
+			}
+			return ""
+		}())
+	}
+
+	// Backdate the next_retry_at so the retry worker picks it up immediately.
+	if _, err := db.Exec(ctx,
+		`UPDATE paygate_webhooks.webhook_delivery_attempts SET next_retry_at = NOW() - INTERVAL '1 minute' WHERE id = $1`,
+		attempts[0].ID,
+	); err != nil {
+		t.Fatalf("backdate next_retry_at: %v", err)
+	}
+
+	// Run the retry worker once.
+	n, err := webhookSvc.RetryPendingDeliveries(ctx, 10)
+	if err != nil {
+		t.Fatalf("retry pending: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 retried delivery, got %d", n)
+	}
+
+	// Wait a brief moment for the second delivery to be recorded.
+	time.Sleep(10 * time.Millisecond)
+
+	// Re-fetch attempts: the original should now be succeeded.
+	attempts, err = webhookSvc.ListDeliveryAttempts(ctx, createdMerchant.ID, sub.ID)
+	if err != nil {
+		t.Fatalf("re-list attempts: %v", err)
+	}
+	// The UpdateDeliveryAttempt updates the original record to succeeded.
+	var succeeded bool
+	for _, a := range attempts {
+		if a.Status == webhook.DeliverySucceeded {
+			succeeded = true
+			break
+		}
+	}
+	if !succeeded {
+		t.Fatalf("expected at least one succeeded delivery after retry, got statuses: %v", func() []webhook.DeliveryStatus {
+			var ss []webhook.DeliveryStatus
+			for _, a := range attempts {
+				ss = append(ss, a.Status)
+			}
+			return ss
+		}())
+	}
+}


### PR DESCRIPTION
## Summary
- `RetryWorker` goroutine polls DB (FOR UPDATE SKIP LOCKED) every 30s for due failed deliveries
- Exponential backoff: 5s → 10s → 30s → 1m → 5m → 10m → 30m → 1h×10 before dead-letter at attempt 18
- `POST /v1/webhooks/{id}/rotate-secret` generates a new HMAC signing secret (returns it once)
- `POST /v1/webhooks/events/{event_id}/replay` re-delivers a recorded event with a new replay ID (bypasses idempotency guard)
- RetryWorker wired into api-gateway alongside order/payment sweepers
- Integration tests: secret rotation, replay, retry worker with backdate-and-run pattern

Closes #271

## Test plan
- [ ] `go test -v -tags integration ./tests/integration/... -run TestIntegrationWebhookSecretRotation`
- [ ] `go test -v -tags integration ./tests/integration/... -run TestIntegrationWebhookReplay`
- [ ] `go test -v -tags integration ./tests/integration/... -run TestIntegrationWebhookRetryWorker`
- [ ] Secret rotation returns new secret different from original
- [ ] Replay re-delivers (mock server called twice total)
- [ ] Retry worker succeeds on second attempt, updates status to succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)