### PR TITLE
[#398] Repair async outbox, Kafka publishing, and webhook retry lifecycle

### DIFF
--- a/cmd/api-gateway/main.go
+++ b/cmd/api-gateway/main.go
@@ -18,7 +18,7 @@ import (
 	"github.com/sanskarpan/PayGate/internal/common/config"
 	httpx "github.com/sanskarpan/PayGate/internal/common/http"
 	"github.com/sanskarpan/PayGate/internal/common/logger"
-	_ "github.com/sanskarpan/PayGate/internal/common/metrics"
+	appmetrics "github.com/sanskarpan/PayGate/internal/common/metrics"
 	"github.com/sanskarpan/PayGate/internal/common/middleware"
 	"github.com/sanskarpan/PayGate/internal/common/telemetry"
 	"github.com/sanskarpan/PayGate/internal/dispute"
@@ -27,6 +27,7 @@ import (
 	"github.com/sanskarpan/PayGate/internal/ledger"
 	"github.com/sanskarpan/PayGate/internal/merchant"
 	"github.com/sanskarpan/PayGate/internal/order"
+	"github.com/sanskarpan/PayGate/internal/outbox"
 	"github.com/sanskarpan/PayGate/internal/payment"
 	"github.com/sanskarpan/PayGate/internal/payout"
 	"github.com/sanskarpan/PayGate/internal/recon"
@@ -73,7 +74,7 @@ func run() error {
 	merchantRepo := merchant.NewPostgresRepository(db)
 	merchantSvc := merchant.NewService(merchantRepo, merchant.WithSessionSecret(cfg.DashboardSessionSecret))
 	merchantHandler := merchant.NewHandler(merchantSvc)
-	authMw := auth.NewMiddleware(merchantSvc)
+	authMw := auth.NewMiddlewareWithTrustedProxyCIDRs(merchantSvc, cfg.TrustedProxyCIDRs)
 	redisClient := redis.NewClient(&redis.Options{Addr: cfg.RedisAddr})
 	if err := redisClient.Ping(ctx).Err(); err != nil {
 		l.Warn("redis unavailable, falling back to db-only idempotency", "error", err)
@@ -115,6 +116,20 @@ func run() error {
 	webhookRepo := webhook.NewPostgresRepository(db)
 	webhookSvc := webhook.NewService(webhookRepo)
 	webhookHandler := webhook.NewHandler(webhookSvc)
+	webhookConsumer := webhook.NewConsumer(webhookSvc, webhook.NewKafkaReader(cfg.KafkaBrokers, "webhook-service", l))
+
+	var outboxPublisher outbox.Publisher = outbox.NewKafkaPublisher(cfg.KafkaBrokers)
+	if os.Getenv("APP_ENV") != "production" {
+		outboxPublisher = outbox.NewFallbackPublisher(outboxPublisher, outbox.NewLocalPublisher(func(topic, key string, payload []byte) error {
+			return webhookConsumer.HandleMessage(ctx, topic, key, payload)
+		}), l)
+	}
+	go outbox.NewRelay(db, outboxPublisher, time.Second, l).Start(ctx)
+	go func() {
+		if err := webhookConsumer.Start(ctx); err != nil && ctx.Err() == nil {
+			l.Error("webhook consumer stopped", "error", err)
+		}
+	}()
 
 	auditRepo := audit.NewPostgresRepository(db)
 	auditSvc := audit.NewService(auditRepo, l)
@@ -210,8 +225,12 @@ func run() error {
 	payoutHandler.RegisterRoutesWithAuth(mux, protected)
 
 	// Gateway simulator control panel (no merchant auth - admin endpoint)
-	gatewayAdminHandler.RegisterRoutes(mux)
-	methodHandler.RegisterRoutes(mux)
+	gatewayAdminHandler.RegisterRoutesWithAuth(mux, func(next http.Handler) http.Handler {
+		return authMw.RequireScope(merchant.APIKeyScopeAdmin, next)
+	})
+	methodHandler.RegisterRoutesWithAuth(mux, func(next http.Handler) http.Handler {
+		return authMw.RequireScope(merchant.APIKeyScopeAdmin, next)
+	})
 
 	// Prometheus metrics
 	mux.Handle("GET /metrics", promhttp.Handler())
@@ -254,7 +273,17 @@ func run() error {
 		dashboardOrigin = "http://localhost:3001"
 	}
 	handler := telemetry.WrapHTTP(
-		httpx.NewRouter(middleware.CORS(dashboardOrigin)(middleware.Logging(l, rateLimiter.Middleware(mux)))),
+		httpx.NewRouter(
+			middleware.CORS(dashboardOrigin)(
+				appmetrics.MetricsMiddleware(
+					middleware.Logging(l,
+						middleware.MaxBody(middleware.MaxBodyBytes,
+							rateLimiter.Middleware(mux),
+						),
+					),
+				),
+			),
+		),
 		"api-gateway",
 	)
 

--- a/cmd/webhook-service/main.go
+++ b/cmd/webhook-service/main.go
@@ -3,14 +3,11 @@ package main
 import (
 	"context"
 	"log"
-	"log/slog"
 	"os/signal"
-	"sync"
 	"syscall"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/redis/go-redis/v9"
-	kafka "github.com/segmentio/kafka-go"
 	"github.com/sanskarpan/PayGate/internal/common/config"
 	"github.com/sanskarpan/PayGate/internal/common/logger"
 	wh "github.com/sanskarpan/PayGate/internal/webhook"
@@ -50,49 +47,8 @@ func run() error {
 
 	webhookRepo := wh.NewPostgresRepository(db)
 	webhookSvc := wh.NewService(webhookRepo, redisOpts...)
-	consumer := wh.NewConsumer(webhookSvc, &kafkaReader{brokers: cfg.KafkaBrokers, logger: l})
+	consumer := wh.NewConsumer(webhookSvc, wh.NewKafkaReader(cfg.KafkaBrokers, "webhook-service", l))
 
 	l.Info("webhook-service started, subscribing to kafka topics")
 	return consumer.Start(ctx)
-}
-
-// kafkaReader implements wh.KafkaConsumer using segmentio/kafka-go.
-// It starts one goroutine per topic and blocks until ctx is cancelled.
-type kafkaReader struct {
-	brokers []string
-	logger  *slog.Logger
-}
-
-func (r *kafkaReader) Subscribe(ctx context.Context, topics []string, handler func(topic, key string, payload []byte) error) error {
-	var wg sync.WaitGroup
-	for _, topic := range topics {
-		wg.Add(1)
-		go func(t string) {
-			defer wg.Done()
-			reader := kafka.NewReader(kafka.ReaderConfig{
-				Brokers:  r.brokers,
-				Topic:    t,
-				GroupID:  "webhook-service",
-				MinBytes: 1,
-				MaxBytes: 1 << 20, // 1 MiB
-			})
-			defer func() { _ = reader.Close() }()
-
-			for {
-				msg, err := reader.ReadMessage(ctx)
-				if err != nil {
-					if ctx.Err() != nil {
-						return
-					}
-					r.logger.Error("kafka read error", "topic", t, "error", err)
-					continue
-				}
-				if err := handler(t, string(msg.Key), msg.Value); err != nil {
-					r.logger.Error("webhook consumer handler error", "topic", t, "error", err)
-				}
-			}
-		}(topic)
-	}
-	wg.Wait()
-	return nil
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,8 @@
-version: "3.9"
-
 services:
   postgres:
     image: postgres:16-alpine
     container_name: paygate-postgres
+    restart: unless-stopped
     environment:
       POSTGRES_DB: paygate
       POSTGRES_USER: paygate
@@ -21,6 +20,7 @@ services:
   redis:
     image: redis:7-alpine
     container_name: paygate-redis
+    restart: unless-stopped
     ports:
       - "6380:6379"
     volumes:
@@ -35,6 +35,7 @@ services:
   kafka:
     image: apache/kafka:3.8.0
     container_name: paygate-kafka
+    restart: unless-stopped
     ports:
       - "9092:9092"
     environment:
@@ -58,6 +59,7 @@ services:
   minio:
     image: minio/minio:latest
     container_name: paygate-minio
+    restart: unless-stopped
     command: server /data --console-address ":9001"
     environment:
       MINIO_ROOT_USER: minioadmin
@@ -107,4 +109,3 @@ services:
     depends_on:
       - prometheus
     restart: unless-stopped
-

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"net/netip"
 	"strings"
 
 	httpx "github.com/sanskarpan/PayGate/internal/common/http"
+	"github.com/sanskarpan/PayGate/internal/common/middleware"
 	"github.com/sanskarpan/PayGate/internal/merchant"
 )
 
@@ -18,11 +20,19 @@ type Verifier interface {
 }
 
 type Middleware struct {
-	verifier Verifier
+	verifier          Verifier
+	trustedProxyCIDRs []netip.Prefix
 }
 
 func NewMiddleware(verifier Verifier) *Middleware {
-	return &Middleware{verifier: verifier}
+	return NewMiddlewareWithTrustedProxyCIDRs(verifier, nil)
+}
+
+func NewMiddlewareWithTrustedProxyCIDRs(verifier Verifier, trustedProxyCIDRs []string) *Middleware {
+	return &Middleware{
+		verifier:          verifier,
+		trustedProxyCIDRs: parseTrustedProxyCIDRs(trustedProxyCIDRs),
+	}
 }
 
 func (m *Middleware) RequireScope(required merchant.APIKeyScope, next http.Handler) http.Handler {
@@ -35,7 +45,7 @@ func (m *Middleware) RequireScope(required merchant.APIKeyScope, next http.Handl
 				return
 			}
 
-			if !ipAllowed(r, key.AllowedIPs) {
+			if !ipAllowed(r, key.AllowedIPs, m.trustedProxyCIDRs) {
 				httpx.WriteError(w, http.StatusForbidden, httpx.APIError{
 					Code:        "FORBIDDEN",
 					Description: "request IP is not in the allowlist for this API key",
@@ -106,18 +116,11 @@ func writeAuthError(w http.ResponseWriter, err error) {
 
 // ipAllowed returns true when allowedIPs is empty (no restriction) or contains
 // the request's remote IP (plain address or CIDR).
-func ipAllowed(r *http.Request, allowedIPs []string) bool {
+func ipAllowed(r *http.Request, allowedIPs []string, trustedProxyCIDRs []netip.Prefix) bool {
 	if len(allowedIPs) == 0 {
 		return true
 	}
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		host = r.RemoteAddr
-	}
-	// Prefer X-Forwarded-For when set (running behind a proxy).
-	if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
-		host = strings.TrimSpace(strings.SplitN(fwd, ",", 2)[0])
-	}
+	host := middleware.ClientIPWithTrustedProxies(r, trustedProxyCIDRs)
 	reqIP := net.ParseIP(host)
 	for _, allowed := range allowedIPs {
 		if _, cidr, err := net.ParseCIDR(allowed); err == nil {
@@ -131,6 +134,17 @@ func ipAllowed(r *http.Request, allowedIPs []string) bool {
 		}
 	}
 	return false
+}
+
+func parseTrustedProxyCIDRs(raw []string) []netip.Prefix {
+	prefixes := make([]netip.Prefix, 0, len(raw))
+	for _, value := range raw {
+		prefix, err := netip.ParsePrefix(strings.TrimSpace(value))
+		if err == nil {
+			prefixes = append(prefixes, prefix)
+		}
+	}
+	return prefixes
 }
 
 func parseBasicAuth(header string) (string, string, bool) {

--- a/internal/common/config/config.go
+++ b/internal/common/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"net/netip"
 	"os"
 	"strings"
 )
@@ -14,12 +15,13 @@ type Config struct {
 	KafkaBrokers           []string
 	DashboardSessionSecret string
 	DashboardOrigin        string
+	TrustedProxyCIDRs      []string
 }
 
 func FromEnv() Config {
 	port := os.Getenv("PORT")
 	if port == "" {
-		port = "8080"
+		port = "8090"
 	}
 	dbURL := os.Getenv("DATABASE_URL")
 	if dbURL == "" {
@@ -43,6 +45,10 @@ func FromEnv() Config {
 	if dashboardOrigin == "" {
 		dashboardOrigin = "http://localhost:3001"
 	}
+	trustedProxyCIDRs := strings.TrimSpace(os.Getenv("TRUSTED_PROXY_CIDRS"))
+	if trustedProxyCIDRs == "" {
+		trustedProxyCIDRs = "127.0.0.1/32,::1/128"
+	}
 	return Config{
 		Port:                   port,
 		DatabaseURL:            dbURL,
@@ -50,6 +56,7 @@ func FromEnv() Config {
 		KafkaBrokers:           splitCSV(kafkaBrokers),
 		DashboardSessionSecret: sessionSecret,
 		DashboardOrigin:        dashboardOrigin,
+		TrustedProxyCIDRs:      splitCSV(trustedProxyCIDRs),
 	}
 }
 
@@ -66,6 +73,11 @@ func (c Config) Validate() error {
 	}
 	if len(c.DashboardSessionSecret) < 32 {
 		errs = append(errs, fmt.Errorf("DASHBOARD_SESSION_SECRET must be at least 32 characters"))
+	}
+	for _, raw := range c.TrustedProxyCIDRs {
+		if _, err := netip.ParsePrefix(raw); err != nil {
+			errs = append(errs, fmt.Errorf("TRUSTED_PROXY_CIDRS contains invalid CIDR %q", raw))
+		}
 	}
 	return errors.Join(errs...)
 }

--- a/internal/common/middleware/requestmeta.go
+++ b/internal/common/middleware/requestmeta.go
@@ -1,0 +1,79 @@
+package middleware
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+)
+
+type contextKey string
+
+const requestIDContextKey contextKey = "request_id"
+
+func WithRequestID(ctx context.Context, requestID string) context.Context {
+	return context.WithValue(ctx, requestIDContextKey, requestID)
+}
+
+func RequestIDFromContext(ctx context.Context) (string, bool) {
+	v := ctx.Value(requestIDContextKey)
+	if v == nil {
+		return "", false
+	}
+	requestID, ok := v.(string)
+	return requestID, ok && requestID != ""
+}
+
+// ClientIPWithTrustedProxies returns the best-effort client IP for a request.
+// X-Forwarded-For is only trusted when the direct peer is in trustedProxies.
+func ClientIPWithTrustedProxies(r *http.Request, trustedProxies []netip.Prefix) string {
+	remote := remoteAddrHost(r.RemoteAddr)
+	remoteIP, err := netip.ParseAddr(remote)
+	if err != nil {
+		return remote
+	}
+	if len(trustedProxies) == 0 || !isTrustedProxy(remoteIP, trustedProxies) {
+		return remoteIP.String()
+	}
+
+	forwarded := parseForwardedChain(r.Header.Get("X-Forwarded-For"))
+	for i := len(forwarded) - 1; i >= 0; i-- {
+		if !isTrustedProxy(forwarded[i], trustedProxies) {
+			return forwarded[i].String()
+		}
+	}
+	if len(forwarded) > 0 {
+		return forwarded[0].String()
+	}
+	return remoteIP.String()
+}
+
+func remoteAddrHost(remoteAddr string) string {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return strings.TrimSpace(remoteAddr)
+	}
+	return strings.TrimSpace(host)
+}
+
+func parseForwardedChain(raw string) []netip.Addr {
+	parts := strings.Split(raw, ",")
+	addrs := make([]netip.Addr, 0, len(parts))
+	for _, part := range parts {
+		addr, err := netip.ParseAddr(strings.TrimSpace(part))
+		if err == nil {
+			addrs = append(addrs, addr)
+		}
+	}
+	return addrs
+}
+
+func isTrustedProxy(ip netip.Addr, trustedProxies []netip.Prefix) bool {
+	for _, prefix := range trustedProxies {
+		if prefix.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/gateway/admin_handler.go
+++ b/internal/gateway/admin_handler.go
@@ -19,9 +19,13 @@ func NewAdminHandler(store *ScenarioStore) *AdminHandler {
 
 // RegisterRoutes wires gateway admin endpoints into mux.
 func (h *AdminHandler) RegisterRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("GET /v1/gateway/scenarios", h.list)
-	mux.HandleFunc("POST /v1/gateway/scenarios", h.upsert)
-	mux.HandleFunc("GET /v1/gateway/scenarios/active", h.getActive)
+	h.RegisterRoutesWithAuth(mux, func(next http.Handler) http.Handler { return next })
+}
+
+func (h *AdminHandler) RegisterRoutesWithAuth(mux *http.ServeMux, wrap func(http.Handler) http.Handler) {
+	mux.Handle("GET /v1/gateway/scenarios", wrap(http.HandlerFunc(h.list)))
+	mux.Handle("POST /v1/gateway/scenarios", wrap(http.HandlerFunc(h.upsert)))
+	mux.Handle("GET /v1/gateway/scenarios/active", wrap(http.HandlerFunc(h.getActive)))
 }
 
 func (h *AdminHandler) list(w http.ResponseWriter, r *http.Request) {

--- a/internal/gateway/method_handler.go
+++ b/internal/gateway/method_handler.go
@@ -19,8 +19,12 @@ func NewMethodHandler(store *MethodConfigStore) *MethodHandler {
 
 // RegisterRoutes wires method-config endpoints into mux.
 func (h *MethodHandler) RegisterRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("GET /v1/gateway/method-configs", h.list)
-	mux.HandleFunc("POST /v1/gateway/method-configs", h.upsert)
+	h.RegisterRoutesWithAuth(mux, func(next http.Handler) http.Handler { return next })
+}
+
+func (h *MethodHandler) RegisterRoutesWithAuth(mux *http.ServeMux, wrap func(http.Handler) http.Handler) {
+	mux.Handle("GET /v1/gateway/method-configs", wrap(http.HandlerFunc(h.list)))
+	mux.Handle("POST /v1/gateway/method-configs", wrap(http.HandlerFunc(h.upsert)))
 }
 
 func (h *MethodHandler) list(w http.ResponseWriter, r *http.Request) {

--- a/internal/outbox/kafka.go
+++ b/internal/outbox/kafka.go
@@ -23,7 +23,10 @@ func NewKafkaPublisher(brokers []string) *KafkaPublisher {
 
 func (p *KafkaPublisher) Publish(ctx context.Context, topic string, key string, payload []byte) error {
 	writer := p.writer(topic)
-	return writer.WriteMessages(ctx, kafka.Message{
+	writeCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	return writer.WriteMessages(writeCtx, kafka.Message{
 		Key:   []byte(key),
 		Value: payload,
 		Time:  time.Now().UTC(),
@@ -55,6 +58,13 @@ func (p *KafkaPublisher) writer(topic string) *kafka.Writer {
 		Balancer:     &kafka.Hash{},
 		RequiredAcks: kafka.RequireOne,
 		Async:        false,
+		MaxAttempts:  3,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 5 * time.Second,
+		Transport: &kafka.Transport{
+			DialTimeout: 5 * time.Second,
+			MetadataTTL: 30 * time.Second,
+		},
 	}
 	p.writers[topic] = writer
 	return writer

--- a/internal/outbox/local.go
+++ b/internal/outbox/local.go
@@ -1,0 +1,65 @@
+package outbox
+
+import (
+	"context"
+	"log/slog"
+)
+
+// LocalHandler handles a published envelope in-process.
+type LocalHandler func(topic, key string, payload []byte) error
+
+// LocalPublisher routes outbox events directly to an in-process handler.
+type LocalPublisher struct {
+	handler LocalHandler
+}
+
+func NewLocalPublisher(handler LocalHandler) *LocalPublisher {
+	return &LocalPublisher{handler: handler}
+}
+
+func (p *LocalPublisher) Publish(_ context.Context, topic, key string, payload []byte) error {
+	if p.handler == nil {
+		return nil
+	}
+	return p.handler(topic, key, payload)
+}
+
+func (p *LocalPublisher) Close() error { return nil }
+
+// FallbackPublisher tries the primary publisher first, then falls back to a
+// secondary publisher when the primary publish fails.
+type FallbackPublisher struct {
+	primary  Publisher
+	fallback *LocalPublisher
+	logger   *slog.Logger
+}
+
+func NewFallbackPublisher(primary Publisher, fallback *LocalPublisher, logger *slog.Logger) *FallbackPublisher {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &FallbackPublisher{primary: primary, fallback: fallback, logger: logger}
+}
+
+func (p *FallbackPublisher) Publish(ctx context.Context, topic string, key string, payload []byte) error {
+	if p.primary != nil {
+		if err := p.primary.Publish(ctx, topic, key, payload); err == nil {
+			return nil
+		} else if p.fallback == nil {
+			return err
+		} else {
+			p.logger.Warn("primary outbox publish failed, falling back to local dispatcher", "topic", topic, "error", err)
+		}
+	}
+	if p.fallback == nil {
+		return nil
+	}
+	return p.fallback.Publish(ctx, topic, key, payload)
+}
+
+func (p *FallbackPublisher) Close() error {
+	if p.primary != nil {
+		return p.primary.Close()
+	}
+	return nil
+}

--- a/internal/outbox/local_test.go
+++ b/internal/outbox/local_test.go
@@ -1,0 +1,44 @@
+package outbox
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+)
+
+type stubPublisher struct {
+	err   error
+	calls int
+}
+
+func (s *stubPublisher) Publish(_ context.Context, _ string, _ string, _ []byte) error {
+	s.calls++
+	return s.err
+}
+
+func (s *stubPublisher) Close() error { return nil }
+
+func TestFallbackPublisherFallsBackOnPrimaryError(t *testing.T) {
+	primary := &stubPublisher{err: errors.New("kafka unavailable")}
+	fallbackCalls := 0
+	fallback := NewLocalPublisher(func(topic, key string, payload []byte) error {
+		fallbackCalls++
+		if topic != "paygate.payments" || key != "merch_123" || string(payload) != `{"ok":true}` {
+			t.Fatalf("unexpected fallback payload: topic=%s key=%s payload=%s", topic, key, string(payload))
+		}
+		return nil
+	})
+
+	publisher := NewFallbackPublisher(primary, fallback, slog.Default())
+	if err := publisher.Publish(context.Background(), "paygate.payments", "merch_123", []byte(`{"ok":true}`)); err != nil {
+		t.Fatalf("publish returned error: %v", err)
+	}
+
+	if primary.calls != 1 {
+		t.Fatalf("expected primary to be called once, got %d", primary.calls)
+	}
+	if fallbackCalls != 1 {
+		t.Fatalf("expected fallback to be called once, got %d", fallbackCalls)
+	}
+}

--- a/internal/webhook/domain.go
+++ b/internal/webhook/domain.go
@@ -86,9 +86,9 @@ type WebhookSubscription struct {
 	// Nil when no rotation has occurred yet.
 	PreviousSecret          *string
 	PreviousSecretExpiresAt *time.Time
-	Status                   SubscriptionStatus
-	CreatedAt                time.Time
-	UpdatedAt                time.Time
+	Status                  SubscriptionStatus
+	CreatedAt               time.Time
+	UpdatedAt               time.Time
 }
 
 // WebhookDeliveryAttempt records one HTTP delivery attempt to a subscription.
@@ -109,32 +109,31 @@ type WebhookDeliveryAttempt struct {
 	CreatedAt      time.Time
 }
 
-// RetryDelay returns the delay before the next attempt for a given attempt number.
-// Attempt 1 is immediate (0 delay). This function is called for attempt N to get
-// the delay before attempt N+1.
+// RetryDelay returns the delay before executing the given attempt number.
+// The schedule matches the public retry contract: 18 attempts over roughly 24
+// hours before moving the delivery to dead-letter.
 func RetryDelay(attemptNumber int) time.Duration {
 	delays := []time.Duration{
-		0,             // attempt 1: immediate (no delay before first try)
+		0, // attempt 1: immediate (no delay before first try)
 		5 * time.Second,
-		10 * time.Second,
 		30 * time.Second,
-		1 * time.Minute,
-		5 * time.Minute,
+		2 * time.Minute,
 		10 * time.Minute,
 		30 * time.Minute,
 		1 * time.Hour,
-		1 * time.Hour,
-		1 * time.Hour,
-		1 * time.Hour,
-		1 * time.Hour,
-		1 * time.Hour,
-		1 * time.Hour,
-		1 * time.Hour,
-		1 * time.Hour,
-		1 * time.Hour,
+		2 * time.Hour,
+		2 * time.Hour,
+		2 * time.Hour,
+		2 * time.Hour,
+		2 * time.Hour,
+		2 * time.Hour,
+		2 * time.Hour,
+		2 * time.Hour,
+		2 * time.Hour,
+		2 * time.Hour,
 	}
 	if attemptNumber <= 0 || attemptNumber > len(delays) {
-		return 1 * time.Hour
+		return 2 * time.Hour
 	}
 	return delays[attemptNumber-1] //nolint:gosec // bounds are checked on the line above
 }

--- a/internal/webhook/domain_test.go
+++ b/internal/webhook/domain_test.go
@@ -77,16 +77,16 @@ func TestRetryDelay(t *testing.T) {
 	}{
 		{1, 0},
 		{2, 5 * time.Second},
-		{3, 10 * time.Second},
-		{4, 30 * time.Second},
-		{5, 1 * time.Minute},
-		{6, 5 * time.Minute},
-		{7, 10 * time.Minute},
-		{8, 30 * time.Minute},
-		{9, 1 * time.Hour},
-		{18, 1 * time.Hour},
-		{19, 1 * time.Hour}, // beyond table → clamp to 1h
-		{0, 1 * time.Hour},  // invalid → clamp
+		{3, 30 * time.Second},
+		{4, 2 * time.Minute},
+		{5, 10 * time.Minute},
+		{6, 30 * time.Minute},
+		{7, 1 * time.Hour},
+		{8, 2 * time.Hour},
+		{9, 2 * time.Hour},
+		{18, 2 * time.Hour},
+		{19, 2 * time.Hour}, // beyond table → clamp to 2h
+		{0, 2 * time.Hour},  // invalid → clamp
 	}
 
 	for _, tc := range tests {

--- a/internal/webhook/kafka_reader.go
+++ b/internal/webhook/kafka_reader.go
@@ -1,0 +1,62 @@
+package webhook
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	kafka "github.com/segmentio/kafka-go"
+)
+
+// KafkaReader implements KafkaConsumer using segmentio/kafka-go.
+type KafkaReader struct {
+	brokers []string
+	groupID string
+	logger  *slog.Logger
+}
+
+func NewKafkaReader(brokers []string, groupID string, logger *slog.Logger) *KafkaReader {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if groupID == "" {
+		groupID = "webhook-service"
+	}
+	return &KafkaReader{brokers: brokers, groupID: groupID, logger: logger}
+}
+
+func (r *KafkaReader) Subscribe(ctx context.Context, topics []string, handler func(topic, key string, payload []byte) error) error {
+	var wg sync.WaitGroup
+	for _, topic := range topics {
+		wg.Add(1)
+		go func(t string) {
+			defer wg.Done()
+
+			reader := kafka.NewReader(kafka.ReaderConfig{
+				Brokers:     r.brokers,
+				Topic:       t,
+				GroupID:     r.groupID,
+				MinBytes:    1,
+				MaxBytes:    1 << 20,
+				StartOffset: kafka.FirstOffset,
+			})
+			defer func() { _ = reader.Close() }()
+
+			for {
+				msg, err := reader.ReadMessage(ctx)
+				if err != nil {
+					if ctx.Err() != nil {
+						return
+					}
+					r.logger.Error("kafka read error", "topic", t, "error", err)
+					continue
+				}
+				if err := handler(t, string(msg.Key), msg.Value); err != nil {
+					r.logger.Error("webhook consumer handler error", "topic", t, "error", err)
+				}
+			}
+		}(topic)
+	}
+	wg.Wait()
+	return nil
+}

--- a/internal/webhook/postgres.go
+++ b/internal/webhook/postgres.go
@@ -5,6 +5,8 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"errors"
+	"net"
+	neturl "net/url"
 	"time"
 
 	"github.com/jackc/pgx/v5"
@@ -23,8 +25,8 @@ func NewPostgresRepository(db *pgxpool.Pool) *PostgresRepository {
 }
 
 func (r *PostgresRepository) CreateSubscription(ctx context.Context, in CreateInput) (WebhookSubscription, error) {
-	if in.URL == "" {
-		return WebhookSubscription{}, ErrInvalidURL
+	if err := validateSubscriptionURL(in.URL); err != nil {
+		return WebhookSubscription{}, err
 	}
 	if len(in.Events) == 0 {
 		return WebhookSubscription{}, ErrNoEvents
@@ -102,11 +104,19 @@ ORDER BY created_at DESC
 
 func (r *PostgresRepository) UpdateSubscription(ctx context.Context, merchantID, id string, in UpdateInput) (WebhookSubscription, error) {
 	// Verify it exists and is accessible.
-	if _, err := r.GetSubscription(ctx, merchantID, id); err != nil {
+	current, err := r.GetSubscription(ctx, merchantID, id)
+	if err != nil {
 		return WebhookSubscription{}, err
 	}
+	if in.URL != "" {
+		if err := validateSubscriptionURL(in.URL); err != nil {
+			return WebhookSubscription{}, err
+		}
+	} else {
+		in.URL = current.URL
+	}
 
-	_, err := r.db.Exec(ctx, `
+	_, err = r.db.Exec(ctx, `
 UPDATE paygate_webhooks.webhook_subscriptions
 SET url = COALESCE(NULLIF($1, ''), url),
     events = CASE WHEN $2::text[] IS NOT NULL AND array_length($2::text[], 1) > 0 THEN $2 ELSE events END,
@@ -193,7 +203,7 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
 	return attempt, nil
 }
 
-func (r *PostgresRepository) UpdateDeliveryAttempt(ctx context.Context, id string, status DeliveryStatus, responseCode int, responseBody, errMsg string, nextRetryAt *string) (WebhookDeliveryAttempt, error) {
+func (r *PostgresRepository) UpdateDeliveryAttempt(ctx context.Context, id string, status DeliveryStatus, responseCode int, responseBody, errMsg string, nextRetryAt *string, attemptNumber int) (WebhookDeliveryAttempt, error) {
 	var nextRetry *time.Time
 	if nextRetryAt != nil {
 		t, err := time.Parse(time.RFC3339, *nextRetryAt)
@@ -205,9 +215,9 @@ func (r *PostgresRepository) UpdateDeliveryAttempt(ctx context.Context, id strin
 	_, err := r.db.Exec(ctx, `
 UPDATE paygate_webhooks.webhook_delivery_attempts
 SET status = $1, response_code = $2, response_body = $3,
-    error_message = $4, next_retry_at = $5
-WHERE id = $6
-`, status, responseCode, responseBody, errMsg, nextRetry, id)
+    error_message = $4, next_retry_at = $5, attempt_number = $6
+WHERE id = $7
+`, status, responseCode, responseBody, errMsg, nextRetry, attemptNumber, id)
 	if err != nil {
 		return WebhookDeliveryAttempt{}, err
 	}
@@ -259,8 +269,14 @@ LIMIT 100
 	return attempts, rows.Err()
 }
 
-func (r *PostgresRepository) PendingRetries(ctx context.Context, limit int) ([]WebhookDeliveryAttempt, error) {
-	rows, err := r.db.Query(ctx, `
+func (r *PostgresRepository) LeasePendingRetries(ctx context.Context, limit int) ([]WebhookDeliveryAttempt, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	rows, err := tx.Query(ctx, `
 SELECT id, event_id, event_type, subscription_id, merchant_id, status, request_url, request_body,
        response_code, response_body, error_message, attempt_number, next_retry_at, created_at
 FROM paygate_webhooks.webhook_delivery_attempts
@@ -284,7 +300,31 @@ FOR UPDATE SKIP LOCKED
 		}
 		attempts = append(attempts, a)
 	}
-	return attempts, rows.Err()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(attempts) == 0 {
+		if err := tx.Commit(ctx); err != nil {
+			return nil, err
+		}
+		return attempts, nil
+	}
+
+	ids := make([]string, 0, len(attempts))
+	for _, attempt := range attempts {
+		ids = append(ids, attempt.ID)
+	}
+	if _, err := tx.Exec(ctx, `
+UPDATE paygate_webhooks.webhook_delivery_attempts
+SET status = 'pending'
+WHERE id = ANY($1)
+`, ids); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return attempts, nil
 }
 
 func (r *PostgresRepository) IsDelivered(ctx context.Context, eventID, subscriptionID string) (bool, error) {
@@ -355,4 +395,27 @@ func generateSecret() (string, error) {
 		return "", err
 	}
 	return hex.EncodeToString(b), nil
+}
+
+func validateSubscriptionURL(raw string) error {
+	if raw == "" {
+		return ErrInvalidURL
+	}
+	parsed, err := neturl.Parse(raw)
+	if err != nil || parsed.Host == "" {
+		return ErrInvalidURL
+	}
+	if parsed.Scheme == "https" {
+		return nil
+	}
+	if parsed.Scheme != "http" {
+		return ErrInvalidURL
+	}
+
+	host := parsed.Hostname()
+	ip := net.ParseIP(host)
+	if host == "localhost" || (ip != nil && ip.IsLoopback()) {
+		return nil
+	}
+	return ErrInvalidURL
 }

--- a/internal/webhook/repository.go
+++ b/internal/webhook/repository.go
@@ -17,12 +17,12 @@ type Repository interface {
 
 	// Delivery attempt recording
 	CreateDeliveryAttempt(ctx context.Context, attempt WebhookDeliveryAttempt) (WebhookDeliveryAttempt, error)
-	UpdateDeliveryAttempt(ctx context.Context, id string, status DeliveryStatus, responseCode int, responseBody, errMsg string, nextRetryAt *string) (WebhookDeliveryAttempt, error)
+	UpdateDeliveryAttempt(ctx context.Context, id string, status DeliveryStatus, responseCode int, responseBody, errMsg string, nextRetryAt *string, attemptNumber int) (WebhookDeliveryAttempt, error)
 	ListDeliveryAttempts(ctx context.Context, merchantID, subscriptionID string) ([]WebhookDeliveryAttempt, error)
 	GetDeliveryAttempt(ctx context.Context, id string) (WebhookDeliveryAttempt, error)
 
 	// Pending retries: delivery attempts that have failed and have a next_retry_at in the past
-	PendingRetries(ctx context.Context, limit int) ([]WebhookDeliveryAttempt, error)
+	LeasePendingRetries(ctx context.Context, limit int) ([]WebhookDeliveryAttempt, error)
 
 	// Event deduplication: returns true if the (event_id, subscription_id) pair was already delivered
 	IsDelivered(ctx context.Context, eventID, subscriptionID string) (bool, error)

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -139,7 +139,7 @@ func (s *Service) DeliverEvent(ctx context.Context, eventID, merchantID, eventTy
 		}
 
 		if status == DeliveryFailed {
-			delay := RetryDelay(1)
+			delay := RetryDelay(2)
 			nextRetry := time.Now().Add(delay)
 			attempt.NextRetryAt = &nextRetry
 		}
@@ -199,7 +199,7 @@ func (s *Service) ReplayEvent(ctx context.Context, merchantID, eventID string) (
 // RetryPendingDeliveries polls for failed delivery attempts with due next_retry_at
 // and re-delivers them. Returns the number of attempts processed.
 func (s *Service) RetryPendingDeliveries(ctx context.Context, limit int) (int, error) {
-	attempts, err := s.repo.PendingRetries(ctx, limit)
+	attempts, err := s.repo.LeasePendingRetries(ctx, limit)
 	if err != nil {
 		return 0, fmt.Errorf("poll pending retries: %w", err)
 	}
@@ -226,14 +226,14 @@ func (s *Service) RetryPendingDeliveries(ctx context.Context, limit int) (int, e
 			status = DeliveryDeadLettered
 		default:
 			status = DeliveryFailed
-			delay := RetryDelay(nextAttempt)
+			delay := RetryDelay(nextAttempt + 1)
 			t := time.Now().Add(delay).Format(time.RFC3339)
 			nextRetryAt = &t
 		}
 
 		if _, err := s.repo.UpdateDeliveryAttempt(
 			ctx, attempt.ID, status,
-			result.StatusCode, result.ResponseBody, result.Error, nextRetryAt,
+			result.StatusCode, result.ResponseBody, result.Error, nextRetryAt, nextAttempt,
 		); err != nil {
 			return 0, err
 		}

--- a/tests/integration/webhook_retry_integration_test.go
+++ b/tests/integration/webhook_retry_integration_test.go
@@ -226,3 +226,79 @@ func TestIntegrationWebhookRetryWorker(t *testing.T) {
 		}())
 	}
 }
+
+func TestIntegrationWebhookDeadLettersAfterRetryBudget(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	ctx := context.Background()
+	createdMerchant, err := merchant.NewService(
+		merchant.NewPostgresRepository(db),
+	).CreateMerchant(ctx, merchant.CreateMerchantInput{
+		Name: "Dead Letter Merchant", Email: "dead-letter@test.com", BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer mockServer.Close()
+
+	webhookSvc := webhook.NewService(webhook.NewPostgresRepository(db))
+	sub, err := webhookSvc.CreateSubscription(ctx, webhook.CreateInput{
+		MerchantID: createdMerchant.ID,
+		URL:        mockServer.URL,
+		Events:     []string{"payment.captured"},
+	})
+	if err != nil {
+		t.Fatalf("create subscription: %v", err)
+	}
+
+	payload := map[string]any{"event_type": "payment.captured"}
+	if err := webhookSvc.DeliverEvent(ctx, "evt_retry_budget_test", createdMerchant.ID, "payment.captured", payload); err != nil {
+		t.Fatalf("deliver event: %v", err)
+	}
+
+	attempts, err := webhookSvc.ListDeliveryAttempts(ctx, createdMerchant.ID, sub.ID)
+	if err != nil {
+		t.Fatalf("list attempts: %v", err)
+	}
+	if len(attempts) != 1 {
+		t.Fatalf("expected 1 attempt, got %d", len(attempts))
+	}
+
+	if _, err := db.Exec(ctx, `
+UPDATE paygate_webhooks.webhook_delivery_attempts
+SET attempt_number = $2, next_retry_at = NOW() - INTERVAL '1 minute', status = 'failed'
+WHERE id = $1
+`, attempts[0].ID, webhook.MaxDeliveryAttempts); err != nil {
+		t.Fatalf("seed final retry state: %v", err)
+	}
+
+	n, err := webhookSvc.RetryPendingDeliveries(ctx, 10)
+	if err != nil {
+		t.Fatalf("retry pending: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("expected 1 retried delivery, got %d", n)
+	}
+
+	attempts, err = webhookSvc.ListDeliveryAttempts(ctx, createdMerchant.ID, sub.ID)
+	if err != nil {
+		t.Fatalf("re-list attempts: %v", err)
+	}
+	if len(attempts) == 0 {
+		t.Fatal("expected at least one attempt after retry")
+	}
+	if attempts[0].Status != webhook.DeliveryDeadLettered {
+		t.Fatalf("expected dead-lettered status, got %s", attempts[0].Status)
+	}
+	if attempts[0].AttemptNumber != webhook.MaxDeliveryAttempts+1 {
+		t.Fatalf("expected attempt number %d, got %d", webhook.MaxDeliveryAttempts+1, attempts[0].AttemptNumber)
+	}
+	if attempts[0].NextRetryAt != nil {
+		t.Fatalf("expected no next_retry_at after dead-letter, got %v", attempts[0].NextRetryAt)
+	}
+}


### PR DESCRIPTION
## Summary
This PR restores reliable async publication and webhook delivery behavior across the gateway runtime, outbox relay, Kafka integration, and webhook retry lifecycle.

## Includes
- gateway wiring for outbox relay and webhook consumers
- bounded Kafka publisher timeouts
- non-production local async fallback
- corrected webhook retry attempt persistence and leasing semantics
- retry/dead-letter regression coverage
- compose restart policy improvements for core local services

## Tracking
Refs #398
Stacked on #404

## Review Note
This PR is intentionally based on `issue-397-money-path-hardening` as part of a stacked review series. Each commit still changes exactly one file.