### PR TITLE
feat(recon): expose GET /v1/recon/mismatches — full reconciliation query API

### DIFF
--- a/cmd/api-gateway/main.go
+++ b/cmd/api-gateway/main.go
@@ -115,7 +115,9 @@ func run() error {
 	go order.NewExpirySweeper(orderSvc, time.Minute, l).Start(ctx)
 	go webhook.NewRetryWorker(webhookSvc, 30*time.Second, l).Start(ctx)
 	go payment.NewSweeper(paymentSvc, 30*time.Second, l).Start(ctx)
-	go recon.NewWorker(db, l).Start(ctx)
+	reconWorker := recon.NewWorker(db, l)
+	go reconWorker.Start(ctx)
+	reconHandler := recon.NewHandler(reconWorker)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", httpx.Healthz)
@@ -178,6 +180,9 @@ func run() error {
 	riskHandler.RegisterRoutesWithAuth(mux, func(scope string, next http.Handler) http.Handler {
 		s := merchant.APIKeyScope(scope)
 		return authMw.RequireScope(s, next)
+	})
+	reconHandler.RegisterRoutesWithAuth(mux, func(next http.Handler) http.Handler {
+		return authMw.RequireScope(merchant.APIKeyScopeRead, next)
 	})
 
 	mux.Handle("GET /v1/merchants/me", authMw.RequireScope(merchant.APIKeyScopeRead, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/recon/handler.go
+++ b/internal/recon/handler.go
@@ -1,0 +1,66 @@
+package recon
+
+import (
+	"net/http"
+	"strconv"
+
+	httpx "github.com/sanskarpan/PayGate/internal/common/http"
+)
+
+// Handler exposes recon query endpoints.
+type Handler struct {
+	worker *Worker
+}
+
+// NewHandler creates a Handler backed by the given Worker.
+func NewHandler(w *Worker) *Handler {
+	return &Handler{worker: w}
+}
+
+// RegisterRoutesWithAuth wires recon read endpoints under authentication.
+func (h *Handler) RegisterRoutesWithAuth(mux *http.ServeMux, wrap func(next http.Handler) http.Handler) {
+	mux.Handle("GET /v1/recon/mismatches", wrap(http.HandlerFunc(h.listMismatches)))
+}
+
+func (h *Handler) listMismatches(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+
+	q := r.URL.Query()
+	limit, _ := strconv.Atoi(q.Get("count"))
+	unresolvedOnly := q.Get("unresolved") == "true"
+
+	mismatches, err := h.worker.ListMismatches(r.Context(), p.MerchantID, limit, unresolvedOnly)
+	if err != nil {
+		httpx.WriteError(w, http.StatusInternalServerError, httpx.APIError{
+			Code:        "SERVER_ERROR",
+			Description: "failed to list recon mismatches",
+		})
+		return
+	}
+
+	items := make([]map[string]any, 0, len(mismatches))
+	for _, mm := range mismatches {
+		items = append(items, map[string]any{
+			"id":             mm.ID,
+			"batch_id":       mm.BatchID,
+			"mismatch_type":  string(mm.MismatchType),
+			"entity_type":    mm.EntityType,
+			"entity_id":      mm.EntityID,
+			"expected_value": mm.ExpectedValue,
+			"actual_value":   mm.ActualValue,
+			"description":    mm.Description,
+			"resolved":       mm.Resolved,
+			"created_at":     mm.CreatedAt.Unix(),
+		})
+	}
+
+	httpx.WriteJSON(w, http.StatusOK, map[string]any{
+		"entity": "collection",
+		"count":  len(items),
+		"items":  items,
+	})
+}

--- a/internal/recon/worker.go
+++ b/internal/recon/worker.go
@@ -227,6 +227,41 @@ WHERE p.status = 'captured'
 	return w.persistBatch(ctx, batchID, "", BatchTypeThreeWay, start, end, checkedCount, len(mismatches), mismatches)
 }
 
+// ListMismatches returns recon mismatches for a merchant, newest first.
+func (w *Worker) ListMismatches(ctx context.Context, merchantID string, limit int, unresolvedOnly bool) ([]ReconMismatch, error) {
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	q := `
+SELECT id, batch_id, merchant_id, mismatch_type, entity_type, entity_id,
+       expected_value, actual_value, description, resolved, created_at
+FROM paygate_recon.recon_mismatches
+WHERE merchant_id = $1
+  AND ($2 = FALSE OR resolved = FALSE)
+ORDER BY created_at DESC
+LIMIT $3`
+
+	rows, err := w.db.Query(ctx, q, merchantID, unresolvedOnly, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list recon mismatches: %w", err)
+	}
+	defer rows.Close()
+
+	var mismatches []ReconMismatch
+	for rows.Next() {
+		var mm ReconMismatch
+		if err := rows.Scan(
+			&mm.ID, &mm.BatchID, &mm.MerchantID, &mm.MismatchType,
+			&mm.EntityType, &mm.EntityID, &mm.ExpectedValue, &mm.ActualValue,
+			&mm.Description, &mm.Resolved, &mm.CreatedAt,
+		); err != nil {
+			return nil, fmt.Errorf("scan recon mismatch: %w", err)
+		}
+		mismatches = append(mismatches, mm)
+	}
+	return mismatches, rows.Err()
+}
+
 func (w *Worker) persistBatch(ctx context.Context, batchID, merchantID string, batchType BatchType, start, end time.Time, checked, mismatchCount int, mismatches []ReconMismatch) (int, error) {
 	tx, err := w.db.Begin(ctx)
 	if err != nil {


### PR DESCRIPTION
## Summary

The reconciliation worker was writing detected mismatches to `paygate_recon.recon_mismatches` but there was no HTTP endpoint to query them. Operators had no way to investigate recon failures through the API or dashboard.

This PR adds the full query path: a new method on the worker, a new HTTP handler, and route registration in the api-gateway.

## Files Changed

| File | Change |
|---|---|
| `internal/recon/worker.go` | Add `ListMismatches(ctx, merchantID, limit, unresolvedOnly)` |
| `internal/recon/handler.go` | New file — HTTP handler with `GET /v1/recon/mismatches` |
| `cmd/api-gateway/main.go` | Save worker to variable, create handler, register route |

## Endpoint

```
GET /v1/recon/mismatches?count=50&unresolved=true
Authorization: Bearer <read-scope-key>
```

Response:
```json
{
  "entity": "collection",
  "count": 1,
  "items": [{ "id": "...", "mismatch_type": "ledger_balance", "resolved": false, ... }]
}
```

## Query Parameters

| Param | Default | Description |
|---|---|---|
| `count` | 50 | Max results (hard cap 200) |
| `unresolved` | false | Filter to unresolved only |

Closes #317
Closes #318
Closes #319

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new API endpoint for listing reconciliation mismatches with support for filtering and pagination
  * Supports filtering by resolution status (resolved/unresolved) and configurable limit-based pagination for efficient data retrieval
  * Requires Read-scope authentication for access
  * Returns comprehensive mismatch details including batch ID, type, entity information, expected versus actual values, descriptions, and timestamps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->