### PR TITLE
Expose outbox unpublished count in /readyz health check

### DIFF
--- a/cmd/api-gateway/main.go
+++ b/cmd/api-gateway/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/http"
 	"os"
@@ -128,6 +129,12 @@ func run() error {
 			}
 		} else {
 			checks["redis"] = "not_configured"
+		}
+
+		// Outbox lag metric: count of unpublished entries.
+		var unpublished int64
+		if err := db.QueryRow(r.Context(), `SELECT COUNT(*) FROM public.outbox WHERE published_at IS NULL`).Scan(&unpublished); err == nil {
+			checks["outbox_unpublished"] = fmt.Sprintf("%d", unpublished)
 		}
 
 		if !ready {


### PR DESCRIPTION
## Summary
- `CleanupPublished` (delete entries >7 days old) was already running in `outbox.Relay.Start()` after every publish batch — no code change needed
- Added `outbox_unpublished` counter to the `/readyz` response so ops/alerting can monitor relay lag

The `/readyz` response now includes:
\`\`\`json
{
  "status": "ok",
  "checks": {
    "postgres": "ok",
    "redis": "ok",
    "outbox_unpublished": "3"
  }
}
\`\`\`

Closes #274

## Test plan
- [ ] `curl /readyz` — response includes `outbox_unpublished` field
- [ ] Field is numeric string count of entries with `published_at IS NULL`

🤖 Generated with [Claude Code](https://claude.com/claude-code)