### PR TITLE
[#399] Tighten auth, request metadata, and runtime safeguards

### DIFF
--- a/internal/audit/middleware.go
+++ b/internal/audit/middleware.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	httpx "github.com/sanskarpan/PayGate/internal/common/http"
+	"github.com/sanskarpan/PayGate/internal/common/middleware"
 )
 
 // Middleware returns an http.Handler wrapper that records an audit log entry
@@ -41,13 +42,11 @@ func (s *Service) Middleware(next http.Handler) http.Handler {
 		resourceType, resourceID := extractResource(r.URL.Path)
 		action := r.Method + " " + resourceType
 
-		// Collect remote IP; prefer X-Forwarded-For when behind a proxy.
-		ip := r.RemoteAddr
-		if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
-			ip = strings.TrimSpace(strings.SplitN(fwd, ",", 2)[0])
+		ip := middleware.ClientIPWithTrustedProxies(r, nil)
+		corrID, _ := middleware.RequestIDFromContext(r.Context())
+		if corrID == "" {
+			corrID = r.Header.Get("X-Request-Id")
 		}
-
-		corrID := r.Header.Get("X-Request-Id")
 
 		s.Record(r.Context(), RecordInput{
 			MerchantID:    p.MerchantID,

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -6,9 +6,11 @@ import (
 	"errors"
 	"net"
 	"net/http"
+	"net/netip"
 	"strings"
 
 	httpx "github.com/sanskarpan/PayGate/internal/common/http"
+	"github.com/sanskarpan/PayGate/internal/common/middleware"
 	"github.com/sanskarpan/PayGate/internal/merchant"
 )
 
@@ -18,11 +20,19 @@ type Verifier interface {
 }
 
 type Middleware struct {
-	verifier Verifier
+	verifier          Verifier
+	trustedProxyCIDRs []netip.Prefix
 }
 
 func NewMiddleware(verifier Verifier) *Middleware {
-	return &Middleware{verifier: verifier}
+	return NewMiddlewareWithTrustedProxyCIDRs(verifier, nil)
+}
+
+func NewMiddlewareWithTrustedProxyCIDRs(verifier Verifier, trustedProxyCIDRs []string) *Middleware {
+	return &Middleware{
+		verifier:          verifier,
+		trustedProxyCIDRs: parseTrustedProxyCIDRs(trustedProxyCIDRs),
+	}
 }
 
 func (m *Middleware) RequireScope(required merchant.APIKeyScope, next http.Handler) http.Handler {
@@ -35,7 +45,7 @@ func (m *Middleware) RequireScope(required merchant.APIKeyScope, next http.Handl
 				return
 			}
 
-			if !ipAllowed(r, key.AllowedIPs) {
+			if !ipAllowed(r, key.AllowedIPs, m.trustedProxyCIDRs) {
 				httpx.WriteError(w, http.StatusForbidden, httpx.APIError{
 					Code:        "FORBIDDEN",
 					Description: "request IP is not in the allowlist for this API key",
@@ -106,18 +116,11 @@ func writeAuthError(w http.ResponseWriter, err error) {
 
 // ipAllowed returns true when allowedIPs is empty (no restriction) or contains
 // the request's remote IP (plain address or CIDR).
-func ipAllowed(r *http.Request, allowedIPs []string) bool {
+func ipAllowed(r *http.Request, allowedIPs []string, trustedProxyCIDRs []netip.Prefix) bool {
 	if len(allowedIPs) == 0 {
 		return true
 	}
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		host = r.RemoteAddr
-	}
-	// Prefer X-Forwarded-For when set (running behind a proxy).
-	if fwd := r.Header.Get("X-Forwarded-For"); fwd != "" {
-		host = strings.TrimSpace(strings.SplitN(fwd, ",", 2)[0])
-	}
+	host := middleware.ClientIPWithTrustedProxies(r, trustedProxyCIDRs)
 	reqIP := net.ParseIP(host)
 	for _, allowed := range allowedIPs {
 		if _, cidr, err := net.ParseCIDR(allowed); err == nil {
@@ -131,6 +134,17 @@ func ipAllowed(r *http.Request, allowedIPs []string) bool {
 		}
 	}
 	return false
+}
+
+func parseTrustedProxyCIDRs(raw []string) []netip.Prefix {
+	prefixes := make([]netip.Prefix, 0, len(raw))
+	for _, value := range raw {
+		prefix, err := netip.ParsePrefix(strings.TrimSpace(value))
+		if err == nil {
+			prefixes = append(prefixes, prefix)
+		}
+	}
+	return prefixes
 }
 
 func parseBasicAuth(header string) (string, string, bool) {

--- a/internal/auth/middleware_test.go
+++ b/internal/auth/middleware_test.go
@@ -61,3 +61,53 @@ func TestRequireScopeSuccess(t *testing.T) {
 		t.Fatalf("expected 200, got %d", rr.Code)
 	}
 }
+
+func TestRequireScopeRejectsSpoofedForwardedForWhenProxyUntrusted(t *testing.T) {
+	m := NewMiddleware(fakeVerifier{ret: merchant.APIKey{
+		ID:         "rzp_test_x",
+		MerchantID: "merch_x",
+		Scope:      merchant.APIKeyScopeRead,
+		AllowedIPs: []string{"203.0.113.10"},
+	}})
+	h := m.RequireScope(merchant.APIKeyScopeRead, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	token := base64.StdEncoding.EncodeToString([]byte("rzp_test_x:secret"))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Basic "+token)
+	req.Header.Set("X-Forwarded-For", "203.0.113.10")
+	req.RemoteAddr = "198.51.100.7:4321"
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", rr.Code)
+	}
+}
+
+func TestRequireScopeUsesForwardedForFromTrustedProxy(t *testing.T) {
+	m := NewMiddlewareWithTrustedProxyCIDRs(fakeVerifier{ret: merchant.APIKey{
+		ID:         "rzp_test_x",
+		MerchantID: "merch_x",
+		Scope:      merchant.APIKeyScopeRead,
+		AllowedIPs: []string{"203.0.113.10"},
+	}}, []string{"127.0.0.1/32"})
+	h := m.RequireScope(merchant.APIKeyScopeRead, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	token := base64.StdEncoding.EncodeToString([]byte("rzp_test_x:secret"))
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	req.Header.Set("Authorization", "Basic "+token)
+	req.Header.Set("X-Forwarded-For", "203.0.113.10")
+	req.RemoteAddr = "127.0.0.1:4321"
+
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+}

--- a/internal/common/config/config.go
+++ b/internal/common/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"net/netip"
 	"os"
 	"strings"
 )
@@ -14,12 +15,13 @@ type Config struct {
 	KafkaBrokers           []string
 	DashboardSessionSecret string
 	DashboardOrigin        string
+	TrustedProxyCIDRs      []string
 }
 
 func FromEnv() Config {
 	port := os.Getenv("PORT")
 	if port == "" {
-		port = "8080"
+		port = "8090"
 	}
 	dbURL := os.Getenv("DATABASE_URL")
 	if dbURL == "" {
@@ -43,6 +45,10 @@ func FromEnv() Config {
 	if dashboardOrigin == "" {
 		dashboardOrigin = "http://localhost:3001"
 	}
+	trustedProxyCIDRs := strings.TrimSpace(os.Getenv("TRUSTED_PROXY_CIDRS"))
+	if trustedProxyCIDRs == "" {
+		trustedProxyCIDRs = "127.0.0.1/32,::1/128"
+	}
 	return Config{
 		Port:                   port,
 		DatabaseURL:            dbURL,
@@ -50,6 +56,7 @@ func FromEnv() Config {
 		KafkaBrokers:           splitCSV(kafkaBrokers),
 		DashboardSessionSecret: sessionSecret,
 		DashboardOrigin:        dashboardOrigin,
+		TrustedProxyCIDRs:      splitCSV(trustedProxyCIDRs),
 	}
 }
 
@@ -66,6 +73,11 @@ func (c Config) Validate() error {
 	}
 	if len(c.DashboardSessionSecret) < 32 {
 		errs = append(errs, fmt.Errorf("DASHBOARD_SESSION_SECRET must be at least 32 characters"))
+	}
+	for _, raw := range c.TrustedProxyCIDRs {
+		if _, err := netip.ParsePrefix(raw); err != nil {
+			errs = append(errs, fmt.Errorf("TRUSTED_PROXY_CIDRS contains invalid CIDR %q", raw))
+		}
 	}
 	return errors.Join(errs...)
 }

--- a/internal/common/http/context.go
+++ b/internal/common/http/context.go
@@ -4,7 +4,9 @@ import "context"
 
 type ctxKey string
 
-const principalCtxKey ctxKey = "principal"
+const (
+	principalCtxKey ctxKey = "principal"
+)
 
 type Principal struct {
 	MerchantID string

--- a/internal/common/middleware/logging.go
+++ b/internal/common/middleware/logging.go
@@ -45,13 +45,14 @@ func Logging(logger *slog.Logger, next http.Handler) http.Handler {
 		}
 
 		next.ServeHTTP(rec, r)
+		requestID, _ := RequestIDFromContext(r.Context())
 		logger.Info("http_request",
 			"method", r.Method,
 			"path", r.URL.Path,
 			"status", rec.status,
 			"duration_ms", time.Since(start).Milliseconds(),
+			"request_id", requestID,
 			"request_body", scrubbed,
 		)
 	})
 }
-

--- a/internal/common/middleware/ratelimit.go
+++ b/internal/common/middleware/ratelimit.go
@@ -4,23 +4,41 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"math"
 	"net"
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"golang.org/x/time/rate"
 )
 
+type clientLimiter struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
 type RateLimiter struct {
-	mu      sync.Mutex
-	clients map[string]*rate.Limiter
-	r       rate.Limit
-	burst   int
+	mu              sync.Mutex
+	clients         map[string]*clientLimiter
+	r               rate.Limit
+	burst           int
+	idleTTL         time.Duration
+	cleanupInterval time.Duration
+	lastCleanup     time.Time
 }
 
 func NewRateLimiter(rps float64, burst int) *RateLimiter {
-	return &RateLimiter{clients: map[string]*rate.Limiter{}, r: rate.Limit(rps), burst: burst}
+	now := time.Now()
+	return &RateLimiter{
+		clients:         map[string]*clientLimiter{},
+		r:               rate.Limit(rps),
+		burst:           burst,
+		idleTTL:         15 * time.Minute,
+		cleanupInterval: time.Minute,
+		lastCleanup:     now,
+	}
 }
 
 func (rl *RateLimiter) Middleware(next http.Handler) http.Handler {
@@ -30,11 +48,13 @@ func (rl *RateLimiter) Middleware(next http.Handler) http.Handler {
 		if !limiter.Allow() {
 			w.Header().Set("Retry-After", "1")
 			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-RateLimit-Remaining", "0")
 			w.WriteHeader(http.StatusTooManyRequests)
 			_ = json.NewEncoder(w).Encode(map[string]any{"error": map[string]any{"code": "RATE_LIMITED", "description": "too many requests"}})
 			return
 		}
 		w.Header().Set("X-RateLimit-Limit", fmt.Sprintf("%.0f", float64(rl.r)))
+		w.Header().Set("X-RateLimit-Remaining", fmt.Sprintf("%d", maxInt(0, int(math.Floor(limiter.Tokens())))))
 		next.ServeHTTP(w, r)
 	})
 }
@@ -66,10 +86,31 @@ func (rl *RateLimiter) rateLimitKey(r *http.Request) string {
 func (rl *RateLimiter) getLimiter(key string) *rate.Limiter {
 	rl.mu.Lock()
 	defer rl.mu.Unlock()
-	limiter, ok := rl.clients[key]
-	if !ok {
-		limiter = rate.NewLimiter(rl.r, rl.burst)
-		rl.clients[key] = limiter
+	now := time.Now()
+	if now.Sub(rl.lastCleanup) >= rl.cleanupInterval {
+		rl.cleanup(now)
 	}
-	return limiter
+	client, ok := rl.clients[key]
+	if !ok {
+		client = &clientLimiter{limiter: rate.NewLimiter(rl.r, rl.burst)}
+		rl.clients[key] = client
+	}
+	client.lastSeen = now
+	return client.limiter
+}
+
+func (rl *RateLimiter) cleanup(now time.Time) {
+	for key, client := range rl.clients {
+		if now.Sub(client.lastSeen) >= rl.idleTTL {
+			delete(rl.clients, key)
+		}
+	}
+	rl.lastCleanup = now
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/internal/common/middleware/requestid.go
+++ b/internal/common/middleware/requestid.go
@@ -14,6 +14,7 @@ func RequestID(next http.Handler) http.Handler {
 		if requestID == "" {
 			requestID = idgen.New("req")
 		}
+		r = r.WithContext(WithRequestID(r.Context(), requestID))
 		w.Header().Set(requestIDHeader, requestID)
 		next.ServeHTTP(w, r)
 	})

--- a/internal/common/middleware/requestmeta.go
+++ b/internal/common/middleware/requestmeta.go
@@ -1,0 +1,79 @@
+package middleware
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"net/netip"
+	"strings"
+)
+
+type contextKey string
+
+const requestIDContextKey contextKey = "request_id"
+
+func WithRequestID(ctx context.Context, requestID string) context.Context {
+	return context.WithValue(ctx, requestIDContextKey, requestID)
+}
+
+func RequestIDFromContext(ctx context.Context) (string, bool) {
+	v := ctx.Value(requestIDContextKey)
+	if v == nil {
+		return "", false
+	}
+	requestID, ok := v.(string)
+	return requestID, ok && requestID != ""
+}
+
+// ClientIPWithTrustedProxies returns the best-effort client IP for a request.
+// X-Forwarded-For is only trusted when the direct peer is in trustedProxies.
+func ClientIPWithTrustedProxies(r *http.Request, trustedProxies []netip.Prefix) string {
+	remote := remoteAddrHost(r.RemoteAddr)
+	remoteIP, err := netip.ParseAddr(remote)
+	if err != nil {
+		return remote
+	}
+	if len(trustedProxies) == 0 || !isTrustedProxy(remoteIP, trustedProxies) {
+		return remoteIP.String()
+	}
+
+	forwarded := parseForwardedChain(r.Header.Get("X-Forwarded-For"))
+	for i := len(forwarded) - 1; i >= 0; i-- {
+		if !isTrustedProxy(forwarded[i], trustedProxies) {
+			return forwarded[i].String()
+		}
+	}
+	if len(forwarded) > 0 {
+		return forwarded[0].String()
+	}
+	return remoteIP.String()
+}
+
+func remoteAddrHost(remoteAddr string) string {
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err != nil {
+		return strings.TrimSpace(remoteAddr)
+	}
+	return strings.TrimSpace(host)
+}
+
+func parseForwardedChain(raw string) []netip.Addr {
+	parts := strings.Split(raw, ",")
+	addrs := make([]netip.Addr, 0, len(parts))
+	for _, part := range parts {
+		addr, err := netip.ParseAddr(strings.TrimSpace(part))
+		if err == nil {
+			addrs = append(addrs, addr)
+		}
+	}
+	return addrs
+}
+
+func isTrustedProxy(ip netip.Addr, trustedProxies []netip.Prefix) bool {
+	for _, prefix := range trustedProxies {
+		if prefix.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/gateway/admin_handler.go
+++ b/internal/gateway/admin_handler.go
@@ -19,9 +19,13 @@ func NewAdminHandler(store *ScenarioStore) *AdminHandler {
 
 // RegisterRoutes wires gateway admin endpoints into mux.
 func (h *AdminHandler) RegisterRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("GET /v1/gateway/scenarios", h.list)
-	mux.HandleFunc("POST /v1/gateway/scenarios", h.upsert)
-	mux.HandleFunc("GET /v1/gateway/scenarios/active", h.getActive)
+	h.RegisterRoutesWithAuth(mux, func(next http.Handler) http.Handler { return next })
+}
+
+func (h *AdminHandler) RegisterRoutesWithAuth(mux *http.ServeMux, wrap func(http.Handler) http.Handler) {
+	mux.Handle("GET /v1/gateway/scenarios", wrap(http.HandlerFunc(h.list)))
+	mux.Handle("POST /v1/gateway/scenarios", wrap(http.HandlerFunc(h.upsert)))
+	mux.Handle("GET /v1/gateway/scenarios/active", wrap(http.HandlerFunc(h.getActive)))
 }
 
 func (h *AdminHandler) list(w http.ResponseWriter, r *http.Request) {

--- a/internal/gateway/method_handler.go
+++ b/internal/gateway/method_handler.go
@@ -19,8 +19,12 @@ func NewMethodHandler(store *MethodConfigStore) *MethodHandler {
 
 // RegisterRoutes wires method-config endpoints into mux.
 func (h *MethodHandler) RegisterRoutes(mux *http.ServeMux) {
-	mux.HandleFunc("GET /v1/gateway/method-configs", h.list)
-	mux.HandleFunc("POST /v1/gateway/method-configs", h.upsert)
+	h.RegisterRoutesWithAuth(mux, func(next http.Handler) http.Handler { return next })
+}
+
+func (h *MethodHandler) RegisterRoutesWithAuth(mux *http.ServeMux, wrap func(http.Handler) http.Handler) {
+	mux.Handle("GET /v1/gateway/method-configs", wrap(http.HandlerFunc(h.list)))
+	mux.Handle("POST /v1/gateway/method-configs", wrap(http.HandlerFunc(h.upsert)))
 }
 
 func (h *MethodHandler) list(w http.ResponseWriter, r *http.Request) {

--- a/internal/payout/domain.go
+++ b/internal/payout/domain.go
@@ -25,10 +25,11 @@ const (
 )
 
 var (
-	ErrPayoutNotFound          = errors.New("payout not found")
-	ErrInvalidTransition       = errors.New("invalid payout state transition")
-	ErrPayoutAlreadyExists     = errors.New("payout already exists for this settlement")
-	ErrSettlementNotProcessed  = errors.New("settlement must be processed before initiating payout")
+	ErrPayoutNotFound         = errors.New("payout not found")
+	ErrInvalidTransition      = errors.New("invalid payout state transition")
+	ErrPayoutAlreadyExists    = errors.New("payout already exists for this settlement")
+	ErrSettlementNotProcessed = errors.New("settlement must be processed before initiating payout")
+	ErrSettlementOnHold       = errors.New("settlement is on hold")
 )
 
 // Transition returns the next PayoutState for the given event,

--- a/internal/payout/handler.go
+++ b/internal/payout/handler.go
@@ -43,6 +43,10 @@ func (h *Handler) initiate(w http.ResponseWriter, r *http.Request) {
 		handleError(w, err)
 		return
 	}
+	if sttl.OnHold {
+		handleError(w, ErrSettlementOnHold)
+		return
+	}
 
 	pout, err := h.svc.InitiatePayoutForSettlement(r.Context(), p.MerchantID, settlementID, sttl.NetAmount, sttl.Currency)
 	if err != nil {
@@ -131,6 +135,8 @@ func handleError(w http.ResponseWriter, err error) {
 		httpx.WriteError(w, http.StatusUnprocessableEntity, httpx.APIError{Code: "INVALID_STATE", Description: err.Error()})
 	case errors.Is(err, ErrSettlementNotProcessed):
 		httpx.WriteError(w, http.StatusUnprocessableEntity, httpx.APIError{Code: "SETTLEMENT_NOT_PROCESSED", Description: err.Error()})
+	case errors.Is(err, ErrSettlementOnHold):
+		httpx.WriteError(w, http.StatusConflict, httpx.APIError{Code: "SETTLEMENT_ON_HOLD", Description: err.Error()})
 	default:
 		// Check for settlement not found too.
 		var errBody struct{ Code string }

--- a/tests/integration/backend_hardening_integration_test.go
+++ b/tests/integration/backend_hardening_integration_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/sanskarpan/PayGate/internal/auth"
 	httpx "github.com/sanskarpan/PayGate/internal/common/http"
+	"github.com/sanskarpan/PayGate/internal/dispute"
 	"github.com/sanskarpan/PayGate/internal/gateway"
 	"github.com/sanskarpan/PayGate/internal/idempotency"
 	"github.com/sanskarpan/PayGate/internal/ledger"
@@ -22,6 +23,7 @@ import (
 	"github.com/sanskarpan/PayGate/internal/order"
 	"github.com/sanskarpan/PayGate/internal/outbox"
 	"github.com/sanskarpan/PayGate/internal/payment"
+	"github.com/sanskarpan/PayGate/internal/payout"
 	"github.com/sanskarpan/PayGate/internal/refund"
 	"github.com/sanskarpan/PayGate/internal/settlement"
 	"github.com/sanskarpan/PayGate/internal/webhook"
@@ -289,6 +291,8 @@ func buildGatewayMux(db *pgxpool.Pool) (*http.ServeMux, *merchant.Service, *orde
 	refundSvc := refund.NewService(refund.NewPostgresRepository(db, ledgerSvc))
 	webhookSvc := webhook.NewService(webhook.NewPostgresRepository(db))
 	settlementSvc := settlement.NewService(settlement.NewPostgresRepository(db, ledgerSvc))
+	payoutSvc := payout.NewService(payout.NewPostgresRepository(db, ledgerSvc), nil)
+	disputeSvc := dispute.NewService(dispute.NewPostgresRepository(db))
 
 	merchantHandler := merchant.NewHandler(merchantSvc)
 	orderHandler := order.NewHandler(orderSvc)
@@ -296,6 +300,8 @@ func buildGatewayMux(db *pgxpool.Pool) (*http.ServeMux, *merchant.Service, *orde
 	refundHandler := refund.NewHandler(refundSvc)
 	webhookHandler := webhook.NewHandler(webhookSvc)
 	settlementHandler := settlement.NewHandler(settlementSvc)
+	payoutHandler := payout.NewHandler(payoutSvc, settlementSvc)
+	disputeHandler := dispute.NewHandler(disputeSvc)
 
 	protected := func(scope merchant.APIKeyScope, next http.Handler) http.Handler {
 		return authMw.RequireScope(scope, idemMw.Wrap(next))
@@ -308,7 +314,9 @@ func buildGatewayMux(db *pgxpool.Pool) (*http.ServeMux, *merchant.Service, *orde
 	paymentHandler.RegisterRoutesWithAuth(mux, protected)
 	refundHandler.RegisterRoutesWithAuth(mux, protected)
 	settlementHandler.RegisterRoutesWithAuth(mux, protected)
+	payoutHandler.RegisterRoutesWithAuth(mux, protected)
 	webhookHandler.RegisterRoutesWithAuth(mux, protected)
+	disputeHandler.RegisterRoutesWithAuth(mux, protected)
 	mux.Handle("GET /v1/merchants/me", authMw.RequireScope(merchant.APIKeyScopeRead, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		p, _ := httpx.PrincipalFromContext(r.Context())
 		httpx.WriteJSON(w, http.StatusOK, map[string]any{"merchant_id": p.MerchantID})

--- a/tests/integration/security_hardening_integration_test.go
+++ b/tests/integration/security_hardening_integration_test.go
@@ -12,9 +12,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sanskarpan/PayGate/internal/auth"
 	"github.com/sanskarpan/PayGate/internal/common/middleware"
 	"github.com/sanskarpan/PayGate/internal/common/scrubber"
+	"github.com/sanskarpan/PayGate/internal/gateway"
+	"github.com/sanskarpan/PayGate/internal/ledger"
 	"github.com/sanskarpan/PayGate/internal/merchant"
+	"github.com/sanskarpan/PayGate/internal/order"
+	"github.com/sanskarpan/PayGate/internal/payment"
+	"github.com/sanskarpan/PayGate/internal/settlement"
 	"github.com/sanskarpan/PayGate/internal/webhook"
 )
 
@@ -150,5 +156,154 @@ func TestIntegrationWebhookSecretRotationGracePeriod(t *testing.T) {
 	expected := time.Now().Add(webhook.RotateSecretGracePeriod)
 	if prevExpiresAt.Before(expected.Add(-5*time.Minute)) || prevExpiresAt.After(expected.Add(5*time.Minute)) {
 		t.Errorf("previous_secret_expires_at=%v, expected ~%v", prevExpiresAt, expected)
+	}
+}
+
+func TestIntegrationWebhookRejectsInsecurePublicHTTPURL(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	mux, merchantSvc, _, _ := buildGatewayMux(db)
+	ctx := context.Background()
+
+	m, err := merchantSvc.CreateMerchant(ctx, merchant.CreateMerchantInput{
+		Name: "Webhook URL Merchant", Email: "webhook-url@test.com", BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+	key, err := merchantSvc.CreateAPIKey(ctx, m.ID, merchant.CreateAPIKeyInput{
+		Mode: merchant.APIKeyModeTest, Scope: merchant.APIKeyScopeWrite,
+	})
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"url":    "http://example.com/hook",
+		"events": []string{"payment.captured"},
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/webhooks", bytes.NewReader(body))
+	req.Header.Set("Authorization", basicAuth(key.KeyID, key.KeySecret))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for insecure webhook URL, got %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestIntegrationGatewayAdminEndpointsRequireAdminScope(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	ctx := context.Background()
+	merchantSvc := merchant.NewService(merchant.NewPostgresRepository(db), merchant.WithSessionSecret("integration-dashboard-secret"))
+	authMw := auth.NewMiddleware(merchantSvc)
+	scenarioStore := gateway.NewScenarioStore(db)
+	adminHandler := gateway.NewAdminHandler(scenarioStore)
+
+	mux := http.NewServeMux()
+	adminHandler.RegisterRoutesWithAuth(mux, func(next http.Handler) http.Handler {
+		return authMw.RequireScope(merchant.APIKeyScopeAdmin, next)
+	})
+
+	m, err := merchantSvc.CreateMerchant(ctx, merchant.CreateMerchantInput{
+		Name: "Admin Control Merchant", Email: "admin-control@test.com", BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+	writeKey, err := merchantSvc.CreateAPIKey(ctx, m.ID, merchant.CreateAPIKeyInput{
+		Mode: merchant.APIKeyModeTest, Scope: merchant.APIKeyScopeWrite,
+	})
+	if err != nil {
+		t.Fatalf("create write api key: %v", err)
+	}
+	adminKey, err := merchantSvc.CreateAPIKey(ctx, m.ID, merchant.CreateAPIKeyInput{
+		Mode: merchant.APIKeyModeTest, Scope: merchant.APIKeyScopeAdmin,
+	})
+	if err != nil {
+		t.Fatalf("create admin api key: %v", err)
+	}
+
+	noAuthReq := httptest.NewRequest(http.MethodGet, "/v1/gateway/scenarios", nil)
+	noAuthRec := httptest.NewRecorder()
+	mux.ServeHTTP(noAuthRec, noAuthReq)
+	if noAuthRec.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401 without auth, got %d", noAuthRec.Code)
+	}
+
+	writeReq := httptest.NewRequest(http.MethodGet, "/v1/gateway/scenarios", nil)
+	writeReq.Header.Set("Authorization", basicAuth(writeKey.KeyID, writeKey.KeySecret))
+	writeRec := httptest.NewRecorder()
+	mux.ServeHTTP(writeRec, writeReq)
+	if writeRec.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 for non-admin key, got %d", writeRec.Code)
+	}
+
+	adminReq := httptest.NewRequest(http.MethodGet, "/v1/gateway/scenarios", nil)
+	adminReq.Header.Set("Authorization", basicAuth(adminKey.KeyID, adminKey.KeySecret))
+	adminRec := httptest.NewRecorder()
+	mux.ServeHTTP(adminRec, adminReq)
+	if adminRec.Code != http.StatusOK {
+		t.Fatalf("expected 200 for admin key, got %d body=%s", adminRec.Code, adminRec.Body.String())
+	}
+}
+
+func TestIntegrationPayoutRejectedWhileSettlementOnHold(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	mux, merchantSvc, orderSvc, paymentSvc := buildGatewayMux(db)
+	ctx := context.Background()
+
+	m, err := merchantSvc.CreateMerchant(ctx, merchant.CreateMerchantInput{
+		Name: "Payout Hold Merchant", Email: "payout-hold@test.com", BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+	key, err := merchantSvc.CreateAPIKey(ctx, m.ID, merchant.CreateAPIKeyInput{
+		Mode: merchant.APIKeyModeTest, Scope: merchant.APIKeyScopeWrite,
+	})
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+
+	o, err := orderSvc.Create(ctx, order.CreateInput{
+		MerchantID: m.ID, Amount: 5000, Currency: "INR", Receipt: "payout-hold-order",
+	})
+	if err != nil {
+		t.Fatalf("create order: %v", err)
+	}
+	authz, err := paymentSvc.Authorize(ctx, payment.AuthorizeInput{
+		MerchantID: m.ID, OrderID: o.ID, Amount: o.Amount, Currency: o.Currency, Method: "card",
+	})
+	if err != nil {
+		t.Fatalf("authorize payment: %v", err)
+	}
+	if _, err := paymentSvc.CaptureForMerchant(ctx, m.ID, authz.PaymentID, o.Amount); err != nil {
+		t.Fatalf("capture payment: %v", err)
+	}
+
+	ledgerSvc := ledger.NewService(ledger.NewRepository(db))
+	settlementSvc := settlement.NewService(settlement.NewPostgresRepository(db, ledgerSvc))
+	sttl, err := settlementSvc.RunBatch(ctx, m.ID, time.Unix(0, 0), time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("run settlement: %v", err)
+	}
+	if err := settlementSvc.Hold(ctx, m.ID, sttl.ID, "manual review"); err != nil {
+		t.Fatalf("hold settlement: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/settlements/"+sttl.ID+"/payout", nil)
+	req.Header.Set("Authorization", basicAuth(key.KeyID, key.KeySecret))
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 for payout on held settlement, got %d body=%s", rec.Code, rec.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary
This PR hardens the request perimeter and operational middleware around trusted proxies, request metadata, admin-only controls, rate limiting, and related integration coverage.

## Includes
- trusted-proxy aware client IP extraction
- secured simulator and method admin endpoints
- request metadata propagation for audit and request-scoped consumers
- rate-limiter eviction and header improvements
- runtime hardening and security regression coverage

## Tracking
Refs #399
Stacked on #405

## Review Note
This PR is stacked on the async/runtime branch to keep review slices small while preserving one-file-per-commit traceability.