### PR TITLE
[Phase 3] Audit logging — append-only audit log for all state mutations

### DIFF
--- a/cmd/api-gateway/main.go
+++ b/cmd/api-gateway/main.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
+	"github.com/sanskarpan/PayGate/internal/audit"
 	"github.com/sanskarpan/PayGate/internal/auth"
 	"github.com/sanskarpan/PayGate/internal/common/config"
 	httpx "github.com/sanskarpan/PayGate/internal/common/http"
@@ -102,6 +103,10 @@ func run() error {
 	webhookSvc := webhook.NewService(webhookRepo)
 	webhookHandler := webhook.NewHandler(webhookSvc)
 
+	auditRepo := audit.NewPostgresRepository(db)
+	auditSvc := audit.NewService(auditRepo, l)
+	auditHandler := audit.NewHandler(auditSvc)
+
 	go order.NewExpirySweeper(orderSvc, time.Minute, l).Start(ctx)
 	go webhook.NewRetryWorker(webhookSvc, 30*time.Second, l).Start(ctx)
 	go payment.NewSweeper(paymentSvc, 30*time.Second, l).Start(ctx)
@@ -153,7 +158,7 @@ func run() error {
 
 	merchantHandler.RegisterRoutes(mux)
 	protected := func(scope merchant.APIKeyScope, next http.Handler) http.Handler {
-		return authMw.RequireScope(scope, idemMw.Wrap(next))
+		return authMw.RequireScope(scope, idemMw.Wrap(auditSvc.Middleware(next)))
 	}
 	orderHandler.RegisterRoutesWithAuth(mux, protected)
 	paymentHandler.RegisterRoutesWithAuth(mux, protected)
@@ -162,6 +167,9 @@ func run() error {
 	webhookHandler.RegisterRoutesWithAuth(mux, protected)
 	merchantHandler.RegisterProtectedRoutes(mux, protected)
 	checkoutHandler.RegisterRoutes(mux)
+	auditHandler.RegisterRoutesWithAuth(mux, func(next http.Handler) http.Handler {
+		return authMw.RequireScope(merchant.APIKeyScopeRead, next)
+	})
 
 	mux.Handle("GET /v1/merchants/me", authMw.RequireScope(merchant.APIKeyScopeRead, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		p, ok := httpx.PrincipalFromContext(r.Context())

--- a/internal/audit/domain.go
+++ b/internal/audit/domain.go
@@ -1,0 +1,53 @@
+package audit
+
+import "time"
+
+// ActorType classifies the identity that performed the action.
+type ActorType string
+
+const (
+	ActorTypeDashboardUser ActorType = "dashboard_user"
+	ActorTypeAPIKey        ActorType = "api_key"
+	ActorTypeSystem        ActorType = "system"
+)
+
+// Log is an append-only record of a state-changing action.
+type Log struct {
+	ID            string
+	MerchantID    string
+	ActorID       string
+	ActorEmail    string
+	ActorType     ActorType
+	Action        string
+	ResourceType  string
+	ResourceID    string
+	Changes       map[string]any
+	IPAddress     string
+	CorrelationID string
+	CreatedAt     time.Time
+}
+
+// RecordInput carries the fields needed to create a new audit log entry.
+// Empty optional fields are silently ignored.
+type RecordInput struct {
+	MerchantID    string
+	ActorID       string
+	ActorEmail    string
+	ActorType     ActorType
+	Action        string
+	ResourceType  string
+	ResourceID    string
+	Changes       map[string]any
+	IPAddress     string
+	CorrelationID string
+}
+
+// ListInput controls which audit logs to return.
+type ListInput struct {
+	MerchantID   string
+	ActorID      string
+	ResourceType string
+	ResourceID   string
+	Limit        int
+	Cursor       string // created_at:id pair for keyset pagination
+}

--- a/internal/audit/handler.go
+++ b/internal/audit/handler.go
@@ -1,0 +1,73 @@
+package audit
+
+import (
+	"net/http"
+	"strconv"
+
+	httpx "github.com/sanskarpan/PayGate/internal/common/http"
+)
+
+type Handler struct {
+	svc *Service
+}
+
+func NewHandler(svc *Service) *Handler {
+	return &Handler{svc: svc}
+}
+
+// RegisterRoutesWithAuth wires the audit log API under authentication.
+func (h *Handler) RegisterRoutesWithAuth(mux *http.ServeMux, wrap func(next http.Handler) http.Handler) {
+	mux.Handle("GET /v1/audit-logs", wrap(http.HandlerFunc(h.listAuditLogs)))
+}
+
+func (h *Handler) listAuditLogs(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+
+	q := r.URL.Query()
+	limit, _ := strconv.Atoi(q.Get("count"))
+
+	logs, err := h.svc.List(r.Context(), ListInput{
+		MerchantID:   p.MerchantID,
+		ActorID:      q.Get("actor_id"),
+		ResourceType: q.Get("resource_type"),
+		ResourceID:   q.Get("resource_id"),
+		Limit:        limit,
+	})
+	if err != nil {
+		httpx.WriteError(w, http.StatusInternalServerError, httpx.APIError{
+			Code:        "SERVER_ERROR",
+			Description: "failed to list audit logs",
+			Source:      "internal",
+			Step:        "audit_log_list",
+			Reason:      "unhandled_exception",
+		})
+		return
+	}
+
+	items := make([]map[string]any, 0, len(logs))
+	for _, l := range logs {
+		items = append(items, map[string]any{
+			"id":             l.ID,
+			"actor_id":       l.ActorID,
+			"actor_email":    l.ActorEmail,
+			"actor_type":     l.ActorType,
+			"action":         l.Action,
+			"resource_type":  l.ResourceType,
+			"resource_id":    l.ResourceID,
+			"changes":        l.Changes,
+			"ip_address":     l.IPAddress,
+			"correlation_id": l.CorrelationID,
+			"created_at":     l.CreatedAt.Unix(),
+		})
+	}
+
+	httpx.WriteJSON(w, http.StatusOK, map[string]any{
+		"entity": "collection",
+		"count":  len(items),
+		"items":  items,
+	})
+}

--- a/internal/audit/middleware.go
+++ b/internal/audit/middleware.go
@@ -1,0 +1,113 @@
+package audit
+
+import (
+	"net/http"
+	"strings"
+
+	httpx "github.com/sanskarpan/PayGate/internal/common/http"
+)
+
+// Middleware returns an http.Handler wrapper that records an audit log entry
+// for every mutating request (POST, PUT, PATCH, DELETE) that completes with a
+// 2xx status code.  Read-only requests (GET, HEAD, OPTIONS) are skipped.
+func (s *Service) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Skip non-mutating methods.
+		switch r.Method {
+		case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		default:
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		rw := &statusRecorder{ResponseWriter: w}
+		next.ServeHTTP(rw, r)
+
+		// Only audit successful mutations.
+		if rw.status < 200 || rw.status >= 300 {
+			return
+		}
+
+		p, ok := httpx.PrincipalFromContext(r.Context())
+		if !ok {
+			return
+		}
+
+		actorType := ActorTypeAPIKey
+		if p.AuthType == "dashboard_user" {
+			actorType = ActorTypeDashboardUser
+		}
+
+		resourceType, resourceID := extractResource(r.URL.Path)
+		action := r.Method + " " + resourceType
+
+		// Collect remote IP; prefer X-Forwarded-For when behind a proxy.
+		ip := r.RemoteAddr
+		if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
+			ip = strings.TrimSpace(strings.SplitN(fwd, ",", 2)[0])
+		}
+
+		corrID := r.Header.Get("X-Request-Id")
+
+		s.Record(r.Context(), RecordInput{
+			MerchantID:    p.MerchantID,
+			ActorID:       firstNonEmpty(p.UserID, p.KeyID),
+			ActorEmail:    p.Email,
+			ActorType:     actorType,
+			Action:        action,
+			ResourceType:  resourceType,
+			ResourceID:    resourceID,
+			IPAddress:     ip,
+			CorrelationID: corrID,
+		})
+	})
+}
+
+// extractResource heuristically extracts resource type and ID from a URL path.
+// "/v1/payments/pay_abc123/refunds" → ("payments.refunds", "pay_abc123")
+func extractResource(path string) (resourceType, resourceID string) {
+	parts := strings.Split(strings.Trim(path, "/"), "/")
+	// Strip /v1 prefix
+	if len(parts) > 0 && parts[0] == "v1" {
+		parts = parts[1:]
+	}
+	if len(parts) == 0 {
+		return "unknown", ""
+	}
+	switch len(parts) {
+	case 1:
+		return parts[0], ""
+	case 2:
+		return parts[0], parts[1]
+	default:
+		// e.g. payments/{id}/refunds → resource = payments.refunds, id = parts[1]
+		return parts[0] + "." + parts[len(parts)-1], parts[1]
+	}
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// statusRecorder captures the HTTP status code written by the next handler.
+type statusRecorder struct {
+	http.ResponseWriter
+	status int
+}
+
+func (r *statusRecorder) WriteHeader(code int) {
+	r.status = code
+	r.ResponseWriter.WriteHeader(code)
+}
+
+func (r *statusRecorder) Write(b []byte) (int, error) {
+	if r.status == 0 {
+		r.status = http.StatusOK
+	}
+	return r.ResponseWriter.Write(b)
+}

--- a/internal/audit/postgres.go
+++ b/internal/audit/postgres.go
@@ -1,0 +1,89 @@
+package audit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sanskarpan/PayGate/internal/common/idgen"
+)
+
+type PostgresRepository struct {
+	db *pgxpool.Pool
+}
+
+func NewPostgresRepository(db *pgxpool.Pool) *PostgresRepository {
+	return &PostgresRepository{db: db}
+}
+
+func (r *PostgresRepository) Create(ctx context.Context, log Log) (Log, error) {
+	log.ID = idgen.New("alog")
+	if log.Changes == nil {
+		log.Changes = map[string]any{}
+	}
+	changesJSON, err := json.Marshal(log.Changes)
+	if err != nil {
+		return Log{}, fmt.Errorf("marshal audit changes: %w", err)
+	}
+
+	q := `
+INSERT INTO paygate_audit.audit_logs
+    (id, merchant_id, actor_id, actor_email, actor_type, action,
+     resource_type, resource_id, changes, ip_address, correlation_id)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+RETURNING created_at`
+
+	if err := r.db.QueryRow(ctx, q,
+		log.ID, log.MerchantID, log.ActorID, log.ActorEmail, log.ActorType,
+		log.Action, log.ResourceType, log.ResourceID,
+		changesJSON, log.IPAddress, log.CorrelationID,
+	).Scan(&log.CreatedAt); err != nil {
+		return Log{}, fmt.Errorf("insert audit log: %w", err)
+	}
+	return log, nil
+}
+
+func (r *PostgresRepository) List(ctx context.Context, in ListInput) ([]Log, error) {
+	limit := in.Limit
+	if limit <= 0 || limit > 100 {
+		limit = 25
+	}
+
+	q := `
+SELECT id, merchant_id, actor_id, actor_email, actor_type, action,
+       resource_type, resource_id, changes, ip_address, correlation_id, created_at
+FROM paygate_audit.audit_logs
+WHERE merchant_id = $1
+  AND ($2 = '' OR actor_id = $2)
+  AND ($3 = '' OR resource_type = $3)
+  AND ($4 = '' OR resource_id = $4)
+ORDER BY created_at DESC, id DESC
+LIMIT $5`
+
+	rows, err := r.db.Query(ctx, q, in.MerchantID, in.ActorID, in.ResourceType, in.ResourceID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list audit logs: %w", err)
+	}
+	defer rows.Close()
+
+	var logs []Log
+	for rows.Next() {
+		var l Log
+		var changesJSON []byte
+		if err := rows.Scan(
+			&l.ID, &l.MerchantID, &l.ActorID, &l.ActorEmail, &l.ActorType,
+			&l.Action, &l.ResourceType, &l.ResourceID,
+			&changesJSON, &l.IPAddress, &l.CorrelationID, &l.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan audit log: %w", err)
+		}
+		if len(changesJSON) > 0 {
+			if err := json.Unmarshal(changesJSON, &l.Changes); err != nil {
+				return nil, fmt.Errorf("unmarshal audit changes: %w", err)
+			}
+		}
+		logs = append(logs, l)
+	}
+	return logs, rows.Err()
+}

--- a/internal/audit/repository.go
+++ b/internal/audit/repository.go
@@ -1,0 +1,12 @@
+package audit
+
+import "context"
+
+// Repository defines the storage contract for audit logs.
+// Implementations must be append-only; no UPDATE or DELETE.
+type Repository interface {
+	// Create persists a new audit log entry and returns it with CreatedAt set.
+	Create(ctx context.Context, log Log) (Log, error)
+	// List returns audit logs for a merchant matching the given filter.
+	List(ctx context.Context, in ListInput) ([]Log, error)
+}

--- a/internal/audit/service.go
+++ b/internal/audit/service.go
@@ -1,0 +1,53 @@
+package audit
+
+import (
+	"context"
+	"log/slog"
+)
+
+// Service records audit events and exposes the query API.
+// Record() is fire-and-forget: errors are logged but never returned to the
+// caller so that audit failures never block the primary operation.
+type Service struct {
+	repo   Repository
+	logger *slog.Logger
+}
+
+func NewService(repo Repository, logger *slog.Logger) *Service {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Service{repo: repo, logger: logger}
+}
+
+// Record creates an audit log entry asynchronously.
+// It must be called after the primary state change succeeds.
+func (s *Service) Record(ctx context.Context, in RecordInput) {
+	go func() {
+		l := Log{
+			MerchantID:    in.MerchantID,
+			ActorID:       in.ActorID,
+			ActorEmail:    in.ActorEmail,
+			ActorType:     in.ActorType,
+			Action:        in.Action,
+			ResourceType:  in.ResourceType,
+			ResourceID:    in.ResourceID,
+			Changes:       in.Changes,
+			IPAddress:     in.IPAddress,
+			CorrelationID: in.CorrelationID,
+		}
+		if _, err := s.repo.Create(ctx, l); err != nil {
+			s.logger.Error("audit record failed",
+				"action", in.Action,
+				"resource_type", in.ResourceType,
+				"resource_id", in.ResourceID,
+				"error", err,
+			)
+		}
+	}()
+}
+
+// List returns audit logs for the given merchant matching the filter.
+func (s *Service) List(ctx context.Context, in ListInput) ([]Log, error) {
+	return s.repo.List(ctx, in)
+}

--- a/migrations/000011_create_audit_logs.down.sql
+++ b/migrations/000011_create_audit_logs.down.sql
@@ -1,0 +1,1 @@
+DROP SCHEMA IF EXISTS paygate_audit CASCADE;

--- a/migrations/000011_create_audit_logs.up.sql
+++ b/migrations/000011_create_audit_logs.up.sql
@@ -1,0 +1,23 @@
+CREATE SCHEMA IF NOT EXISTS paygate_audit;
+
+CREATE TABLE IF NOT EXISTS paygate_audit.audit_logs (
+    id             TEXT PRIMARY KEY,
+    merchant_id    TEXT        NOT NULL,
+    actor_id       TEXT        NOT NULL,
+    actor_email    TEXT        NOT NULL DEFAULT '',
+    actor_type     TEXT        NOT NULL CHECK (actor_type IN ('dashboard_user','api_key','system')),
+    action         TEXT        NOT NULL,
+    resource_type  TEXT        NOT NULL,
+    resource_id    TEXT        NOT NULL,
+    changes        JSONB       NOT NULL DEFAULT '{}',
+    ip_address     TEXT        NOT NULL DEFAULT '',
+    correlation_id TEXT        NOT NULL DEFAULT '',
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_audit_logs_merchant_id
+    ON paygate_audit.audit_logs(merchant_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_resource
+    ON paygate_audit.audit_logs(merchant_id, resource_type, resource_id);
+CREATE INDEX IF NOT EXISTS idx_audit_logs_actor
+    ON paygate_audit.audit_logs(merchant_id, actor_id);

--- a/tests/integration/audit_integration_test.go
+++ b/tests/integration/audit_integration_test.go
@@ -1,0 +1,157 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sanskarpan/PayGate/internal/audit"
+	"github.com/sanskarpan/PayGate/internal/auth"
+	httpx "github.com/sanskarpan/PayGate/internal/common/http"
+	"github.com/sanskarpan/PayGate/internal/idempotency"
+	"github.com/sanskarpan/PayGate/internal/merchant"
+	"github.com/sanskarpan/PayGate/internal/order"
+)
+
+func buildAuditMux(db *pgxpool.Pool) (*http.ServeMux, *merchant.Service, *audit.Service) {
+	merchantRepo := merchant.NewPostgresRepository(db)
+	merchantSvc := merchant.NewService(merchantRepo, merchant.WithSessionSecret("audit-test-secret"))
+	authMw := auth.NewMiddleware(merchantSvc)
+	idemMw := idempotency.NewMiddleware(idempotency.NewStore(db, nil))
+
+	auditRepo := audit.NewPostgresRepository(db)
+	auditSvc := audit.NewService(auditRepo, nil)
+	auditHandler := audit.NewHandler(auditSvc)
+
+	orderSvc := order.NewService(order.NewPostgresRepository(db))
+	orderHandler := order.NewHandler(orderSvc)
+	merchantHandler := merchant.NewHandler(merchantSvc)
+
+	protected := func(scope merchant.APIKeyScope, next http.Handler) http.Handler {
+		return authMw.RequireScope(scope, idemMw.Wrap(auditSvc.Middleware(next)))
+	}
+
+	mux := http.NewServeMux()
+	merchantHandler.RegisterRoutes(mux)
+	merchantHandler.RegisterProtectedRoutes(mux, protected)
+	orderHandler.RegisterRoutesWithAuth(mux, protected)
+	auditHandler.RegisterRoutesWithAuth(mux, func(next http.Handler) http.Handler {
+		return authMw.RequireScope(merchant.APIKeyScopeRead, next)
+	})
+	mux.Handle("GET /v1/merchants/me", authMw.RequireScope(merchant.APIKeyScopeRead, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p, _ := httpx.PrincipalFromContext(r.Context())
+		httpx.WriteJSON(w, http.StatusOK, map[string]any{"merchant_id": p.MerchantID})
+	})))
+	return mux, merchantSvc, auditSvc
+}
+
+func TestIntegrationAuditLogRecordsOrderCreate(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	mux, merchantSvc, _ := buildAuditMux(db)
+	ctx := context.Background()
+
+	m, err := merchantSvc.CreateMerchant(ctx, merchant.CreateMerchantInput{
+		Name: "Audit Merchant", Email: "audit@test.com", BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+	key, err := merchantSvc.CreateAPIKey(ctx, m.ID, merchant.CreateAPIKeyInput{
+		Mode: merchant.APIKeyModeTest, Scope: merchant.APIKeyScopeWrite,
+	})
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+	authHdr := basicAuth(key.KeyID, key.KeySecret)
+
+	// Create an order — should produce an audit log entry.
+	body, _ := json.Marshal(map[string]any{"amount": 5000, "currency": "INR", "receipt": "audit-order-1"})
+	req := httptest.NewRequest(http.MethodPost, "/v1/orders", bytes.NewReader(body))
+	req.Header.Set("Authorization", authHdr)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Request-Id", "corr-audit-001")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("create order: expected 201, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	// Give the goroutine time to write.
+	time.Sleep(100 * time.Millisecond)
+
+	// Query audit logs via the API.
+	logReq := httptest.NewRequest(http.MethodGet, "/v1/audit-logs?resource_type=orders", nil)
+	logReq.Header.Set("Authorization", authHdr)
+	logRec := httptest.NewRecorder()
+	mux.ServeHTTP(logRec, logReq)
+	if logRec.Code != http.StatusOK {
+		t.Fatalf("list audit logs: expected 200, got %d body=%s", logRec.Code, logRec.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal(logRec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode audit list: %v", err)
+	}
+	if int(resp["count"].(float64)) < 1 {
+		t.Fatal("expected at least one audit log for orders")
+	}
+	items := resp["items"].([]any)
+	entry := items[0].(map[string]any)
+	if entry["resource_type"] != "orders" {
+		t.Fatalf("expected resource_type=orders, got %v", entry["resource_type"])
+	}
+	if entry["correlation_id"] != "corr-audit-001" {
+		t.Fatalf("expected correlation_id=corr-audit-001, got %v", entry["correlation_id"])
+	}
+}
+
+func TestIntegrationAuditLogFiltersOutGetRequests(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	mux, merchantSvc, auditSvc := buildAuditMux(db)
+	ctx := context.Background()
+
+	m, err := merchantSvc.CreateMerchant(ctx, merchant.CreateMerchantInput{
+		Name: "Audit Read Merchant", Email: "auditread@test.com", BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+	key, err := merchantSvc.CreateAPIKey(ctx, m.ID, merchant.CreateAPIKeyInput{
+		Mode: merchant.APIKeyModeTest, Scope: merchant.APIKeyScopeRead,
+	})
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+	authHdr := basicAuth(key.KeyID, key.KeySecret)
+
+	// Count audit logs before the GET request.
+	beforeLogs, _ := auditSvc.List(ctx, audit.ListInput{MerchantID: m.ID})
+	before := len(beforeLogs)
+
+	// GET /v1/merchants/me — should NOT create an audit entry.
+	req := httptest.NewRequest(http.MethodGet, "/v1/merchants/me", nil)
+	req.Header.Set("Authorization", authHdr)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET merchants/me: expected 200, got %d", rec.Code)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	afterLogs, _ := auditSvc.List(ctx, audit.ListInput{MerchantID: m.ID})
+	if len(afterLogs) != before {
+		t.Fatalf("GET request should not create audit log: before=%d after=%d", before, len(afterLogs))
+	}
+}


### PR DESCRIPTION
## Summary
- `internal/audit/` package: domain types, append-only repository, service with async `Record()`, HTTP handler, and HTTP middleware
- Middleware wraps every protected handler — records POST/PUT/PATCH/DELETE requests that return 2xx with actor, resource type/ID, IP, and correlation ID
- `GET /v1/audit-logs` endpoint with `actor_id`, `resource_type`, `resource_id`, `count` filters
- Migration `000011_create_audit_logs` adds `paygate_audit.audit_logs` table with indexes on merchant, resource, and actor
- API gateway wired to apply `auditSvc.Middleware` inside every authenticated handler wrapper

## Test plan
- [x] `TestIntegrationAuditLogRecordsOrderCreate` — POST /v1/orders creates an audit log; log contains correct resource_type and correlation_id
- [x] `TestIntegrationAuditLogFiltersOutGetRequests` — GET requests do not create audit logs
- [x] All unit tests pass (`go test ./...`)
- [x] `golangci-lint run ./...` — 0 issues

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)