### PR TITLE
feat(settlement-service): implement daily batch scheduler daemon from empty stub

### DIFF
--- a/cmd/settlement-service/main.go
+++ b/cmd/settlement-service/main.go
@@ -1,3 +1,103 @@
 package main
 
-func main() {}
+import (
+	"context"
+	"log"
+	"log/slog"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sanskarpan/PayGate/internal/common/config"
+	"github.com/sanskarpan/PayGate/internal/common/logger"
+	"github.com/sanskarpan/PayGate/internal/ledger"
+	"github.com/sanskarpan/PayGate/internal/settlement"
+)
+
+func main() {
+	if err := run(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func run() error {
+	cfg := config.FromEnv()
+	l := logger.New("settlement-service")
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	db, err := pgxpool.New(ctx, cfg.DatabaseURL)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+
+	if err := db.Ping(ctx); err != nil {
+		return err
+	}
+
+	ledgerRepo := ledger.NewRepository(db)
+	ledgerSvc := ledger.NewService(ledgerRepo)
+	settlementRepo := settlement.NewPostgresRepository(db, ledgerSvc)
+	settlementSvc := settlement.NewService(settlementRepo)
+
+	l.Info("settlement-service started, running initial batch")
+	runBatchAllMerchants(ctx, db, settlementSvc, l)
+
+	ticker := time.NewTicker(24 * time.Hour)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			runBatchAllMerchants(ctx, db, settlementSvc, l)
+		}
+	}
+}
+
+// runBatchAllMerchants queries all active merchants and runs a settlement batch
+// covering all captured, non-settled payments up to now.
+func runBatchAllMerchants(ctx context.Context, db *pgxpool.Pool, svc *settlement.Service, l *slog.Logger) {
+	rows, err := db.Query(ctx, `SELECT id FROM paygate_merchants.merchants WHERE status = 'active'`)
+	if err != nil {
+		l.Error("list merchants for settlement", "error", err)
+		return
+	}
+	defer rows.Close()
+
+	var merchantIDs []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			l.Error("scan merchant id", "error", err)
+			continue
+		}
+		merchantIDs = append(merchantIDs, id)
+	}
+	rows.Close()
+
+	periodStart := time.Unix(0, 0)
+	periodEnd := time.Now().UTC()
+
+	for _, merchantID := range merchantIDs {
+		sttl, err := svc.RunBatch(ctx, merchantID, periodStart, periodEnd)
+		if err == settlement.ErrNoEligiblePayments {
+			l.Info("no eligible payments for settlement", "merchant_id", merchantID)
+			continue
+		}
+		if err != nil {
+			l.Error("settlement batch failed", "merchant_id", merchantID, "error", err)
+			continue
+		}
+		l.Info("settlement batch completed",
+			"merchant_id", merchantID,
+			"settlement_id", sttl.ID,
+			"net_amount", sttl.NetAmount,
+			"payment_count", sttl.PaymentCount,
+		)
+	}
+}


### PR DESCRIPTION
## Problem

`cmd/settlement-service/main.go` was `package main / func main() {}` — a completely empty stub. The settlement batch process **never ran** as a standalone service. Settlements could never be automatically created; the system accumulated captured payments with no settlement ever generated.

## Solution

Full daemon implementation:

1. Connects to Postgres via `pgxpool`
2. Wires `ledger.Service` → `settlement.Service` (settlement depends on ledger for double-entry postings)
3. Runs an initial batch on startup to cover any backlog
4. Schedules a `time.Ticker` every 24 hours
5. On each tick, queries all active merchants (`SELECT id FROM paygate_merchants.merchants WHERE status = 'active'`) and calls `RunBatch` per merchant
6. `ErrNoEligiblePayments` → info log and continue
7. Other errors → error log and continue (never crash)
8. Graceful shutdown on `SIGINT`/`SIGTERM`

## Files Changed

| File | Change |
|---|---|
| `cmd/settlement-service/main.go` | Full implementation (was empty stub) |

## Before / After

```
Before: package main
        func main() {}

After:  ~100 lines — full daily scheduler with merchant discovery, batch
        execution, error handling, and graceful shutdown
```

Closes #321