### PR TITLE
feat: add risk alerts via outbox events

### DIFF
--- a/internal/risk/domain.go
+++ b/internal/risk/domain.go
@@ -1,6 +1,7 @@
 package risk
 
 import (
+	"context"
 	"errors"
 	"time"
 )
@@ -25,6 +26,11 @@ const (
 var (
 	ErrRiskEventNotFound = errors.New("risk event not found")
 )
+
+// AlertFunc is called when a risk evaluation results in a hold or block action.
+// It receives the risk event so callers can write outbox events or send notifications.
+// A nil AlertFunc means alerts are disabled.
+type AlertFunc func(ctx context.Context, ev RiskEvent)
 
 // RiskEvent records the risk evaluation for a single payment.
 type RiskEvent struct {

--- a/internal/risk/outbox_alert.go
+++ b/internal/risk/outbox_alert.go
@@ -1,0 +1,37 @@
+package risk
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sanskarpan/PayGate/internal/outbox"
+)
+
+// OutboxAlertFunc returns an AlertFunc that writes a risk.alert outbox event
+// for every hold or block action. This allows downstream consumers (e.g. the
+// webhook service) to notify merchants of flagged payments in real time.
+func OutboxAlertFunc(db *pgxpool.Pool) AlertFunc {
+	writer := outbox.NewWriter()
+	return func(ctx context.Context, ev RiskEvent) {
+		// Begin a standalone transaction for the outbox write.
+		tx, err := db.Begin(ctx)
+		if err != nil {
+			return
+		}
+		defer func() { _ = tx.Rollback(ctx) }()
+		_ = writer.WriteTx(ctx, tx, outbox.Event{
+			AggregateType: "risk",
+			AggregateID:   ev.ID,
+			EventType:     "risk.alert",
+			MerchantID:    ev.MerchantID,
+			Payload: map[string]any{
+				"risk_event_id": ev.ID,
+				"payment_id":    ev.PaymentID,
+				"score":         ev.Score,
+				"action":        ev.Action,
+				"rules":         ev.TriggeredRules,
+			},
+		})
+		_ = tx.Commit(ctx)
+	}
+}

--- a/internal/risk/service.go
+++ b/internal/risk/service.go
@@ -7,15 +7,27 @@ import (
 
 // Service evaluates payment risk and manages risk event records.
 type Service struct {
-	repo   Repository
-	logger *slog.Logger
+	repo    Repository
+	logger  *slog.Logger
+	alertFn AlertFunc
 }
 
-func NewService(repo Repository, logger *slog.Logger) *Service {
+// WithAlertFunc returns a functional option that sets the alert function on the Service.
+func WithAlertFunc(fn AlertFunc) func(*Service) {
+	return func(s *Service) {
+		s.alertFn = fn
+	}
+}
+
+func NewService(repo Repository, logger *slog.Logger, opts ...func(*Service)) *Service {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Service{repo: repo, logger: logger}
+	svc := &Service{repo: repo, logger: logger}
+	for _, opt := range opts {
+		opt(svc)
+	}
+	return svc
 }
 
 // EvaluatePayment performs a risk evaluation for a payment attempt.
@@ -71,6 +83,9 @@ func (s *Service) EvaluatePayment(ctx context.Context, in EvalInput) (RiskEvent,
 			"action", result.Action,
 			"rules", result.TriggeredRules,
 		)
+		if s.alertFn != nil {
+			go s.alertFn(ctx, ev)
+		}
 	}
 
 	return ev, nil


### PR DESCRIPTION
Closes #299

- domain.go: AlertFunc type
- service.go: WithAlertFunc option + fire alertFn goroutine on hold/block
- outbox_alert.go: OutboxAlertFunc writes risk.alert outbox event