### PR TITLE
fix: E2E audit — Phase 0–4 defect resolution

### DIFF
--- a/internal/outbox/relay.go
+++ b/internal/outbox/relay.go
@@ -46,6 +46,7 @@ func NewRelay(db *pgxpool.Pool, publisher Publisher, interval time.Duration, log
 func (r *Relay) Start(ctx context.Context) {
 	ticker := time.NewTicker(r.interval)
 	defer ticker.Stop()
+	defer func() { _ = r.publisher.Close() }()
 	for {
 		select {
 		case <-ctx.Done():

--- a/internal/payment/handler.go
+++ b/internal/payment/handler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"net"
 	"net/http"
 	"strconv"
 	"strings"
@@ -75,6 +76,8 @@ func (h *Handler) authorize(w http.ResponseWriter, r *http.Request) {
 		ip := r.RemoteAddr
 		if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
 			ip = strings.TrimSpace(strings.SplitN(fwd, ",", 2)[0])
+		} else if host, _, err := net.SplitHostPort(ip); err == nil {
+			ip = host
 		}
 		action, riskErr := h.risk.EvaluateAuthorize(r.Context(), p.MerchantID, out.PaymentID, req.Amount, ip)
 		if riskErr == nil && action == "block" {

--- a/internal/recon/worker.go
+++ b/internal/recon/worker.go
@@ -167,7 +167,7 @@ HAVING COALESCE(SUM(le.credit_amount), 0) = 0
 		return 0, err
 	}
 
-	return w.persistBatch(ctx, batchID, "", BatchTypePaymentLedger, start, end, checkedCount+len(mismatches), len(mismatches), mismatches)
+	return w.persistBatch(ctx, batchID, "", BatchTypePaymentLedger, start, end, checkedCount, len(mismatches), mismatches)
 }
 
 // RunThreeWayCheck verifies settled payments have matching settlement_items.

--- a/internal/risk/service.go
+++ b/internal/risk/service.go
@@ -84,7 +84,10 @@ func (s *Service) EvaluatePayment(ctx context.Context, in EvalInput) (RiskEvent,
 			"rules", result.TriggeredRules,
 		)
 		if s.alertFn != nil {
-			go s.alertFn(ctx, ev)
+			// Use a context that carries trace/values from ctx but is not
+			// cancelled when the HTTP request completes, so the alert can
+			// finish its own I/O independently.
+			go s.alertFn(context.WithoutCancel(ctx), ev)
 		}
 	}
 

--- a/internal/webhook/domain.go
+++ b/internal/webhook/domain.go
@@ -95,6 +95,7 @@ type WebhookSubscription struct {
 type WebhookDeliveryAttempt struct {
 	ID             string
 	EventID        string
+	EventType      string // populated so retries can set the correct X-PayGate-Event header
 	SubscriptionID string
 	MerchantID     string
 	Status         DeliveryStatus

--- a/internal/webhook/postgres.go
+++ b/internal/webhook/postgres.go
@@ -178,11 +178,11 @@ func (r *PostgresRepository) CreateDeliveryAttempt(ctx context.Context, attempt 
 	}
 	_, err := r.db.Exec(ctx, `
 INSERT INTO paygate_webhooks.webhook_delivery_attempts
-    (id, event_id, subscription_id, merchant_id, status, request_url, request_body,
+    (id, event_id, event_type, subscription_id, merchant_id, status, request_url, request_body,
      response_code, response_body, error_message, attempt_number, next_retry_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
 `,
-		attempt.ID, attempt.EventID, attempt.SubscriptionID, attempt.MerchantID,
+		attempt.ID, attempt.EventID, attempt.EventType, attempt.SubscriptionID, attempt.MerchantID,
 		attempt.Status, attempt.RequestURL, attempt.RequestBody,
 		attempt.ResponseCode, attempt.ResponseBody, attempt.ErrorMessage,
 		attempt.AttemptNumber, attempt.NextRetryAt,
@@ -217,12 +217,12 @@ WHERE id = $6
 func (r *PostgresRepository) GetDeliveryAttempt(ctx context.Context, id string) (WebhookDeliveryAttempt, error) {
 	var a WebhookDeliveryAttempt
 	err := r.db.QueryRow(ctx, `
-SELECT id, event_id, subscription_id, merchant_id, status, request_url, request_body,
+SELECT id, event_id, event_type, subscription_id, merchant_id, status, request_url, request_body,
        response_code, response_body, error_message, attempt_number, next_retry_at, created_at
 FROM paygate_webhooks.webhook_delivery_attempts
 WHERE id = $1
 `, id).Scan(
-		&a.ID, &a.EventID, &a.SubscriptionID, &a.MerchantID, &a.Status,
+		&a.ID, &a.EventID, &a.EventType, &a.SubscriptionID, &a.MerchantID, &a.Status,
 		&a.RequestURL, &a.RequestBody, &a.ResponseCode, &a.ResponseBody, &a.ErrorMessage,
 		&a.AttemptNumber, &a.NextRetryAt, &a.CreatedAt,
 	)
@@ -234,7 +234,7 @@ WHERE id = $1
 
 func (r *PostgresRepository) ListDeliveryAttempts(ctx context.Context, merchantID, subscriptionID string) ([]WebhookDeliveryAttempt, error) {
 	rows, err := r.db.Query(ctx, `
-SELECT id, event_id, subscription_id, merchant_id, status, request_url, request_body,
+SELECT id, event_id, event_type, subscription_id, merchant_id, status, request_url, request_body,
        response_code, response_body, error_message, attempt_number, next_retry_at, created_at
 FROM paygate_webhooks.webhook_delivery_attempts
 WHERE merchant_id = $1 AND subscription_id = $2
@@ -249,7 +249,7 @@ LIMIT 100
 	var attempts []WebhookDeliveryAttempt
 	for rows.Next() {
 		var a WebhookDeliveryAttempt
-		if err := rows.Scan(&a.ID, &a.EventID, &a.SubscriptionID, &a.MerchantID, &a.Status,
+		if err := rows.Scan(&a.ID, &a.EventID, &a.EventType, &a.SubscriptionID, &a.MerchantID, &a.Status,
 			&a.RequestURL, &a.RequestBody, &a.ResponseCode, &a.ResponseBody, &a.ErrorMessage,
 			&a.AttemptNumber, &a.NextRetryAt, &a.CreatedAt); err != nil {
 			return nil, err
@@ -261,7 +261,7 @@ LIMIT 100
 
 func (r *PostgresRepository) PendingRetries(ctx context.Context, limit int) ([]WebhookDeliveryAttempt, error) {
 	rows, err := r.db.Query(ctx, `
-SELECT id, event_id, subscription_id, merchant_id, status, request_url, request_body,
+SELECT id, event_id, event_type, subscription_id, merchant_id, status, request_url, request_body,
        response_code, response_body, error_message, attempt_number, next_retry_at, created_at
 FROM paygate_webhooks.webhook_delivery_attempts
 WHERE status = 'failed' AND next_retry_at IS NOT NULL AND next_retry_at <= NOW()
@@ -277,7 +277,7 @@ FOR UPDATE SKIP LOCKED
 	var attempts []WebhookDeliveryAttempt
 	for rows.Next() {
 		var a WebhookDeliveryAttempt
-		if err := rows.Scan(&a.ID, &a.EventID, &a.SubscriptionID, &a.MerchantID, &a.Status,
+		if err := rows.Scan(&a.ID, &a.EventID, &a.EventType, &a.SubscriptionID, &a.MerchantID, &a.Status,
 			&a.RequestURL, &a.RequestBody, &a.ResponseCode, &a.ResponseBody, &a.ErrorMessage,
 			&a.AttemptNumber, &a.NextRetryAt, &a.CreatedAt); err != nil {
 			return nil, err
@@ -298,7 +298,7 @@ WHERE event_id = $1 AND subscription_id = $2 AND status = 'succeeded'
 
 func (r *PostgresRepository) FindDeliveryByEvent(ctx context.Context, merchantID, eventID string) ([]WebhookDeliveryAttempt, error) {
 	rows, err := r.db.Query(ctx, `
-SELECT id, event_id, subscription_id, merchant_id, status, request_url, request_body,
+SELECT id, event_id, event_type, subscription_id, merchant_id, status, request_url, request_body,
        response_code, response_body, error_message, attempt_number, next_retry_at, created_at
 FROM paygate_webhooks.webhook_delivery_attempts
 WHERE merchant_id = $1 AND event_id = $2
@@ -313,7 +313,7 @@ LIMIT 100
 	var attempts []WebhookDeliveryAttempt
 	for rows.Next() {
 		var a WebhookDeliveryAttempt
-		if err := rows.Scan(&a.ID, &a.EventID, &a.SubscriptionID, &a.MerchantID, &a.Status,
+		if err := rows.Scan(&a.ID, &a.EventID, &a.EventType, &a.SubscriptionID, &a.MerchantID, &a.Status,
 			&a.RequestURL, &a.RequestBody, &a.ResponseCode, &a.ResponseBody, &a.ErrorMessage,
 			&a.AttemptNumber, &a.NextRetryAt, &a.CreatedAt); err != nil {
 			return nil, err

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -126,6 +126,7 @@ func (s *Service) DeliverEvent(ctx context.Context, eventID, merchantID, eventTy
 
 		attempt := WebhookDeliveryAttempt{
 			EventID:        eventID,
+			EventType:      eventType,
 			SubscriptionID: sub.ID,
 			MerchantID:     merchantID,
 			Status:         status,
@@ -210,7 +211,7 @@ func (s *Service) RetryPendingDeliveries(ctx context.Context, limit int) (int, e
 			continue
 		}
 
-		result := s.deliverer.Deliver(ctx, sub.URL, sub.Secret, "", attempt.RequestBody)
+		result := s.deliverer.Deliver(ctx, sub.URL, sub.Secret, attempt.EventType, attempt.RequestBody)
 
 		nextAttempt := attempt.AttemptNumber + 1
 		var (

--- a/migrations/000020_add_event_type_to_webhook_delivery_attempts.down.sql
+++ b/migrations/000020_add_event_type_to_webhook_delivery_attempts.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE paygate_webhooks.webhook_delivery_attempts
+    DROP COLUMN IF EXISTS event_type;

--- a/migrations/000020_add_event_type_to_webhook_delivery_attempts.up.sql
+++ b/migrations/000020_add_event_type_to_webhook_delivery_attempts.up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE paygate_webhooks.webhook_delivery_attempts
+    ADD COLUMN IF NOT EXISTS event_type TEXT NOT NULL DEFAULT '';


### PR DESCRIPTION
## Defect Report

Full E2E audit of every feature shipped across Phases 0–4. Five confirmed defects were found and fixed.

---

### DEF-001 · P2 · Webhook retry drops `X-PayGate-Event` header

**File:** `internal/webhook/service.go:213`

**Root cause:** `WebhookDeliveryAttempt` had no `EventType` field, so `RetryPendingDeliveries` passed `""` to `Deliver()`. Every retry sent a blank `X-PayGate-Event` header, breaking receivers that route or verify based on event type.

**Fix:**
- Migration `000020` — `ALTER TABLE … ADD COLUMN event_type TEXT NOT NULL DEFAULT ''`
- Added `EventType string` to `WebhookDeliveryAttempt` struct (`domain.go`)
- All INSERT/SELECT/SCAN queries in `postgres.go` updated to include `event_type`
- `DeliverEvent` now stores `eventType` in the attempt record
- `RetryPendingDeliveries` now passes `attempt.EventType` to `Deliver()`

**Verification:** `go test ./internal/webhook/...` passes; `X-PayGate-Event` header is now set on retries.

---

### DEF-002 · P2 · Reconciliation `checked_count` stored as 2× mismatch count

**File:** `internal/recon/worker.go:170`

**Root cause:** The payment-ledger check query uses a `HAVING` filter that returns **only** mismatched rows. `checkedCount` was incremented once per returned row, so `checkedCount == len(mismatches)` always. Passing `checkedCount+len(mismatches)` stored double the mismatch count in `recon_batches.checked_count`.

**Fix:** Changed `checkedCount+len(mismatches)` → `checkedCount`.

**Verification:** `go test ./internal/recon/...`; the `checked_count` column now reflects the mismatch count without duplication.

---

### DEF-003 · P2 · Outbox relay leaks Kafka writer on graceful shutdown

**File:** `internal/outbox/relay.go:Start()`

**Root cause:** When the context was cancelled `Start()` returned immediately without calling `r.publisher.Close()`, leaving the Kafka writer's goroutines and TCP connections open indefinitely.

**Fix:** Added `defer func() { _ = r.publisher.Close() }()` at the start of `Start()`.

**Verification:** `go build ./internal/outbox/...` passes.

---

### DEF-004 · P2 · Risk alert goroutine inherits HTTP request context

**File:** `internal/risk/service.go:87`

**Root cause:** `go s.alertFn(ctx, ev)` passed the HTTP request-scoped context into the goroutine. When the handler returned and the request completed, `ctx` was cancelled, aborting any I/O the alert function was performing (e.g. writing to a Slack webhook or database).

**Fix:** Changed to `go s.alertFn(context.WithoutCancel(ctx), ev)`. This preserves trace/value propagation while decoupling the goroutine's lifetime from the request.

**Verification:** `go test ./internal/risk/...` passes; lint clean.

---

### DEF-005 · P2 · Risk velocity counter keyed on `host:port` instead of `host`

**File:** `internal/payment/handler.go:75`

**Root cause:** `r.RemoteAddr` is `"host:port"` format. Without stripping the port, direct connections (no `X-Forwarded-For`) created velocity counter keys like `"127.0.0.1:54321"` — one per ephemeral port — allowing the same client to bypass per-IP rate limits by opening new connections.

**Fix:** After the `X-Forwarded-For` check, added `net.SplitHostPort(ip)` fallback to extract just the host.

**Verification:** `go build ./internal/payment/...` passes; lint clean.

---

## Test plan
- [x] `go build ./...` — zero errors
- [x] `go test ./...` — all unit tests pass
- [x] `golangci-lint run` — 0 issues
- [ ] Integration tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)