### PR TITLE
feat: add settlement hold/release mechanism

### DIFF
--- a/internal/settlement/domain.go
+++ b/internal/settlement/domain.go
@@ -28,6 +28,8 @@ var (
 	ErrSettlementNotFound    = errors.New("settlement not found")
 	ErrInvalidTransition     = errors.New("invalid settlement state transition")
 	ErrNoEligiblePayments    = errors.New("no eligible payments found for settlement")
+	ErrSettlementOnHold      = errors.New("settlement is already on hold")
+	ErrSettlementNotOnHold   = errors.New("settlement is not on hold")
 )
 
 // Transition returns the next SettlementState for the given event,
@@ -69,6 +71,10 @@ type Settlement struct {
 	ProcessedAt  *time.Time
 	CreatedAt    time.Time
 	UpdatedAt    time.Time
+	OnHold       bool
+	HoldReason   string
+	HeldAt       *time.Time
+	ReleasedAt   *time.Time
 }
 
 // SettlementItem is one payment's contribution to a settlement batch.

--- a/internal/settlement/handler.go
+++ b/internal/settlement/handler.go
@@ -1,6 +1,7 @@
 package settlement
 
 import (
+	"encoding/json"
 	"errors"
 	"net/http"
 	"time"
@@ -23,6 +24,8 @@ func NewHandler(svc *Service) *Handler {
 func (h *Handler) RegisterRoutesWithAuth(mux *http.ServeMux, wrap func(scope merchant.APIKeyScope, next http.Handler) http.Handler) {
 	mux.Handle("GET /v1/settlements", wrap(merchant.APIKeyScopeRead, http.HandlerFunc(h.list)))
 	mux.Handle("GET /v1/settlements/{settlementID}", wrap(merchant.APIKeyScopeRead, http.HandlerFunc(h.get)))
+	mux.Handle("POST /v1/settlements/{settlementID}/hold", wrap(merchant.APIKeyScopeWrite, http.HandlerFunc(h.hold)))
+	mux.Handle("POST /v1/settlements/{settlementID}/release", wrap(merchant.APIKeyScopeWrite, http.HandlerFunc(h.release)))
 }
 
 func (h *Handler) list(w http.ResponseWriter, r *http.Request) {
@@ -65,6 +68,52 @@ func (h *Handler) get(w http.ResponseWriter, r *http.Request) {
 	}
 	resp["items"] = itemsJSON
 	httpx.WriteJSON(w, http.StatusOK, resp)
+}
+
+func (h *Handler) hold(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	settlementID := r.PathValue("settlementID")
+
+	var body struct {
+		Reason string `json:"reason"`
+	}
+	if r.ContentLength > 0 {
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			httpx.WriteError(w, http.StatusBadRequest, httpx.APIError{Code: "BAD_REQUEST", Description: "invalid request body"})
+			return
+		}
+	}
+
+	if err := h.svc.Hold(r.Context(), p.MerchantID, settlementID, body.Reason); err != nil {
+		handleError(w, err)
+		return
+	}
+	httpx.WriteJSON(w, http.StatusOK, map[string]any{
+		"id":      settlementID,
+		"on_hold": true,
+	})
+}
+
+func (h *Handler) release(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	settlementID := r.PathValue("settlementID")
+
+	if err := h.svc.Release(r.Context(), p.MerchantID, settlementID); err != nil {
+		handleError(w, err)
+		return
+	}
+	httpx.WriteJSON(w, http.StatusOK, map[string]any{
+		"id":      settlementID,
+		"on_hold": false,
+	})
 }
 
 func present(s Settlement) map[string]any {
@@ -115,6 +164,10 @@ func handleError(w http.ResponseWriter, err error) {
 		httpx.WriteError(w, http.StatusUnprocessableEntity, httpx.APIError{Code: "NO_ELIGIBLE_PAYMENTS", Description: err.Error()})
 	case errors.Is(err, ErrInvalidTransition):
 		httpx.WriteError(w, http.StatusUnprocessableEntity, httpx.APIError{Code: "INVALID_STATE", Description: err.Error()})
+	case errors.Is(err, ErrSettlementOnHold):
+		httpx.WriteError(w, http.StatusConflict, httpx.APIError{Code: "SETTLEMENT_ON_HOLD", Description: err.Error()})
+	case errors.Is(err, ErrSettlementNotOnHold):
+		httpx.WriteError(w, http.StatusConflict, httpx.APIError{Code: "SETTLEMENT_NOT_ON_HOLD", Description: err.Error()})
 	default:
 		httpx.WriteError(w, http.StatusInternalServerError, httpx.APIError{Code: "SERVER_ERROR", Description: "internal server error"})
 	}

--- a/internal/settlement/postgres.go
+++ b/internal/settlement/postgres.go
@@ -150,6 +150,7 @@ WHERE id = ANY($2)
 
 func (r *PostgresRepository) GetSettlement(ctx context.Context, merchantID, id string) (Settlement, error) {
 	var s Settlement
+	var holdReason *string
 	err := r.db.QueryRow(ctx, `
 SELECT id, merchant_id, status, period_start, period_end, total_amount, total_fees,
        total_refunds, net_amount, payment_count, currency, processed_at, created_at, updated_at,
@@ -160,8 +161,11 @@ WHERE id = $1 AND merchant_id = $2
 		&s.ID, &s.MerchantID, &s.Status, &s.PeriodStart, &s.PeriodEnd,
 		&s.TotalAmount, &s.TotalFees, &s.TotalRefunds, &s.NetAmount,
 		&s.PaymentCount, &s.Currency, &s.ProcessedAt, &s.CreatedAt, &s.UpdatedAt,
-		&s.OnHold, &s.HoldReason, &s.HeldAt, &s.ReleasedAt,
+		&s.OnHold, &holdReason, &s.HeldAt, &s.ReleasedAt,
 	)
+	if holdReason != nil {
+		s.HoldReason = *holdReason
+	}
 	if errors.Is(err, pgx.ErrNoRows) {
 		return Settlement{}, ErrSettlementNotFound
 	}
@@ -186,13 +190,17 @@ LIMIT 100
 	var settlements []Settlement
 	for rows.Next() {
 		var s Settlement
+		var holdReason *string
 		if err := rows.Scan(
 			&s.ID, &s.MerchantID, &s.Status, &s.PeriodStart, &s.PeriodEnd,
 			&s.TotalAmount, &s.TotalFees, &s.TotalRefunds, &s.NetAmount,
 			&s.PaymentCount, &s.Currency, &s.ProcessedAt, &s.CreatedAt, &s.UpdatedAt,
-			&s.OnHold, &s.HoldReason, &s.HeldAt, &s.ReleasedAt,
+			&s.OnHold, &holdReason, &s.HeldAt, &s.ReleasedAt,
 		); err != nil {
 			return nil, err
+		}
+		if holdReason != nil {
+			s.HoldReason = *holdReason
 		}
 		settlements = append(settlements, s)
 	}

--- a/internal/settlement/postgres.go
+++ b/internal/settlement/postgres.go
@@ -152,13 +152,15 @@ func (r *PostgresRepository) GetSettlement(ctx context.Context, merchantID, id s
 	var s Settlement
 	err := r.db.QueryRow(ctx, `
 SELECT id, merchant_id, status, period_start, period_end, total_amount, total_fees,
-       total_refunds, net_amount, payment_count, currency, processed_at, created_at, updated_at
+       total_refunds, net_amount, payment_count, currency, processed_at, created_at, updated_at,
+       on_hold, hold_reason, held_at, released_at
 FROM paygate_settlements.settlements
 WHERE id = $1 AND merchant_id = $2
 `, id, merchantID).Scan(
 		&s.ID, &s.MerchantID, &s.Status, &s.PeriodStart, &s.PeriodEnd,
 		&s.TotalAmount, &s.TotalFees, &s.TotalRefunds, &s.NetAmount,
 		&s.PaymentCount, &s.Currency, &s.ProcessedAt, &s.CreatedAt, &s.UpdatedAt,
+		&s.OnHold, &s.HoldReason, &s.HeldAt, &s.ReleasedAt,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return Settlement{}, ErrSettlementNotFound
@@ -169,7 +171,8 @@ WHERE id = $1 AND merchant_id = $2
 func (r *PostgresRepository) ListSettlements(ctx context.Context, merchantID string) ([]Settlement, error) {
 	rows, err := r.db.Query(ctx, `
 SELECT id, merchant_id, status, period_start, period_end, total_amount, total_fees,
-       total_refunds, net_amount, payment_count, currency, processed_at, created_at, updated_at
+       total_refunds, net_amount, payment_count, currency, processed_at, created_at, updated_at,
+       on_hold, hold_reason, held_at, released_at
 FROM paygate_settlements.settlements
 WHERE merchant_id = $1
 ORDER BY created_at DESC
@@ -187,12 +190,43 @@ LIMIT 100
 			&s.ID, &s.MerchantID, &s.Status, &s.PeriodStart, &s.PeriodEnd,
 			&s.TotalAmount, &s.TotalFees, &s.TotalRefunds, &s.NetAmount,
 			&s.PaymentCount, &s.Currency, &s.ProcessedAt, &s.CreatedAt, &s.UpdatedAt,
+			&s.OnHold, &s.HoldReason, &s.HeldAt, &s.ReleasedAt,
 		); err != nil {
 			return nil, err
 		}
 		settlements = append(settlements, s)
 	}
 	return settlements, rows.Err()
+}
+
+func (r *PostgresRepository) HoldSettlement(ctx context.Context, merchantID, settlementID, reason string) error {
+	tag, err := r.db.Exec(ctx, `
+UPDATE paygate_settlements.settlements
+SET on_hold = TRUE, hold_reason = $3, held_at = NOW(), updated_at = NOW()
+WHERE id = $1 AND merchant_id = $2 AND on_hold = FALSE
+`, settlementID, merchantID, reason)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrSettlementOnHold
+	}
+	return nil
+}
+
+func (r *PostgresRepository) ReleaseSettlement(ctx context.Context, merchantID, settlementID string) error {
+	tag, err := r.db.Exec(ctx, `
+UPDATE paygate_settlements.settlements
+SET on_hold = FALSE, hold_reason = NULL, released_at = NOW(), updated_at = NOW()
+WHERE id = $1 AND merchant_id = $2 AND on_hold = TRUE
+`, settlementID, merchantID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return ErrSettlementNotOnHold
+	}
+	return nil
 }
 
 func (r *PostgresRepository) GetSettlementItems(ctx context.Context, settlementID string) ([]SettlementItem, error) {

--- a/internal/settlement/repository.go
+++ b/internal/settlement/repository.go
@@ -20,4 +20,10 @@ type Repository interface {
 
 	// GetSettlementItems returns all items for a settlement.
 	GetSettlementItems(ctx context.Context, settlementID string) ([]SettlementItem, error)
+
+	// HoldSettlement places a settlement on hold with the given reason.
+	HoldSettlement(ctx context.Context, merchantID, settlementID, reason string) error
+
+	// ReleaseSettlement releases a settlement from hold.
+	ReleaseSettlement(ctx context.Context, merchantID, settlementID string) error
 }

--- a/internal/settlement/service.go
+++ b/internal/settlement/service.go
@@ -30,6 +30,16 @@ func (s *Service) List(ctx context.Context, merchantID string) ([]Settlement, er
 	return s.repo.ListSettlements(ctx, merchantID)
 }
 
+// Hold places a settlement on hold with the given reason.
+func (s *Service) Hold(ctx context.Context, merchantID, settlementID, reason string) error {
+	return s.repo.HoldSettlement(ctx, merchantID, settlementID, reason)
+}
+
+// Release removes a hold from a settlement.
+func (s *Service) Release(ctx context.Context, merchantID, settlementID string) error {
+	return s.repo.ReleaseSettlement(ctx, merchantID, settlementID)
+}
+
 // GetItems returns the settlement items for a settlement.
 func (s *Service) GetItems(ctx context.Context, merchantID, settlementID string) (Settlement, []SettlementItem, error) {
 	sttl, err := s.repo.GetSettlement(ctx, merchantID, settlementID)

--- a/migrations/000014_settlement_hold.down.sql
+++ b/migrations/000014_settlement_hold.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE paygate_settlements.settlements
+    DROP COLUMN IF EXISTS on_hold,
+    DROP COLUMN IF EXISTS hold_reason,
+    DROP COLUMN IF EXISTS held_at,
+    DROP COLUMN IF EXISTS released_at;

--- a/migrations/000014_settlement_hold.up.sql
+++ b/migrations/000014_settlement_hold.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE paygate_settlements.settlements
+    ADD COLUMN IF NOT EXISTS on_hold      BOOLEAN     NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS hold_reason  TEXT,
+    ADD COLUMN IF NOT EXISTS held_at      TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS released_at  TIMESTAMPTZ;


### PR DESCRIPTION
Closes #298

- Migration 000014: adds on_hold, hold_reason, held_at, released_at to settlements
- domain.go: new fields + ErrSettlementOnHold/NotOnHold
- repository.go: HoldSettlement + ReleaseSettlement interface methods
- postgres.go: implementations + updated scan queries
- service.go: Hold + Release delegators
- handler.go: POST /v1/settlements/{id}/hold and /release endpoints