### PR TITLE
feat(middleware): extract CORS configuration into standalone reusable package

### DIFF
--- a/internal/common/middleware/cors.go
+++ b/internal/common/middleware/cors.go
@@ -1,0 +1,23 @@
+package middleware
+
+import "net/http"
+
+// CORS returns middleware that adds CORS headers for the given allowed origin.
+// It handles OPTIONS preflight requests with a 204 and forwards all other
+// requests to next after setting the response headers.
+func CORS(allowedOrigin string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Access-Control-Allow-Origin", allowedOrigin)
+			w.Header().Set("Access-Control-Allow-Credentials", "true")
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization, Idempotency-Key, X-Request-Id")
+
+			if r.Method == http.MethodOptions {
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

CORS logic was previously inlined in `cmd/api-gateway/main.go`. Extracting it into `internal/common/middleware/cors.go` makes it independently testable and reusable by any future service.

## Files Changed

| File | Change |
|---|---|
| `internal/common/middleware/cors.go` | New file — `CORS(allowedOrigin string)` middleware |

## Behaviour

- Sets `Access-Control-Allow-Origin`, `Allow-Credentials`, `Allow-Methods`, `Allow-Headers`
- Handles `OPTIONS` preflight with `204 No Content` and returns early
- Supports credentialed requests (`credentials: "include"`) from the Next.js dashboard

Closes #335