### PR TITLE
fix(dashboard): resolve UI issues from end-to-end audit (#312)

### DIFF
--- a/dashboard/app/disputes/[id]/page.tsx
+++ b/dashboard/app/disputes/[id]/page.tsx
@@ -28,47 +28,27 @@ export default async function DisputeDetailPage({ params }: { params: { id: stri
       </div>
 
       <div className="detail-card">
-        <dl className="detail-grid">
-          <dt>Payment ID</dt>
-          <dd>{dispute.payment_id}</dd>
-          <dt>Amount</dt>
-          <dd>{formatMoney(dispute.amount, dispute.currency)}</dd>
-          <dt>Reason</dt>
-          <dd>{dispute.reason}</dd>
-          <dt>Status</dt>
-          <dd><span className={statusBadge(dispute.status)}>{dispute.status}</span></dd>
+        <dl className="detail-list">
+          <div><dt>Payment ID</dt><dd>{dispute.payment_id}</dd></div>
+          <div><dt>Amount</dt><dd>{formatMoney(dispute.amount, dispute.currency)}</dd></div>
+          <div><dt>Reason</dt><dd>{dispute.reason}</dd></div>
+          <div><dt>Status</dt><dd><span className={statusBadge(dispute.status)}>{dispute.status}</span></dd></div>
           {dispute.due_by && (
-            <>
-              <dt>Evidence Due By</dt>
-              <dd>{formatTime(dispute.due_by)}</dd>
-            </>
+            <div><dt>Evidence Due By</dt><dd>{formatTime(dispute.due_by)}</dd></div>
           )}
           {dispute.evidence_submitted_at && (
-            <>
-              <dt>Evidence Submitted</dt>
-              <dd>{formatTime(dispute.evidence_submitted_at)}</dd>
-            </>
+            <div><dt>Evidence Submitted</dt><dd>{formatTime(dispute.evidence_submitted_at)}</dd></div>
           )}
           {dispute.resolved_at && (
-            <>
-              <dt>Resolved At</dt>
-              <dd>{formatTime(dispute.resolved_at)}</dd>
-            </>
+            <div><dt>Resolved At</dt><dd>{formatTime(dispute.resolved_at)}</dd></div>
           )}
           {dispute.settlement_id && (
-            <>
-              <dt>Settlement ID</dt>
-              <dd>{dispute.settlement_id}</dd>
-            </>
+            <div><dt>Settlement ID</dt><dd>{dispute.settlement_id}</dd></div>
           )}
           {dispute.notes && (
-            <>
-              <dt>Notes</dt>
-              <dd>{dispute.notes}</dd>
-            </>
+            <div><dt>Notes</dt><dd>{dispute.notes}</dd></div>
           )}
-          <dt>Created At</dt>
-          <dd>{formatTime(dispute.created_at)}</dd>
+          <div><dt>Created At</dt><dd>{formatTime(dispute.created_at)}</dd></div>
         </dl>
 
         {dispute.evidence && Object.keys(dispute.evidence).length > 0 && (

--- a/dashboard/app/globals.css
+++ b/dashboard/app/globals.css
@@ -2,6 +2,7 @@
   --bg: #f4efe6;
   --card: rgba(255, 250, 241, 0.82);
   --panel: #fffaf1;
+  --surface: rgba(255, 255, 255, 0.55);
   --ink: #1e1a16;
   --muted: #6d6258;
   --accent: #0c6c57;
@@ -313,7 +314,8 @@ select {
 .badge-success,
 .badge-warning,
 .badge-error,
-.badge-info {
+.badge-info,
+.badge-neutral {
   display: inline-block;
   padding: 2px 10px;
   border-radius: 999px;
@@ -339,6 +341,11 @@ select {
 .badge-info {
   background: rgba(14, 100, 160, 0.12);
   color: #0a4f7a;
+}
+
+.badge-neutral {
+  background: rgba(109, 98, 88, 0.1);
+  color: var(--muted);
 }
 
 .action-button {

--- a/dashboard/app/layout.tsx
+++ b/dashboard/app/layout.tsx
@@ -1,6 +1,12 @@
+import type { Metadata } from "next";
 import "./globals.css";
 import Nav from "../components/nav";
 import { getViewerOptional } from "../lib/api";
+
+export const metadata: Metadata = {
+  title: "PayGate",
+  description: "Payment gateway dashboard",
+};
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const viewer = await getViewerOptional();

--- a/dashboard/app/refunds/page.tsx
+++ b/dashboard/app/refunds/page.tsx
@@ -1,5 +1,5 @@
 import { getRefunds, requireViewer } from "../../lib/api";
-import { formatMoney, formatTime } from "../../lib/types";
+import { type RefundItem, formatMoney, formatTime } from "../../lib/types";
 
 function statusBadge(status: string) {
   if (status === "processed") return "badge-success";
@@ -33,7 +33,7 @@ export default async function RefundsPage({
     );
   }
 
-  let data: { items: Array<{ id: string; amount: number; currency: string; status: string; reason: string; created_at: number }>; count: number };
+  let data: { items: RefundItem[]; count: number };
   let fetchError: string | null = null;
 
   try {


### PR DESCRIPTION
## Summary

- Add `--surface` CSS variable (was used in `disputes/[id]` and `gateway` pages but never defined — pre blocks rendered with no background)
- Add `badge-neutral` CSS class (was the default fallback in 4 `statusBadge()` functions but had no rule — unknown-status badges were invisible)
- Export `metadata` from root layout so Next.js injects `<title>` and required meta tags
- Fix dispute detail page to use `detail-list` with `<div>` wrappers instead of `detail-grid` directly on `<dl>` — restores muted label colour and row separators
- Fix refunds page to import and use `RefundItem` instead of a duplicated inline type

## Test plan

- [ ] Visit `/disputes` — status badges for `open` state render with correct muted styling
- [ ] Visit `/disputes/{id}` — detail rows have label colour and border separators; evidence `<pre>` has a background
- [ ] Visit `/gateway` — API example `<pre>` has a background
- [ ] Visit `/payouts` — `pending` status badge renders correctly
- [ ] Browser tab shows "PayGate" as the page title
- [ ] `npm run build` inside `dashboard/` passes with no type errors

Closes #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Added neutral badge styling to the component system.
  * Introduced new theme variable for surface element colors.

* **Refactor**
  * Improved dispute detail metadata display layout structure.

* **Chores**
  * Updated application metadata including title and description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->