### PR TITLE
Add settlement service: nightly batch, fee calculation, ledger entries, settlement items

### DIFF
--- a/cmd/api-gateway/main.go
+++ b/cmd/api-gateway/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sanskarpan/PayGate/internal/order"
 	"github.com/sanskarpan/PayGate/internal/payment"
 	"github.com/sanskarpan/PayGate/internal/refund"
+	"github.com/sanskarpan/PayGate/internal/settlement"
 	"github.com/sanskarpan/PayGate/internal/webhook"
 )
 
@@ -91,6 +92,10 @@ func run() error {
 	refundSvc := refund.NewService(refundRepo)
 	refundHandler := refund.NewHandler(refundSvc)
 
+	settlementRepo := settlement.NewPostgresRepository(db, ledgerSvc)
+	settlementSvc := settlement.NewService(settlementRepo)
+	settlementHandler := settlement.NewHandler(settlementSvc)
+
 	webhookRepo := webhook.NewPostgresRepository(db)
 	webhookSvc := webhook.NewService(webhookRepo)
 	webhookHandler := webhook.NewHandler(webhookSvc)
@@ -144,6 +149,7 @@ func run() error {
 	orderHandler.RegisterRoutesWithAuth(mux, protected)
 	paymentHandler.RegisterRoutesWithAuth(mux, protected)
 	refundHandler.RegisterRoutesWithAuth(mux, protected)
+	settlementHandler.RegisterRoutesWithAuth(mux, protected)
 	webhookHandler.RegisterRoutesWithAuth(mux, protected)
 	merchantHandler.RegisterProtectedRoutes(mux, protected)
 	checkoutHandler.RegisterRoutes(mux)

--- a/internal/settlement/domain.go
+++ b/internal/settlement/domain.go
@@ -1,0 +1,106 @@
+package settlement
+
+import (
+	"errors"
+	"time"
+)
+
+// SettlementState is the explicit state machine type for settlements.
+type SettlementState string
+
+// SettlementEvent drives transitions in the settlement state machine.
+type SettlementEvent string
+
+const (
+	StateCreated    SettlementState = "created"
+	StateProcessing SettlementState = "processing"
+	StateProcessed  SettlementState = "processed"
+	StateFailed     SettlementState = "failed"
+)
+
+const (
+	EventProcess  SettlementEvent = "process"   // created → processing
+	EventComplete SettlementEvent = "complete"   // processing → processed
+	EventFail     SettlementEvent = "fail"       // processing → failed
+)
+
+var (
+	ErrSettlementNotFound    = errors.New("settlement not found")
+	ErrInvalidTransition     = errors.New("invalid settlement state transition")
+	ErrNoEligiblePayments    = errors.New("no eligible payments found for settlement")
+)
+
+// Transition returns the next SettlementState for the given event,
+// or ErrInvalidTransition if the event is invalid from the current state.
+func Transition(from SettlementState, ev SettlementEvent) (SettlementState, error) {
+	table := map[SettlementState]map[SettlementEvent]SettlementState{
+		StateCreated: {
+			EventProcess: StateProcessing,
+		},
+		StateProcessing: {
+			EventComplete: StateProcessed,
+			EventFail:     StateFailed,
+		},
+	}
+	m, ok := table[from]
+	if !ok {
+		return "", ErrInvalidTransition
+	}
+	next, ok := m[ev]
+	if !ok {
+		return "", ErrInvalidTransition
+	}
+	return next, nil
+}
+
+// Settlement groups payments for a merchant into a single payout batch.
+type Settlement struct {
+	ID           string
+	MerchantID   string
+	Status       SettlementState
+	PeriodStart  time.Time
+	PeriodEnd    time.Time
+	TotalAmount  int64 // sum of captured payment amounts
+	TotalFees    int64 // sum of platform fees deducted
+	TotalRefunds int64 // sum of refunded amounts
+	NetAmount    int64 // TotalAmount - TotalFees - TotalRefunds
+	PaymentCount int
+	Currency     string
+	ProcessedAt  *time.Time
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+}
+
+// SettlementItem is one payment's contribution to a settlement batch.
+type SettlementItem struct {
+	ID           string
+	SettlementID string
+	PaymentID    string
+	MerchantID   string
+	Amount       int64 // gross captured amount
+	Fee          int64 // platform fee taken at capture (2% of amount)
+	Refunds      int64 // total amount_refunded on payment
+	Net          int64 // Amount - Fee - Refunds
+	Currency     string
+	CreatedAt    time.Time
+}
+
+// CalculateFee returns the platform fee for a given payment amount.
+// The fee rate is 2% (200 basis points), consistent with the capture ledger entries.
+func CalculateFee(amount int64) int64 {
+	return amount * 2 / 100
+}
+
+// CalculateNet returns the net merchant payout for an item.
+func CalculateNet(amount, fee, refunds int64) int64 {
+	return amount - fee - refunds
+}
+
+// EligiblePayment carries the fields needed to settle a single payment.
+type EligiblePayment struct {
+	PaymentID      string
+	Amount         int64
+	Fee            int64
+	AmountRefunded int64
+	Currency       string
+}

--- a/internal/settlement/domain_test.go
+++ b/internal/settlement/domain_test.go
@@ -1,0 +1,79 @@
+package settlement
+
+import "testing"
+
+func TestSettlementTransition(t *testing.T) {
+	tests := []struct {
+		from    SettlementState
+		event   SettlementEvent
+		want    SettlementState
+		wantErr bool
+	}{
+		{StateCreated, EventProcess, StateProcessing, false},
+		{StateProcessing, EventComplete, StateProcessed, false},
+		{StateProcessing, EventFail, StateFailed, false},
+		// Invalid transitions
+		{StateCreated, EventComplete, "", true},
+		{StateCreated, EventFail, "", true},
+		{StateProcessed, EventProcess, "", true},
+		{StateProcessed, EventComplete, "", true},
+		{StateFailed, EventProcess, "", true},
+		{StateFailed, EventComplete, "", true},
+	}
+
+	for _, tc := range tests {
+		got, err := Transition(tc.from, tc.event)
+		if tc.wantErr {
+			if err == nil {
+				t.Errorf("Transition(%s, %s): expected error, got %s", tc.from, tc.event, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("Transition(%s, %s): unexpected error: %v", tc.from, tc.event, err)
+			continue
+		}
+		if got != tc.want {
+			t.Errorf("Transition(%s, %s) = %s, want %s", tc.from, tc.event, got, tc.want)
+		}
+	}
+}
+
+func TestCalculateFee(t *testing.T) {
+	tests := []struct {
+		amount int64
+		want   int64
+	}{
+		{10000, 200},  // 2% of ₹100.00 = ₹2.00
+		{5000, 100},   // 2% of ₹50.00 = ₹1.00
+		{99, 1},       // 2% of ₹0.99 = ₹0.01 (integer division)
+		{100, 2},
+		{0, 0},
+	}
+	for _, tc := range tests {
+		got := CalculateFee(tc.amount)
+		if got != tc.want {
+			t.Errorf("CalculateFee(%d) = %d, want %d", tc.amount, got, tc.want)
+		}
+	}
+}
+
+func TestCalculateNet(t *testing.T) {
+	tests := []struct {
+		amount  int64
+		fee     int64
+		refunds int64
+		want    int64
+	}{
+		{10000, 200, 0, 9800},
+		{10000, 200, 5000, 4800},
+		{10000, 200, 10000, -200}, // full refund — net is negative
+		{5000, 100, 2500, 2400},
+	}
+	for _, tc := range tests {
+		got := CalculateNet(tc.amount, tc.fee, tc.refunds)
+		if got != tc.want {
+			t.Errorf("CalculateNet(%d, %d, %d) = %d, want %d", tc.amount, tc.fee, tc.refunds, got, tc.want)
+		}
+	}
+}

--- a/internal/settlement/handler.go
+++ b/internal/settlement/handler.go
@@ -1,0 +1,121 @@
+package settlement
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	httpx "github.com/sanskarpan/PayGate/internal/common/http"
+	"github.com/sanskarpan/PayGate/internal/merchant"
+)
+
+// Handler exposes the settlement HTTP endpoints.
+type Handler struct {
+	svc *Service
+}
+
+// NewHandler creates a Handler.
+func NewHandler(svc *Service) *Handler {
+	return &Handler{svc: svc}
+}
+
+// RegisterRoutesWithAuth wires settlement endpoints into mux under auth.
+func (h *Handler) RegisterRoutesWithAuth(mux *http.ServeMux, wrap func(scope merchant.APIKeyScope, next http.Handler) http.Handler) {
+	mux.Handle("GET /v1/settlements", wrap(merchant.APIKeyScopeRead, http.HandlerFunc(h.list)))
+	mux.Handle("GET /v1/settlements/{settlementID}", wrap(merchant.APIKeyScopeRead, http.HandlerFunc(h.get)))
+}
+
+func (h *Handler) list(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	settlements, err := h.svc.List(r.Context(), p.MerchantID)
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+	items := make([]map[string]any, 0, len(settlements))
+	for _, s := range settlements {
+		items = append(items, present(s))
+	}
+	httpx.WriteJSON(w, http.StatusOK, map[string]any{
+		"entity": "collection",
+		"count":  len(items),
+		"items":  items,
+	})
+}
+
+func (h *Handler) get(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	sttl, lineItems, err := h.svc.GetItems(r.Context(), p.MerchantID, r.PathValue("settlementID"))
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+	resp := present(sttl)
+	itemsJSON := make([]map[string]any, 0, len(lineItems))
+	for _, item := range lineItems {
+		itemsJSON = append(itemsJSON, presentItem(item))
+	}
+	resp["items"] = itemsJSON
+	httpx.WriteJSON(w, http.StatusOK, resp)
+}
+
+func present(s Settlement) map[string]any {
+	var processedAt *int64
+	if s.ProcessedAt != nil {
+		ts := s.ProcessedAt.Unix()
+		processedAt = &ts
+	}
+	return map[string]any{
+		"id":            s.ID,
+		"entity":        "settlement",
+		"merchant_id":   s.MerchantID,
+		"status":        s.Status,
+		"period_start":  s.PeriodStart.Unix(),
+		"period_end":    s.PeriodEnd.Unix(),
+		"total_amount":  s.TotalAmount,
+		"total_fees":    s.TotalFees,
+		"total_refunds": s.TotalRefunds,
+		"net_amount":    s.NetAmount,
+		"payment_count": s.PaymentCount,
+		"currency":      s.Currency,
+		"processed_at":  processedAt,
+		"created_at":    s.CreatedAt.Unix(),
+		"created_at_rfc": s.CreatedAt.Format(time.RFC3339),
+	}
+}
+
+func presentItem(item SettlementItem) map[string]any {
+	return map[string]any{
+		"id":            item.ID,
+		"entity":        "settlement_item",
+		"settlement_id": item.SettlementID,
+		"payment_id":    item.PaymentID,
+		"amount":        item.Amount,
+		"fee":           item.Fee,
+		"refunds":       item.Refunds,
+		"net":           item.Net,
+		"currency":      item.Currency,
+		"created_at":    item.CreatedAt.Unix(),
+	}
+}
+
+func handleError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrSettlementNotFound):
+		httpx.WriteError(w, http.StatusNotFound, httpx.APIError{Code: "NOT_FOUND", Description: err.Error()})
+	case errors.Is(err, ErrNoEligiblePayments):
+		httpx.WriteError(w, http.StatusUnprocessableEntity, httpx.APIError{Code: "NO_ELIGIBLE_PAYMENTS", Description: err.Error()})
+	case errors.Is(err, ErrInvalidTransition):
+		httpx.WriteError(w, http.StatusUnprocessableEntity, httpx.APIError{Code: "INVALID_STATE", Description: err.Error()})
+	default:
+		httpx.WriteError(w, http.StatusInternalServerError, httpx.APIError{Code: "SERVER_ERROR", Description: "internal server error"})
+	}
+}

--- a/internal/settlement/postgres.go
+++ b/internal/settlement/postgres.go
@@ -1,0 +1,220 @@
+package settlement
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sanskarpan/PayGate/internal/common/idgen"
+	"github.com/sanskarpan/PayGate/internal/ledger"
+	"github.com/sanskarpan/PayGate/internal/outbox"
+)
+
+// PostgresRepository implements Repository using pgxpool.
+type PostgresRepository struct {
+	db     *pgxpool.Pool
+	ledger *ledger.Service
+	outbox *outbox.Writer
+}
+
+// NewPostgresRepository creates a new PostgresRepository.
+func NewPostgresRepository(db *pgxpool.Pool, ledgerSvc *ledger.Service) *PostgresRepository {
+	return &PostgresRepository{db: db, ledger: ledgerSvc, outbox: outbox.NewWriter()}
+}
+
+// RunBatch collects all captured, non-settled payments for the merchant in [periodStart, periodEnd),
+// creates a settlement + items, writes ledger entries, marks payments settled, and writes outbox events.
+func (r *PostgresRepository) RunBatch(ctx context.Context, merchantID string, periodStart, periodEnd time.Time) (Settlement, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return Settlement{}, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	// Collect eligible payments (captured, not yet settled, within period).
+	rows, err := tx.Query(ctx, `
+SELECT id, amount, fee, amount_refunded, currency
+FROM paygate_payments.payments
+WHERE merchant_id = $1
+  AND status = 'captured'
+  AND settled = false
+  AND captured_at >= $2
+  AND captured_at < $3
+FOR UPDATE SKIP LOCKED
+`, merchantID, periodStart, periodEnd)
+	if err != nil {
+		return Settlement{}, fmt.Errorf("query eligible payments: %w", err)
+	}
+	defer rows.Close()
+
+	var payments []EligiblePayment
+	for rows.Next() {
+		var p EligiblePayment
+		if err := rows.Scan(&p.PaymentID, &p.Amount, &p.Fee, &p.AmountRefunded, &p.Currency); err != nil {
+			return Settlement{}, fmt.Errorf("scan payment: %w", err)
+		}
+		payments = append(payments, p)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return Settlement{}, err
+	}
+	if len(payments) == 0 {
+		return Settlement{}, ErrNoEligiblePayments
+	}
+
+	// Aggregate totals.
+	var totalAmount, totalFees, totalRefunds int64
+	currency := payments[0].Currency
+	for _, p := range payments {
+		totalAmount += p.Amount
+		totalFees += p.Fee
+		totalRefunds += p.AmountRefunded
+	}
+	netAmount := CalculateNet(totalAmount, totalFees, totalRefunds)
+
+	// Create settlement record.
+	sttlID := idgen.New("sttl")
+	now := time.Now().UTC()
+	if _, err := tx.Exec(ctx, `
+INSERT INTO paygate_settlements.settlements
+    (id, merchant_id, status, period_start, period_end, total_amount, total_fees,
+     total_refunds, net_amount, payment_count, currency, processed_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+`, sttlID, merchantID, StateProcessed, periodStart, periodEnd,
+		totalAmount, totalFees, totalRefunds, netAmount, len(payments), currency, now,
+	); err != nil {
+		return Settlement{}, fmt.Errorf("insert settlement: %w", err)
+	}
+
+	// Create settlement items and collect payment IDs.
+	paymentIDs := make([]string, 0, len(payments))
+	for _, p := range payments {
+		net := CalculateNet(p.Amount, p.Fee, p.AmountRefunded)
+		if _, err := tx.Exec(ctx, `
+INSERT INTO paygate_settlements.settlement_items
+    (id, settlement_id, payment_id, merchant_id, amount, fee, refunds, net, currency)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+`, idgen.New("si"), sttlID, p.PaymentID, merchantID, p.Amount, p.Fee, p.AmountRefunded, net, p.Currency,
+		); err != nil {
+			return Settlement{}, fmt.Errorf("insert settlement item: %w", err)
+		}
+		paymentIDs = append(paymentIDs, p.PaymentID)
+	}
+
+	// Write double-entry ledger: Dr. MERCHANT_PAYABLE / Cr. SETTLEMENT_CLEARING
+	if _, err := r.ledger.CreateEntriesTx(ctx, tx, merchantID, "settlement", sttlID,
+		fmt.Sprintf("settlement batch %s", sttlID),
+		[]ledger.Entry{
+			{AccountCode: "MERCHANT_PAYABLE", DebitAmount: netAmount, Description: "merchant payout on settlement"},
+			{AccountCode: "SETTLEMENT_CLEARING", CreditAmount: netAmount, Description: "settlement clearing"},
+		},
+	); err != nil {
+		return Settlement{}, fmt.Errorf("write settlement ledger entries: %w", err)
+	}
+
+	// Mark payments as settled.
+	if _, err := tx.Exec(ctx, `
+UPDATE paygate_payments.payments
+SET settled = true, settlement_id = $1, updated_at = NOW()
+WHERE id = ANY($2)
+`, sttlID, paymentIDs); err != nil {
+		return Settlement{}, fmt.Errorf("mark payments settled: %w", err)
+	}
+
+	// Write outbox events.
+	if err := r.outbox.WriteTx(ctx, tx, outbox.Event{
+		AggregateType: "settlement",
+		AggregateID:   sttlID,
+		EventType:     "settlement.processed",
+		MerchantID:    merchantID,
+		Payload: map[string]any{
+			"settlement_id": sttlID,
+			"net_amount":    netAmount,
+			"payment_count": len(payments),
+			"currency":      currency,
+		},
+	}); err != nil {
+		return Settlement{}, fmt.Errorf("write settlement outbox event: %w", err)
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return Settlement{}, err
+	}
+
+	return r.GetSettlement(ctx, merchantID, sttlID)
+}
+
+func (r *PostgresRepository) GetSettlement(ctx context.Context, merchantID, id string) (Settlement, error) {
+	var s Settlement
+	err := r.db.QueryRow(ctx, `
+SELECT id, merchant_id, status, period_start, period_end, total_amount, total_fees,
+       total_refunds, net_amount, payment_count, currency, processed_at, created_at, updated_at
+FROM paygate_settlements.settlements
+WHERE id = $1 AND merchant_id = $2
+`, id, merchantID).Scan(
+		&s.ID, &s.MerchantID, &s.Status, &s.PeriodStart, &s.PeriodEnd,
+		&s.TotalAmount, &s.TotalFees, &s.TotalRefunds, &s.NetAmount,
+		&s.PaymentCount, &s.Currency, &s.ProcessedAt, &s.CreatedAt, &s.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Settlement{}, ErrSettlementNotFound
+	}
+	return s, err
+}
+
+func (r *PostgresRepository) ListSettlements(ctx context.Context, merchantID string) ([]Settlement, error) {
+	rows, err := r.db.Query(ctx, `
+SELECT id, merchant_id, status, period_start, period_end, total_amount, total_fees,
+       total_refunds, net_amount, payment_count, currency, processed_at, created_at, updated_at
+FROM paygate_settlements.settlements
+WHERE merchant_id = $1
+ORDER BY created_at DESC
+LIMIT 100
+`, merchantID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var settlements []Settlement
+	for rows.Next() {
+		var s Settlement
+		if err := rows.Scan(
+			&s.ID, &s.MerchantID, &s.Status, &s.PeriodStart, &s.PeriodEnd,
+			&s.TotalAmount, &s.TotalFees, &s.TotalRefunds, &s.NetAmount,
+			&s.PaymentCount, &s.Currency, &s.ProcessedAt, &s.CreatedAt, &s.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		settlements = append(settlements, s)
+	}
+	return settlements, rows.Err()
+}
+
+func (r *PostgresRepository) GetSettlementItems(ctx context.Context, settlementID string) ([]SettlementItem, error) {
+	rows, err := r.db.Query(ctx, `
+SELECT id, settlement_id, payment_id, merchant_id, amount, fee, refunds, net, currency, created_at
+FROM paygate_settlements.settlement_items
+WHERE settlement_id = $1
+ORDER BY created_at
+`, settlementID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var items []SettlementItem
+	for rows.Next() {
+		var item SettlementItem
+		if err := rows.Scan(&item.ID, &item.SettlementID, &item.PaymentID, &item.MerchantID,
+			&item.Amount, &item.Fee, &item.Refunds, &item.Net, &item.Currency, &item.CreatedAt); err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	return items, rows.Err()
+}

--- a/internal/settlement/repository.go
+++ b/internal/settlement/repository.go
@@ -1,0 +1,23 @@
+package settlement
+
+import (
+	"context"
+	"time"
+)
+
+// Repository defines storage operations for the settlement service.
+type Repository interface {
+	// RunBatch collects eligible payments for merchantID in [periodStart, periodEnd),
+	// creates a Settlement + SettlementItems, writes ledger entries and outbox events,
+	// and marks the payments as settled — all in a single Postgres transaction.
+	RunBatch(ctx context.Context, merchantID string, periodStart, periodEnd time.Time) (Settlement, error)
+
+	// GetSettlement returns a settlement by ID scoped to the merchant.
+	GetSettlement(ctx context.Context, merchantID, id string) (Settlement, error)
+
+	// ListSettlements returns all settlements for a merchant, most recent first.
+	ListSettlements(ctx context.Context, merchantID string) ([]Settlement, error)
+
+	// GetSettlementItems returns all items for a settlement.
+	GetSettlementItems(ctx context.Context, settlementID string) ([]SettlementItem, error)
+}

--- a/internal/settlement/service.go
+++ b/internal/settlement/service.go
@@ -1,0 +1,44 @@
+package settlement
+
+import (
+	"context"
+	"time"
+)
+
+// Service orchestrates the settlement use-cases.
+type Service struct {
+	repo Repository
+}
+
+// NewService creates a new Service.
+func NewService(repo Repository) *Service {
+	return &Service{repo: repo}
+}
+
+// RunBatch runs the settlement batch for merchantID covering [periodStart, periodEnd).
+func (s *Service) RunBatch(ctx context.Context, merchantID string, periodStart, periodEnd time.Time) (Settlement, error) {
+	return s.repo.RunBatch(ctx, merchantID, periodStart, periodEnd)
+}
+
+// Get returns a settlement by ID, scoped to the merchant.
+func (s *Service) Get(ctx context.Context, merchantID, id string) (Settlement, error) {
+	return s.repo.GetSettlement(ctx, merchantID, id)
+}
+
+// List returns all settlements for a merchant, most recent first.
+func (s *Service) List(ctx context.Context, merchantID string) ([]Settlement, error) {
+	return s.repo.ListSettlements(ctx, merchantID)
+}
+
+// GetItems returns the settlement items for a settlement.
+func (s *Service) GetItems(ctx context.Context, merchantID, settlementID string) (Settlement, []SettlementItem, error) {
+	sttl, err := s.repo.GetSettlement(ctx, merchantID, settlementID)
+	if err != nil {
+		return Settlement{}, nil, err
+	}
+	items, err := s.repo.GetSettlementItems(ctx, settlementID)
+	if err != nil {
+		return Settlement{}, nil, err
+	}
+	return sttl, items, nil
+}

--- a/migrations/000008_create_settlements.down.sql
+++ b/migrations/000008_create_settlements.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS paygate_settlements.settlement_items;
+DROP TABLE IF EXISTS paygate_settlements.settlements;
+DROP SCHEMA IF EXISTS paygate_settlements;

--- a/migrations/000008_create_settlements.up.sql
+++ b/migrations/000008_create_settlements.up.sql
@@ -1,0 +1,41 @@
+CREATE SCHEMA IF NOT EXISTS paygate_settlements;
+
+CREATE TABLE IF NOT EXISTS paygate_settlements.settlements (
+    id              TEXT PRIMARY KEY,
+    merchant_id     TEXT NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'created'
+                        CHECK (status IN ('created', 'processing', 'processed', 'failed')),
+    period_start    TIMESTAMPTZ NOT NULL,
+    period_end      TIMESTAMPTZ NOT NULL,
+    total_amount    BIGINT NOT NULL DEFAULT 0,
+    total_fees      BIGINT NOT NULL DEFAULT 0,
+    total_refunds   BIGINT NOT NULL DEFAULT 0,
+    net_amount      BIGINT NOT NULL DEFAULT 0,
+    payment_count   INTEGER NOT NULL DEFAULT 0,
+    currency        TEXT NOT NULL DEFAULT 'INR',
+    processed_at    TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_settlements_merchant
+    ON paygate_settlements.settlements (merchant_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS paygate_settlements.settlement_items (
+    id             TEXT PRIMARY KEY,
+    settlement_id  TEXT NOT NULL REFERENCES paygate_settlements.settlements (id),
+    payment_id     TEXT NOT NULL,
+    merchant_id    TEXT NOT NULL,
+    amount         BIGINT NOT NULL,
+    fee            BIGINT NOT NULL DEFAULT 0,
+    refunds        BIGINT NOT NULL DEFAULT 0,
+    net            BIGINT NOT NULL,
+    currency       TEXT NOT NULL DEFAULT 'INR',
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_settlement_items_settlement
+    ON paygate_settlements.settlement_items (settlement_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_settlement_items_payment
+    ON paygate_settlements.settlement_items (payment_id);

--- a/tests/integration/backend_hardening_integration_test.go
+++ b/tests/integration/backend_hardening_integration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/sanskarpan/PayGate/internal/outbox"
 	"github.com/sanskarpan/PayGate/internal/payment"
 	"github.com/sanskarpan/PayGate/internal/refund"
+	"github.com/sanskarpan/PayGate/internal/settlement"
 	"github.com/sanskarpan/PayGate/internal/webhook"
 )
 
@@ -287,12 +288,14 @@ func buildGatewayMux(db *pgxpool.Pool) (*http.ServeMux, *merchant.Service, *orde
 	paymentSvc := payment.NewService(payment.NewPostgresRepository(db, ledgerSvc, orderSvc), gateway.NewSimulator())
 	refundSvc := refund.NewService(refund.NewPostgresRepository(db, ledgerSvc))
 	webhookSvc := webhook.NewService(webhook.NewPostgresRepository(db))
+	settlementSvc := settlement.NewService(settlement.NewPostgresRepository(db, ledgerSvc))
 
 	merchantHandler := merchant.NewHandler(merchantSvc)
 	orderHandler := order.NewHandler(orderSvc)
 	paymentHandler := payment.NewHandler(paymentSvc)
 	refundHandler := refund.NewHandler(refundSvc)
 	webhookHandler := webhook.NewHandler(webhookSvc)
+	settlementHandler := settlement.NewHandler(settlementSvc)
 
 	protected := func(scope merchant.APIKeyScope, next http.Handler) http.Handler {
 		return authMw.RequireScope(scope, idemMw.Wrap(next))
@@ -304,6 +307,7 @@ func buildGatewayMux(db *pgxpool.Pool) (*http.ServeMux, *merchant.Service, *orde
 	orderHandler.RegisterRoutesWithAuth(mux, protected)
 	paymentHandler.RegisterRoutesWithAuth(mux, protected)
 	refundHandler.RegisterRoutesWithAuth(mux, protected)
+	settlementHandler.RegisterRoutesWithAuth(mux, protected)
 	webhookHandler.RegisterRoutesWithAuth(mux, protected)
 	mux.Handle("GET /v1/merchants/me", authMw.RequireScope(merchant.APIKeyScopeRead, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		p, _ := httpx.PrincipalFromContext(r.Context())

--- a/tests/integration/settlement_integration_test.go
+++ b/tests/integration/settlement_integration_test.go
@@ -1,0 +1,150 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sanskarpan/PayGate/internal/ledger"
+	"github.com/sanskarpan/PayGate/internal/merchant"
+	"github.com/sanskarpan/PayGate/internal/order"
+	"github.com/sanskarpan/PayGate/internal/payment"
+	"github.com/sanskarpan/PayGate/internal/settlement"
+)
+
+func TestIntegrationSettlementBatch(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	mux, merchantSvc, orderSvc, paymentSvc := buildGatewayMux(db)
+	ctx := context.Background()
+
+	createdMerchant, err := merchantSvc.CreateMerchant(ctx, merchant.CreateMerchantInput{
+		Name: "Settlement Merchant", Email: "settlement@test.com", BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+	key, err := merchantSvc.CreateAPIKey(ctx, createdMerchant.ID, merchant.CreateAPIKeyInput{
+		Mode: merchant.APIKeyModeTest, Scope: merchant.APIKeyScopeRead,
+	})
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+	authHeader := basicAuth(key.KeyID, key.KeySecret)
+
+	// Create and capture two payments.
+	capturePayment := func(amount int64, receipt string) {
+		t.Helper()
+		o, err := orderSvc.Create(ctx, order.CreateInput{
+			MerchantID: createdMerchant.ID, Amount: amount, Currency: "INR", Receipt: receipt,
+		})
+		if err != nil {
+			t.Fatalf("create order: %v", err)
+		}
+		auth, err := paymentSvc.Authorize(ctx, payment.AuthorizeInput{
+			MerchantID: createdMerchant.ID, OrderID: o.ID,
+			Amount: o.Amount, Currency: o.Currency, Method: "card",
+		})
+		if err != nil {
+			t.Fatalf("authorize: %v", err)
+		}
+		if _, err := paymentSvc.CaptureForMerchant(ctx, createdMerchant.ID, auth.PaymentID, o.Amount); err != nil {
+			t.Fatalf("capture: %v", err)
+		}
+	}
+	capturePayment(10000, "settle-1")
+	capturePayment(5000, "settle-2")
+
+	// Run settlement batch covering from epoch to now+1h.
+	settlementSvc := settlement.NewService(settlement.NewPostgresRepository(db, ledger.NewService(ledger.NewRepository(db))))
+	periodEnd := time.Now().Add(time.Hour)
+	sttl, err := settlementSvc.RunBatch(ctx, createdMerchant.ID, time.Unix(0, 0), periodEnd)
+	if err != nil {
+		t.Fatalf("run batch: %v", err)
+	}
+
+	if sttl.PaymentCount != 2 {
+		t.Fatalf("expected 2 payments, got %d", sttl.PaymentCount)
+	}
+	// Total: 10000 + 5000 = 15000; fees: 200 + 100 = 300; net: 14700
+	if sttl.TotalAmount != 15000 {
+		t.Fatalf("expected total_amount=15000, got %d", sttl.TotalAmount)
+	}
+	if sttl.TotalFees != 300 {
+		t.Fatalf("expected total_fees=300, got %d", sttl.TotalFees)
+	}
+	if sttl.NetAmount != 14700 {
+		t.Fatalf("expected net_amount=14700, got %d", sttl.NetAmount)
+	}
+	if sttl.Status != settlement.StateProcessed {
+		t.Fatalf("expected status=processed, got %s", sttl.Status)
+	}
+
+	// Verify payments are marked settled.
+	var unsettledCount int
+	if err := db.QueryRow(ctx,
+		`SELECT COUNT(*) FROM paygate_payments.payments WHERE merchant_id = $1 AND settled = false AND status = 'captured'`,
+		createdMerchant.ID,
+	).Scan(&unsettledCount); err != nil {
+		t.Fatalf("query unsettled: %v", err)
+	}
+	if unsettledCount != 0 {
+		t.Fatalf("expected 0 unsettled payments after batch, got %d", unsettledCount)
+	}
+
+	// Verify ledger entries were written (Dr. MERCHANT_PAYABLE / Cr. SETTLEMENT_CLEARING).
+	var count int
+	if err := db.QueryRow(ctx,
+		`SELECT COUNT(*) FROM paygate_ledger.ledger_entries WHERE source_id = $1`,
+		sttl.ID,
+	).Scan(&count); err != nil {
+		t.Fatalf("query ledger entries: %v", err)
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 ledger entries for settlement, got %d", count)
+	}
+
+	// Verify outbox event was written.
+	var evCount int
+	if err := db.QueryRow(ctx,
+		`SELECT COUNT(*) FROM public.outbox WHERE aggregate_id = $1 AND event_type = 'settlement.processed'`,
+		sttl.ID,
+	).Scan(&evCount); err != nil {
+		t.Fatalf("query outbox event: %v", err)
+	}
+	if evCount != 1 {
+		t.Fatalf("expected 1 settlement.processed outbox event, got %d", evCount)
+	}
+
+	t.Run("list settlements via API", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/settlements", nil)
+		req.Header.Set("Authorization", authHeader)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("get settlement detail via API", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/v1/settlements/"+sttl.ID, nil)
+		req.Header.Set("Authorization", authHeader)
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		if rec.Code != http.StatusOK {
+			t.Fatalf("expected 200, got %d body=%s", rec.Code, rec.Body.String())
+		}
+	})
+
+	t.Run("second batch with no eligible payments returns error", func(t *testing.T) {
+		_, err := settlementSvc.RunBatch(ctx, createdMerchant.ID, time.Unix(0, 0), periodEnd)
+		if err == nil {
+			t.Fatal("expected error for empty batch")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Settlement domain with explicit state machine (`created → processing → processed/failed`)
- `RunBatch` collects all captured, non-settled payments for a merchant in a time window; calculates 2% platform fee per payment; creates settlement + items; writes Dr. MERCHANT_PAYABLE / Cr. SETTLEMENT_CLEARING ledger entries; marks payments settled; writes `settlement.processed` outbox event — all in one Postgres transaction with `FOR UPDATE SKIP LOCKED`
- REST endpoints: `GET /v1/settlements`, `GET /v1/settlements/{id}` (includes settlement items)
- Integration tests: 2-payment batch, ledger entry verification, outbox event, idempotent empty-batch error

Closes #272

## Test plan
- [ ] `go test -v -tags integration ./tests/integration/... -run TestIntegrationSettlementBatch`
- [ ] `go test ./internal/settlement/...`
- [ ] Settlement batch creates correct totals: amount=15000, fees=300, net=14700
- [ ] Payments marked `settled=true` after batch
- [ ] 2 ledger entries created (Dr MERCHANT_PAYABLE, Cr SETTLEMENT_CLEARING)
- [ ] 1 `settlement.processed` outbox event written
- [ ] Second batch on same payments returns `ErrNoEligiblePayments`

🤖 Generated with [Claude Code](https://claude.com/claude-code)