### PR TITLE
fix(api-gateway): wire CORS middleware into handler chain

### DIFF
--- a/cmd/api-gateway/main.go
+++ b/cmd/api-gateway/main.go
@@ -218,7 +218,14 @@ func run() error {
 	})))
 
 	rateLimiter := middleware.NewRateLimiter(25, 25)
-	handler := telemetry.WrapHTTP(httpx.NewRouter(middleware.Logging(l, rateLimiter.Middleware(mux))), "api-gateway")
+	dashboardOrigin := cfg.DashboardOrigin
+	if dashboardOrigin == "" {
+		dashboardOrigin = "http://localhost:3001"
+	}
+	handler := telemetry.WrapHTTP(
+		httpx.NewRouter(middleware.CORS(dashboardOrigin)(middleware.Logging(l, rateLimiter.Middleware(mux)))),
+		"api-gateway",
+	)
 
 	server := &http.Server{
 		Addr:              ":" + cfg.Port,


### PR DESCRIPTION
## Problem

`middleware.CORS` was added but never connected. The two client-side dashboard components (`api-key-manager.tsx`, `ip-allowlist-manager.tsx`) make direct browser `fetch()` calls to the API — both fail with CORS policy errors in production.

## Fix

Wire `cfg.DashboardOrigin` + `middleware.CORS` into the api-gateway handler chain before the logging middleware, so preflight OPTIONS requests are handled before auth.

## Files Changed

| File | Change |
|---|---|
| `cmd/api-gateway/main.go` | Add CORS wrapper around handler chain |

Closes #348