### PR TITLE
fix: add missing merchant_id field to risk and audit API responses

### DIFF
--- a/internal/audit/handler.go
+++ b/internal/audit/handler.go
@@ -52,6 +52,7 @@ func (h *Handler) listAuditLogs(w http.ResponseWriter, r *http.Request) {
 	for _, l := range logs {
 		items = append(items, map[string]any{
 			"id":             l.ID,
+			"merchant_id":    l.MerchantID,
 			"actor_id":       l.ActorID,
 			"actor_email":    l.ActorEmail,
 			"actor_type":     l.ActorType,

--- a/internal/risk/handler.go
+++ b/internal/risk/handler.go
@@ -103,6 +103,7 @@ func (h *Handler) resolveRiskEvent(w http.ResponseWriter, r *http.Request) {
 func riskEventToMap(ev RiskEvent) map[string]any {
 	m := map[string]any{
 		"id":              ev.ID,
+		"merchant_id":     ev.MerchantID,
 		"payment_id":      ev.PaymentID,
 		"score":           ev.Score,
 		"action":          ev.Action,


### PR DESCRIPTION
## Summary

Two API response serialisers were omitting `merchant_id` despite the TypeScript client types declaring it as a required field. This caused `undefined` to render in the merchant column on both the risk events and audit log dashboard pages.

## Files Changed

| File | Change |
|---|---|
| `internal/risk/handler.go` | Add `"merchant_id": ev.MerchantID` to `riskEventToMap` |
| `internal/audit/handler.go` | Add `"merchant_id": l.MerchantID` to audit item map |

## Root Cause

The domain structs (`RiskEvent`, `AuditLog`) carry `MerchantID` but the map literals that build the JSON response bodies were written without it — a silent omission with no compile-time error.

## Impact

- Risk events page: merchant ID column now populated
- Audit log page: merchant ID column now populated
- Any API consumer relying on `merchant_id` in either response now receives the correct value

Closes #315
Closes #316