### PR TITLE
feat: dashboard Phase 3 — risk, audit log, team management (#287)

### DIFF
--- a/dashboard/app/audit/page.tsx
+++ b/dashboard/app/audit/page.tsx
@@ -1,0 +1,42 @@
+import { getAuditLogs, requireViewer } from "../../lib/api";
+import { formatTime } from "../../lib/types";
+
+export default async function AuditLogPage() {
+  const viewer = await requireViewer();
+  const logs = await getAuditLogs();
+
+  return (
+    <section className="stack">
+      <div className="hero-card">
+        <div className="eyebrow">Compliance</div>
+        <h1>Audit Log</h1>
+        <p className="lede">
+          {logs.count} event{logs.count !== 1 ? "s" : ""} recorded for {viewer.merchant_id}.
+        </p>
+      </div>
+      <div className="list-card">
+        {logs.items.length === 0 ? (
+          <p className="muted">No audit events recorded yet.</p>
+        ) : (
+          logs.items.map((log) => (
+            <div className="list-row" key={log.id}>
+              <div>
+                <div className="row-title">
+                  {log.action} — {log.resource_type}
+                  {log.resource_id ? ` / ${log.resource_id}` : ""}
+                </div>
+                <div className="row-meta">
+                  <span>{log.actor_email || log.actor_id}</span>
+                  <span className="badge-info">{log.actor_type}</span>
+                  {log.ip_address && <span>{log.ip_address}</span>}
+                  <span>{formatTime(log.created_at)}</span>
+                </div>
+              </div>
+              <div className="amount-pill">{log.id}</div>
+            </div>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}

--- a/dashboard/app/risk/page.tsx
+++ b/dashboard/app/risk/page.tsx
@@ -1,0 +1,50 @@
+import { getRiskEvents, requireViewer } from "../../lib/api";
+import { formatTime } from "../../lib/types";
+
+function actionBadge(action: string) {
+  if (action === "block") return "badge-error";
+  if (action === "hold") return "badge-warning";
+  return "badge-success";
+}
+
+export default async function RiskEventsPage() {
+  const viewer = await requireViewer();
+  const events = await getRiskEvents();
+
+  return (
+    <section className="stack">
+      <div className="hero-card">
+        <div className="eyebrow">Risk Engine</div>
+        <h1>Risk Events</h1>
+        <p className="lede">
+          {events.count} event{events.count !== 1 ? "s" : ""} recorded for {viewer.merchant_id}.
+        </p>
+      </div>
+      <div className="list-card">
+        {events.items.length === 0 ? (
+          <p className="muted">No risk events recorded yet.</p>
+        ) : (
+          events.items.map((ev) => (
+            <div className="list-row" key={ev.id}>
+              <div>
+                <div className="row-title">{ev.payment_id}</div>
+                <div className="row-meta">
+                  <span className={actionBadge(ev.action)}>{ev.action}</span>
+                  <span>score: {ev.score}</span>
+                  {ev.triggered_rules.length > 0 && (
+                    <span>{ev.triggered_rules.join(", ")}</span>
+                  )}
+                  {ev.resolved && (
+                    <span className="badge-success">resolved</span>
+                  )}
+                  <span>{formatTime(ev.created_at)}</span>
+                </div>
+              </div>
+              <div className="amount-pill">{ev.id}</div>
+            </div>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}

--- a/dashboard/app/team/page.tsx
+++ b/dashboard/app/team/page.tsx
@@ -1,0 +1,75 @@
+import { getInvitations, requireViewer } from "../../lib/api";
+import { formatTime } from "../../lib/types";
+
+function statusBadge(status: string) {
+  if (status === "accepted") return "badge-success";
+  if (status === "pending") return "badge-warning";
+  return "badge-error";
+}
+
+export default async function TeamPage() {
+  const viewer = await requireViewer();
+  const invitations = await getInvitations();
+
+  return (
+    <section className="stack">
+      <div className="hero-card">
+        <div className="eyebrow">Team Management</div>
+        <h1>Team</h1>
+        <p className="lede">
+          {invitations.count} invitation{invitations.count !== 1 ? "s" : ""} for{" "}
+          {viewer.merchant_id}.
+        </p>
+      </div>
+
+      <div className="list-card">
+        <div className="list-row">
+          <form action="/api/invite" method="POST" className="inline-form">
+            <input
+              type="email"
+              name="email"
+              placeholder="colleague@example.com"
+              required
+              className="input"
+            />
+            <select name="role" className="input">
+              <option value="developer">Developer</option>
+              <option value="readonly">Read-only</option>
+              <option value="ops">Operations</option>
+            </select>
+            <button type="submit" className="action-button">
+              Send Invite
+            </button>
+          </form>
+        </div>
+      </div>
+
+      <div className="list-card">
+        {invitations.items.length === 0 ? (
+          <p className="muted">No invitations sent yet.</p>
+        ) : (
+          invitations.items.map((inv) => (
+            <div className="list-row" key={inv.id}>
+              <div>
+                <div className="row-title">{inv.email}</div>
+                <div className="row-meta">
+                  <span className={statusBadge(inv.status)}>{inv.status}</span>
+                  <span>{inv.role}</span>
+                  <span>invited by {inv.invited_by}</span>
+                  <span>expires {formatTime(inv.expires_at)}</span>
+                </div>
+              </div>
+              {inv.status === "pending" && (
+                <form action={`/api/revoke-invite/${inv.id}`} method="POST">
+                  <button type="submit" className="ghost-button">
+                    Revoke
+                  </button>
+                </form>
+              )}
+            </div>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}

--- a/dashboard/components/nav.tsx
+++ b/dashboard/components/nav.tsx
@@ -9,6 +9,9 @@ const links = [
   ["/settlements", "Settlements"],
   ["/recon", "Reconciliation"],
   ["/api-keys", "API Keys"],
+  ["/risk", "Risk"],
+  ["/audit", "Audit Log"],
+  ["/team", "Team"],
 ];
 
 export default function Nav({ viewer }: { viewer: DashboardViewer | null }) {

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -3,12 +3,15 @@ import { notFound, redirect } from "next/navigation";
 
 import type {
   APIKeyItem,
+  AuditLogItem,
   DeliveryAttemptItem,
   DashboardViewer,
+  InvitationItem,
   OrderItem,
   PaymentItem,
   ReconMismatch,
   RefundItem,
+  RiskEventItem,
   SettlementItem,
   SettlementLineItem,
   WebhookItem,
@@ -191,4 +194,77 @@ export async function getReconMismatches() {
     return { items: [] as ReconMismatch[], count: 0 };
   }
   return (await response.json()) as CollectionResponse<ReconMismatch>;
+}
+
+export async function getRiskEvents() {
+  await requireViewer();
+  const response = await apiFetch("/v1/risk/events");
+  if (!response.ok) {
+    throw new Error(`risk events fetch failed: ${response.status}`);
+  }
+  return (await response.json()) as CollectionResponse<RiskEventItem>;
+}
+
+export async function resolveRiskEvent(id: string, resolvedBy: string) {
+  await requireViewer();
+  const response = await apiFetch(`/v1/risk/events/${id}/resolve`, {
+    method: "POST",
+    body: JSON.stringify({ resolved_by: resolvedBy }),
+  });
+  if (!response.ok) {
+    throw new Error(`resolve risk event failed: ${response.status}`);
+  }
+  return (await response.json()) as RiskEventItem;
+}
+
+export async function getAuditLogs(params?: {
+  resource_type?: string;
+  resource_id?: string;
+  actor_id?: string;
+}) {
+  await requireViewer();
+  const qs = params
+    ? "?" +
+      Object.entries(params)
+        .filter(([, v]) => v)
+        .map(([k, v]) => `${k}=${encodeURIComponent(v!)}`)
+        .join("&")
+    : "";
+  const response = await apiFetch(`/v1/audit-logs${qs}`);
+  if (!response.ok) {
+    throw new Error(`audit logs fetch failed: ${response.status}`);
+  }
+  return (await response.json()) as CollectionResponse<AuditLogItem>;
+}
+
+export async function getInvitations() {
+  await requireViewer();
+  const response = await apiFetch("/v1/merchants/me/invitations");
+  if (!response.ok) {
+    throw new Error(`invitations fetch failed: ${response.status}`);
+  }
+  return (await response.json()) as CollectionResponse<InvitationItem>;
+}
+
+export async function inviteTeamMember(email: string, role: string) {
+  await requireViewer();
+  const response = await apiFetch("/v1/merchants/me/invitations", {
+    method: "POST",
+    body: JSON.stringify({ email, role }),
+  });
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    throw new Error((body as { error?: { description?: string } }).error?.description ?? "invite failed");
+  }
+  return (await response.json()) as InvitationItem;
+}
+
+export async function revokeInvitation(id: string) {
+  await requireViewer();
+  const response = await apiFetch(`/v1/merchants/me/invitations/${id}`, {
+    method: "DELETE",
+  });
+  if (!response.ok) {
+    throw new Error(`revoke invitation failed: ${response.status}`);
+  }
 }

--- a/dashboard/lib/types.ts
+++ b/dashboard/lib/types.ts
@@ -115,6 +115,45 @@ export type ReconMismatch = {
   created_at: number;
 };
 
+export type RiskEventItem = {
+  id: string;
+  merchant_id: string;
+  payment_id: string;
+  score: number;
+  action: string;
+  triggered_rules: string[];
+  resolved: boolean;
+  resolved_by: string | null;
+  resolved_at: number | null;
+  created_at: number;
+};
+
+export type AuditLogItem = {
+  id: string;
+  merchant_id: string;
+  actor_id: string;
+  actor_email: string;
+  actor_type: string;
+  action: string;
+  resource_type: string;
+  resource_id: string;
+  ip_address: string;
+  correlation_id: string;
+  created_at: number;
+};
+
+export type InvitationItem = {
+  id: string;
+  merchant_id: string;
+  email: string;
+  role: string;
+  status: string;
+  invited_by: string;
+  expires_at: number;
+  accepted_at: number | null;
+  created_at: number;
+};
+
 export function formatMoney(amount: number, currency: string) {
   return new Intl.NumberFormat("en-IN", {
     style: "currency",


### PR DESCRIPTION
## Summary

- **`dashboard/lib/types.ts`** — Added `RiskEventItem`, `AuditLogItem`, `InvitationItem` types
- **`dashboard/lib/api.ts`** — Added `getRiskEvents`, `resolveRiskEvent`, `getAuditLogs`, `getInvitations`, `inviteTeamMember`, `revokeInvitation` helpers
- **`dashboard/app/risk/page.tsx`** — Risk events list: action badge (allow/hold/block), score, triggered rules, resolution status
- **`dashboard/app/audit/page.tsx`** — Audit log viewer: action, resource, actor email/type, IP, timestamp
- **`dashboard/app/team/page.tsx`** — Team management: invite form (email + role), pending/accepted invitation list with revoke button
- **`dashboard/components/nav.tsx`** — Added Risk, Audit Log, Team nav links

## Test plan

- [x] `npx tsc --noEmit` passes with no errors
- [x] All three new pages follow the existing server-component pattern (`requireViewer` guard, `apiFetch` with cookie forwarding)
- [x] Nav links wired to `/risk`, `/audit`, `/team`

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)