### PR TITLE
[#400] Complete dispute, payout, and reconciliation operational correctness

### DIFF
--- a/internal/dispute/domain.go
+++ b/internal/dispute/domain.go
@@ -29,8 +29,14 @@ const (
 
 var (
 	ErrDisputeNotFound          = errors.New("dispute not found")
+	ErrPaymentNotFound          = errors.New("payment not found")
+	ErrSettlementNotFound       = errors.New("settlement not found")
 	ErrInvalidTransition        = errors.New("invalid dispute state transition")
+	ErrInvalidReason            = errors.New("invalid dispute reason")
+	ErrInvalidAmount            = errors.New("invalid dispute amount")
+	ErrInvalidCurrency          = errors.New("dispute currency does not match payment currency")
 	ErrEvidenceAlreadySubmitted = errors.New("evidence already submitted for this dispute")
+	ErrEvidenceNotAllowed       = errors.New("evidence can only be submitted while dispute is open")
 	ErrDisputeTerminal          = errors.New("dispute is in a terminal state and cannot be transitioned")
 )
 
@@ -91,4 +97,21 @@ type Dispute struct {
 	Notes               string
 	CreatedAt           time.Time
 	UpdatedAt           time.Time
+}
+
+// PaymentReference is the subset of payment data needed to validate dispute creation.
+type PaymentReference struct {
+	ID         string
+	MerchantID string
+	Amount     int64
+	Currency   string
+}
+
+func isValidReason(reason string) bool {
+	for _, valid := range ValidReasons {
+		if reason == valid {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/dispute/handler.go
+++ b/internal/dispute/handler.go
@@ -40,21 +40,16 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body struct {
-		PaymentID    string  `json:"payment_id"`
-		Reason       string  `json:"reason"`
-		Amount       int64   `json:"amount"`
-		Currency     string  `json:"currency"`
-		DueBy        *int64  `json:"due_by"`
-		SettlementID string  `json:"settlement_id"`
+		PaymentID    string `json:"payment_id"`
+		Reason       string `json:"reason"`
+		Amount       int64  `json:"amount"`
+		Currency     string `json:"currency"`
+		DueBy        *int64 `json:"due_by"`
+		SettlementID string `json:"settlement_id"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 		httpx.WriteError(w, http.StatusBadRequest, httpx.APIError{Code: "BAD_REQUEST_ERROR", Description: "invalid request body"})
 		return
-	}
-
-	currency := body.Currency
-	if currency == "" {
-		currency = "INR"
 	}
 
 	var dueBy *time.Time
@@ -63,7 +58,7 @@ func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
 		dueBy = &t
 	}
 
-	d, err := h.svc.Create(r.Context(), p.MerchantID, body.PaymentID, body.Reason, body.Amount, currency, dueBy)
+	d, err := h.svc.Create(r.Context(), p.MerchantID, body.PaymentID, body.SettlementID, body.Reason, body.Amount, body.Currency, dueBy)
 	if err != nil {
 		handleError(w, err)
 		return
@@ -203,21 +198,21 @@ func present(d Dispute) map[string]any {
 		resolvedAt = &ts
 	}
 	return map[string]any{
-		"entity":               "dispute",
-		"id":                   d.ID,
-		"merchant_id":          d.MerchantID,
-		"payment_id":           d.PaymentID,
-		"settlement_id":        d.SettlementID,
-		"status":               d.Status,
-		"reason":               d.Reason,
-		"amount":               d.Amount,
-		"currency":             d.Currency,
-		"evidence":             d.Evidence,
+		"entity":                "dispute",
+		"id":                    d.ID,
+		"merchant_id":           d.MerchantID,
+		"payment_id":            d.PaymentID,
+		"settlement_id":         d.SettlementID,
+		"status":                d.Status,
+		"reason":                d.Reason,
+		"amount":                d.Amount,
+		"currency":              d.Currency,
+		"evidence":              d.Evidence,
 		"evidence_submitted_at": evidenceSubmittedAt,
-		"due_by":               dueBy,
-		"resolved_at":          resolvedAt,
-		"notes":                d.Notes,
-		"created_at":           d.CreatedAt.Unix(),
+		"due_by":                dueBy,
+		"resolved_at":           resolvedAt,
+		"notes":                 d.Notes,
+		"created_at":            d.CreatedAt.Unix(),
 	}
 }
 
@@ -225,10 +220,16 @@ func handleError(w http.ResponseWriter, err error) {
 	switch {
 	case errors.Is(err, ErrDisputeNotFound):
 		httpx.WriteError(w, http.StatusNotFound, httpx.APIError{Code: "NOT_FOUND", Description: err.Error()})
+	case errors.Is(err, ErrPaymentNotFound), errors.Is(err, ErrSettlementNotFound):
+		httpx.WriteError(w, http.StatusNotFound, httpx.APIError{Code: "NOT_FOUND", Description: err.Error()})
+	case errors.Is(err, ErrInvalidReason), errors.Is(err, ErrInvalidAmount), errors.Is(err, ErrInvalidCurrency):
+		httpx.WriteError(w, http.StatusBadRequest, httpx.APIError{Code: "BAD_REQUEST_ERROR", Description: err.Error()})
 	case errors.Is(err, ErrInvalidTransition):
 		httpx.WriteError(w, http.StatusUnprocessableEntity, httpx.APIError{Code: "INVALID_STATE", Description: err.Error()})
 	case errors.Is(err, ErrDisputeTerminal):
 		httpx.WriteError(w, http.StatusUnprocessableEntity, httpx.APIError{Code: "DISPUTE_TERMINAL", Description: err.Error()})
+	case errors.Is(err, ErrEvidenceNotAllowed):
+		httpx.WriteError(w, http.StatusUnprocessableEntity, httpx.APIError{Code: "INVALID_STATE", Description: err.Error()})
 	case errors.Is(err, ErrEvidenceAlreadySubmitted):
 		httpx.WriteError(w, http.StatusConflict, httpx.APIError{Code: "EVIDENCE_ALREADY_SUBMITTED", Description: err.Error()})
 	default:

--- a/internal/dispute/postgres.go
+++ b/internal/dispute/postgres.go
@@ -115,7 +115,8 @@ LIMIT $2
 }
 
 // UpdateStatus transitions the dispute status, sets resolved_at for terminal states,
-// and emits a dispute.updated outbox event in a single transaction.
+// and emits a dispute.updated outbox event plus a terminal dispute.<status>
+// event when appropriate.
 func (r *PostgresRepository) UpdateStatus(ctx context.Context, merchantID, id string, status DisputeState, notes string) (Dispute, error) {
 	tx, err := r.db.Begin(ctx)
 	if err != nil {
@@ -158,6 +159,21 @@ WHERE id = $1 AND merchant_id = $2
 		return Dispute{}, fmt.Errorf("write dispute.updated outbox event: %w", err)
 	}
 
+	if isTerminal {
+		if err := r.outbox.WriteTx(ctx, tx, outbox.Event{
+			AggregateType: "dispute",
+			AggregateID:   id,
+			EventType:     "dispute." + string(status),
+			MerchantID:    merchantID,
+			Payload: map[string]any{
+				"dispute_id": id,
+				"status":     status,
+			},
+		}); err != nil {
+			return Dispute{}, fmt.Errorf("write dispute terminal outbox event: %w", err)
+		}
+	}
+
 	if err := tx.Commit(ctx); err != nil {
 		return Dispute{}, err
 	}
@@ -187,6 +203,37 @@ WHERE id = $1 AND merchant_id = $2
 	}
 
 	return r.GetByID(ctx, merchantID, id)
+}
+
+func (r *PostgresRepository) GetPaymentReference(ctx context.Context, merchantID, paymentID string) (PaymentReference, error) {
+	row := r.db.QueryRow(ctx, `
+SELECT id, merchant_id, amount, currency
+FROM paygate_payments.payments
+WHERE id = $1 AND merchant_id = $2
+`, paymentID, merchantID)
+
+	var ref PaymentReference
+	if err := row.Scan(&ref.ID, &ref.MerchantID, &ref.Amount, &ref.Currency); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return PaymentReference{}, ErrPaymentNotFound
+		}
+		return PaymentReference{}, err
+	}
+	return ref, nil
+}
+
+func (r *PostgresRepository) SettlementExists(ctx context.Context, merchantID, settlementID string) (bool, error) {
+	var exists bool
+	if err := r.db.QueryRow(ctx, `
+SELECT EXISTS(
+	SELECT 1
+	FROM paygate_settlements.settlements
+	WHERE id = $1 AND merchant_id = $2
+)
+`, settlementID, merchantID).Scan(&exists); err != nil {
+		return false, err
+	}
+	return exists, nil
 }
 
 // scanner is the common interface shared by pgx.Row and pgx.Rows.

--- a/internal/dispute/repository.go
+++ b/internal/dispute/repository.go
@@ -19,4 +19,10 @@ type Repository interface {
 
 	// SubmitEvidence stores the evidence payload and stamps evidence_submitted_at.
 	SubmitEvidence(ctx context.Context, merchantID, id string, evidence map[string]any) (Dispute, error)
+
+	// GetPaymentReference returns the backing payment details used to validate a dispute.
+	GetPaymentReference(ctx context.Context, merchantID, paymentID string) (PaymentReference, error)
+
+	// SettlementExists reports whether the settlement belongs to the merchant.
+	SettlementExists(ctx context.Context, merchantID, settlementID string) (bool, error)
 }

--- a/internal/dispute/service.go
+++ b/internal/dispute/service.go
@@ -19,16 +19,50 @@ func NewService(repo Repository) *Service {
 }
 
 // Create opens a new dispute for the given merchant and payment.
-func (s *Service) Create(ctx context.Context, merchantID, paymentID, reason string, amount int64, currency string, dueBy *time.Time) (Dispute, error) {
+func (s *Service) Create(ctx context.Context, merchantID, paymentID, settlementID, reason string, amount int64, currency string, dueBy *time.Time) (Dispute, error) {
+	if paymentID == "" {
+		return Dispute{}, ErrPaymentNotFound
+	}
+	if !isValidReason(reason) {
+		return Dispute{}, ErrInvalidReason
+	}
+	if amount <= 0 {
+		return Dispute{}, ErrInvalidAmount
+	}
+
+	paymentRef, err := s.repo.GetPaymentReference(ctx, merchantID, paymentID)
+	if err != nil {
+		return Dispute{}, err
+	}
+	if amount > paymentRef.Amount {
+		return Dispute{}, ErrInvalidAmount
+	}
+	if currency == "" {
+		currency = paymentRef.Currency
+	}
+	if currency != paymentRef.Currency {
+		return Dispute{}, ErrInvalidCurrency
+	}
+	if settlementID != "" {
+		exists, err := s.repo.SettlementExists(ctx, merchantID, settlementID)
+		if err != nil {
+			return Dispute{}, err
+		}
+		if !exists {
+			return Dispute{}, ErrSettlementNotFound
+		}
+	}
+
 	d := Dispute{
-		ID:         idgen.New("disp"),
-		MerchantID: merchantID,
-		PaymentID:  paymentID,
-		Status:     StateOpen,
-		Reason:     reason,
-		Amount:     amount,
-		Currency:   currency,
-		DueBy:      dueBy,
+		ID:           idgen.New("disp"),
+		MerchantID:   merchantID,
+		PaymentID:    paymentID,
+		SettlementID: settlementID,
+		Status:       StateOpen,
+		Reason:       reason,
+		Amount:       amount,
+		Currency:     currency,
+		DueBy:        dueBy,
 	}
 	return s.repo.Create(ctx, d)
 }
@@ -61,6 +95,9 @@ func (s *Service) SubmitEvidence(ctx context.Context, merchantID, id string, evi
 	d, err := s.repo.GetByID(ctx, merchantID, id)
 	if err != nil {
 		return Dispute{}, err
+	}
+	if d.Status != StateOpen {
+		return Dispute{}, ErrEvidenceNotAllowed
 	}
 	if d.EvidenceSubmittedAt != nil {
 		return Dispute{}, ErrEvidenceAlreadySubmitted

--- a/internal/order/handler.go
+++ b/internal/order/handler.go
@@ -97,13 +97,16 @@ func (h *Handler) list(w http.ResponseWriter, r *http.Request) {
 		items = append(items, presentOrder(o))
 	}
 
-	httpx.WriteJSON(w, http.StatusOK, map[string]any{
-		"entity":      "collection",
-		"count":       len(items),
-		"items":       items,
-		"has_more":    out.HasMore,
-		"next_cursor": out.NextCursor,
-	})
+	resp := map[string]any{
+		"entity":   "collection",
+		"count":    len(items),
+		"items":    items,
+		"has_more": out.HasMore,
+	}
+	if out.HasMore && out.NextCursor != "" {
+		resp["next_cursor"] = out.NextCursor
+	}
+	httpx.WriteJSON(w, http.StatusOK, resp)
 }
 
 func presentOrder(o Order) map[string]any {

--- a/internal/payout/domain.go
+++ b/internal/payout/domain.go
@@ -25,10 +25,11 @@ const (
 )
 
 var (
-	ErrPayoutNotFound          = errors.New("payout not found")
-	ErrInvalidTransition       = errors.New("invalid payout state transition")
-	ErrPayoutAlreadyExists     = errors.New("payout already exists for this settlement")
-	ErrSettlementNotProcessed  = errors.New("settlement must be processed before initiating payout")
+	ErrPayoutNotFound         = errors.New("payout not found")
+	ErrInvalidTransition      = errors.New("invalid payout state transition")
+	ErrPayoutAlreadyExists    = errors.New("payout already exists for this settlement")
+	ErrSettlementNotProcessed = errors.New("settlement must be processed before initiating payout")
+	ErrSettlementOnHold       = errors.New("settlement is on hold")
 )
 
 // Transition returns the next PayoutState for the given event,

--- a/internal/payout/handler.go
+++ b/internal/payout/handler.go
@@ -43,6 +43,10 @@ func (h *Handler) initiate(w http.ResponseWriter, r *http.Request) {
 		handleError(w, err)
 		return
 	}
+	if sttl.OnHold {
+		handleError(w, ErrSettlementOnHold)
+		return
+	}
 
 	pout, err := h.svc.InitiatePayoutForSettlement(r.Context(), p.MerchantID, settlementID, sttl.NetAmount, sttl.Currency)
 	if err != nil {
@@ -131,6 +135,8 @@ func handleError(w http.ResponseWriter, err error) {
 		httpx.WriteError(w, http.StatusUnprocessableEntity, httpx.APIError{Code: "INVALID_STATE", Description: err.Error()})
 	case errors.Is(err, ErrSettlementNotProcessed):
 		httpx.WriteError(w, http.StatusUnprocessableEntity, httpx.APIError{Code: "SETTLEMENT_NOT_PROCESSED", Description: err.Error()})
+	case errors.Is(err, ErrSettlementOnHold):
+		httpx.WriteError(w, http.StatusConflict, httpx.APIError{Code: "SETTLEMENT_ON_HOLD", Description: err.Error()})
 	default:
 		// Check for settlement not found too.
 		var errBody struct{ Code string }

--- a/internal/payout/service.go
+++ b/internal/payout/service.go
@@ -16,6 +16,9 @@ type Service struct {
 
 // NewService creates a new Service.
 func NewService(repo Repository, logger *slog.Logger) *Service {
+	if logger == nil {
+		logger = slog.Default()
+	}
 	return &Service{repo: repo, logger: logger}
 }
 

--- a/internal/recon/domain.go
+++ b/internal/recon/domain.go
@@ -28,6 +28,8 @@ const (
 	MismatchSettlementPaymentMismatch MismatchType = "settlement_payment_mismatch"
 	// PaymentSettledNotInBatch: payment.settled=true but no settlement_item found.
 	MismatchPaymentSettledNotInBatch MismatchType = "payment_settled_not_in_batch"
+	// OrphanSettlementItem: a settlement item points to a missing payment.
+	MismatchOrphanSettlementItem MismatchType = "orphan_settlement_item"
 )
 
 var ErrBatchNotFound = errors.New("recon batch not found")

--- a/internal/recon/worker.go
+++ b/internal/recon/worker.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/sanskarpan/PayGate/internal/common/idgen"
+	"github.com/sanskarpan/PayGate/internal/settlement"
 )
 
 // Worker runs periodic reconciliation checks against the Postgres DB.
@@ -118,6 +119,10 @@ HAVING SUM(debit_amount) != SUM(credit_amount)
 // RunPaymentLedgerCheck verifies each captured payment in [start, end) has ledger entries.
 func (w *Worker) RunPaymentLedgerCheck(ctx context.Context, start, end time.Time) (int, error) {
 	batchID := idgen.New("recon")
+	checkedCount, err := w.countCapturedPayments(ctx, start, end)
+	if err != nil {
+		return 0, fmt.Errorf("count captured payments: %w", err)
+	}
 
 	rows, err := w.db.Query(ctx, `
 SELECT p.id, p.merchant_id, p.amount,
@@ -137,9 +142,7 @@ HAVING COALESCE(SUM(le.credit_amount), 0) = 0
 	defer rows.Close()
 
 	var mismatches []ReconMismatch
-	var checkedCount int
 	for rows.Next() {
-		checkedCount++
 		var paymentID, merchantID string
 		var paymentAmount, ledgerCredits int64
 		if err := rows.Scan(&paymentID, &merchantID, &paymentAmount, &ledgerCredits); err != nil {
@@ -173,9 +176,13 @@ HAVING COALESCE(SUM(le.credit_amount), 0) = 0
 // RunThreeWayCheck verifies settled payments have matching settlement_items.
 func (w *Worker) RunThreeWayCheck(ctx context.Context, start, end time.Time) (int, error) {
 	batchID := idgen.New("recon")
+	checkedCount, err := w.countCapturedPayments(ctx, start, end)
+	if err != nil {
+		return 0, fmt.Errorf("count captured payments: %w", err)
+	}
 
 	rows, err := w.db.Query(ctx, `
-SELECT p.id, p.merchant_id, p.amount, p.settled, p.settlement_id,
+SELECT p.id, p.merchant_id, p.amount, p.fee, p.amount_refunded, p.settled, p.settlement_id,
        si.id   AS si_id,
        si.net  AS si_net
 FROM paygate_payments.payments p
@@ -190,21 +197,22 @@ WHERE p.status = 'captured'
 	defer rows.Close()
 
 	var mismatches []ReconMismatch
-	var checkedCount int
 	for rows.Next() {
-		checkedCount++
 		var (
 			paymentID, merchantID string
 			amount                int64
+			fee                   int64
+			amountRefunded        int64
 			settled               bool
 			settlementID          *string
 			siID                  *string
 			siNet                 *int64
 		)
-		if err := rows.Scan(&paymentID, &merchantID, &amount, &settled, &settlementID, &siID, &siNet); err != nil {
+		if err := rows.Scan(&paymentID, &merchantID, &amount, &fee, &amountRefunded, &settled, &settlementID, &siID, &siNet); err != nil {
 			return 0, err
 		}
 
+		expectedNet := settlement.CalculateNet(amount, fee, settlement.CalculateRefundNetImpact(amount, fee, amountRefunded))
 		if settled && siID == nil {
 			mismatches = append(mismatches, ReconMismatch{
 				ID:            idgen.New("mm"),
@@ -217,6 +225,33 @@ WHERE p.status = 'captured'
 				ActualValue:   "no settlement_item found",
 				Description:   fmt.Sprintf("payment %s marked settled but no settlement_item", paymentID),
 			})
+			continue
+		}
+		if siID != nil && siNet != nil && *siNet != expectedNet {
+			mismatches = append(mismatches, ReconMismatch{
+				ID:            idgen.New("mm"),
+				BatchID:       batchID,
+				MerchantID:    merchantID,
+				MismatchType:  MismatchSettlementPaymentMismatch,
+				EntityType:    "payment",
+				EntityID:      paymentID,
+				ExpectedValue: fmt.Sprintf("%d", expectedNet),
+				ActualValue:   fmt.Sprintf("%d", *siNet),
+				Description:   fmt.Sprintf("payment %s settlement net mismatch: expected=%d actual=%d", paymentID, expectedNet, *siNet),
+			})
+		}
+		if !settled && siID != nil {
+			mismatches = append(mismatches, ReconMismatch{
+				ID:            idgen.New("mm"),
+				BatchID:       batchID,
+				MerchantID:    merchantID,
+				MismatchType:  MismatchSettlementPaymentMismatch,
+				EntityType:    "payment",
+				EntityID:      paymentID,
+				ExpectedValue: "settled=true",
+				ActualValue:   "settled=false",
+				Description:   fmt.Sprintf("payment %s has settlement_item but is not marked settled", paymentID),
+			})
 		}
 	}
 	rows.Close()
@@ -224,7 +259,54 @@ WHERE p.status = 'captured'
 		return 0, err
 	}
 
+	orphanRows, err := w.db.Query(ctx, `
+SELECT si.id, si.merchant_id, si.payment_id
+FROM paygate_settlements.settlement_items si
+LEFT JOIN paygate_payments.payments p ON p.id = si.payment_id
+JOIN paygate_settlements.settlements s ON s.id = si.settlement_id
+WHERE s.processed_at >= $1 AND s.processed_at < $2
+  AND p.id IS NULL
+`, start, end)
+	if err != nil {
+		return 0, fmt.Errorf("query orphan settlement items: %w", err)
+	}
+	defer orphanRows.Close()
+
+	for orphanRows.Next() {
+		var settlementItemID, merchantID, paymentID string
+		if err := orphanRows.Scan(&settlementItemID, &merchantID, &paymentID); err != nil {
+			return 0, err
+		}
+		mismatches = append(mismatches, ReconMismatch{
+			ID:            idgen.New("mm"),
+			BatchID:       batchID,
+			MerchantID:    merchantID,
+			MismatchType:  MismatchOrphanSettlementItem,
+			EntityType:    "settlement_item",
+			EntityID:      settlementItemID,
+			ExpectedValue: "payment exists",
+			ActualValue:   fmt.Sprintf("missing payment %s", paymentID),
+			Description:   fmt.Sprintf("settlement item %s references missing payment %s", settlementItemID, paymentID),
+		})
+	}
+	if err := orphanRows.Err(); err != nil {
+		return 0, err
+	}
+
 	return w.persistBatch(ctx, batchID, "", BatchTypeThreeWay, start, end, checkedCount, len(mismatches), mismatches)
+}
+
+func (w *Worker) countCapturedPayments(ctx context.Context, start, end time.Time) (int, error) {
+	var count int
+	if err := w.db.QueryRow(ctx, `
+SELECT COUNT(*)
+FROM paygate_payments.payments
+WHERE status = 'captured'
+  AND captured_at >= $1 AND captured_at < $2
+`, start, end).Scan(&count); err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 // ListMismatches returns recon mismatches for a merchant, newest first.

--- a/tests/integration/dispute_integration_test.go
+++ b/tests/integration/dispute_integration_test.go
@@ -1,0 +1,188 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sanskarpan/PayGate/internal/ledger"
+	"github.com/sanskarpan/PayGate/internal/merchant"
+	"github.com/sanskarpan/PayGate/internal/order"
+	"github.com/sanskarpan/PayGate/internal/payment"
+	"github.com/sanskarpan/PayGate/internal/settlement"
+)
+
+func TestIntegrationDisputeLifecycleAndValidation(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	mux, merchantSvc, orderSvc, paymentSvc := buildGatewayMux(db)
+	ctx := context.Background()
+
+	createdMerchant, err := merchantSvc.CreateMerchant(ctx, merchant.CreateMerchantInput{
+		Name: "Dispute Merchant", Email: "dispute@test.com", BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+	key, err := merchantSvc.CreateAPIKey(ctx, createdMerchant.ID, merchant.CreateAPIKeyInput{
+		Mode: merchant.APIKeyModeTest, Scope: merchant.APIKeyScopeWrite,
+	})
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+	authHeader := basicAuth(key.KeyID, key.KeySecret)
+
+	o, err := orderSvc.Create(ctx, order.CreateInput{
+		MerchantID: createdMerchant.ID,
+		Amount:     10000,
+		Currency:   "INR",
+		Receipt:    "disp-1",
+	})
+	if err != nil {
+		t.Fatalf("create order: %v", err)
+	}
+	auth, err := paymentSvc.Authorize(ctx, payment.AuthorizeInput{
+		MerchantID: createdMerchant.ID,
+		OrderID:    o.ID,
+		Amount:     o.Amount,
+		Currency:   o.Currency,
+		Method:     "card",
+	})
+	if err != nil {
+		t.Fatalf("authorize payment: %v", err)
+	}
+	if _, err := paymentSvc.CaptureForMerchant(ctx, createdMerchant.ID, auth.PaymentID, o.Amount); err != nil {
+		t.Fatalf("capture payment: %v", err)
+	}
+
+	ledgerSvc := ledger.NewService(ledger.NewRepository(db))
+	settlementSvc := settlement.NewService(settlement.NewPostgresRepository(db, ledgerSvc))
+	sttl, err := settlementSvc.RunBatch(ctx, createdMerchant.ID, time.Unix(0, 0), time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("run settlement batch: %v", err)
+	}
+
+	createBody, _ := json.Marshal(map[string]any{
+		"payment_id":    auth.PaymentID,
+		"settlement_id": sttl.ID,
+		"reason":        "fraudulent",
+		"amount":        o.Amount,
+	})
+	createReq := httptest.NewRequest(http.MethodPost, "/v1/disputes", bytes.NewReader(createBody))
+	createReq.Header.Set("Authorization", authHeader)
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	mux.ServeHTTP(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("create dispute: expected 201, got %d body=%s", createRec.Code, createRec.Body.String())
+	}
+
+	var created map[string]any
+	if err := json.Unmarshal(createRec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode dispute response: %v", err)
+	}
+	disputeID := created["id"].(string)
+	if got := created["settlement_id"]; got != sttl.ID {
+		t.Fatalf("expected settlement_id %s, got %v", sttl.ID, got)
+	}
+	if got := created["currency"]; got != "INR" {
+		t.Fatalf("expected currency INR, got %v", got)
+	}
+
+	invalidReasonBody, _ := json.Marshal(map[string]any{
+		"payment_id": auth.PaymentID,
+		"reason":     "not_a_real_reason",
+		"amount":     100,
+	})
+	invalidReasonReq := httptest.NewRequest(http.MethodPost, "/v1/disputes", bytes.NewReader(invalidReasonBody))
+	invalidReasonReq.Header.Set("Authorization", authHeader)
+	invalidReasonReq.Header.Set("Content-Type", "application/json")
+	invalidReasonRec := httptest.NewRecorder()
+	mux.ServeHTTP(invalidReasonRec, invalidReasonReq)
+	if invalidReasonRec.Code != http.StatusBadRequest {
+		t.Fatalf("invalid reason: expected 400, got %d body=%s", invalidReasonRec.Code, invalidReasonRec.Body.String())
+	}
+
+	wrongCurrencyBody, _ := json.Marshal(map[string]any{
+		"payment_id": auth.PaymentID,
+		"reason":     "fraudulent",
+		"amount":     100,
+		"currency":   "USD",
+	})
+	wrongCurrencyReq := httptest.NewRequest(http.MethodPost, "/v1/disputes", bytes.NewReader(wrongCurrencyBody))
+	wrongCurrencyReq.Header.Set("Authorization", authHeader)
+	wrongCurrencyReq.Header.Set("Content-Type", "application/json")
+	wrongCurrencyRec := httptest.NewRecorder()
+	mux.ServeHTTP(wrongCurrencyRec, wrongCurrencyReq)
+	if wrongCurrencyRec.Code != http.StatusBadRequest {
+		t.Fatalf("wrong currency: expected 400, got %d body=%s", wrongCurrencyRec.Code, wrongCurrencyRec.Body.String())
+	}
+
+	evidenceBody, _ := json.Marshal(map[string]any{
+		"proof_url": "https://example.com/evidence",
+	})
+	evidenceReq := httptest.NewRequest(http.MethodPost, "/v1/disputes/"+disputeID+"/submit-evidence", bytes.NewReader(evidenceBody))
+	evidenceReq.Header.Set("Authorization", authHeader)
+	evidenceReq.Header.Set("Content-Type", "application/json")
+	evidenceRec := httptest.NewRecorder()
+	mux.ServeHTTP(evidenceRec, evidenceReq)
+	if evidenceRec.Code != http.StatusOK {
+		t.Fatalf("submit evidence: expected 200, got %d body=%s", evidenceRec.Code, evidenceRec.Body.String())
+	}
+
+	reviewReq := httptest.NewRequest(http.MethodPost, "/v1/disputes/"+disputeID+"/review", nil)
+	reviewReq.Header.Set("Authorization", authHeader)
+	reviewRec := httptest.NewRecorder()
+	mux.ServeHTTP(reviewRec, reviewReq)
+	if reviewRec.Code != http.StatusOK {
+		t.Fatalf("review dispute: expected 200, got %d body=%s", reviewRec.Code, reviewRec.Body.String())
+	}
+
+	lateEvidenceReq := httptest.NewRequest(http.MethodPost, "/v1/disputes/"+disputeID+"/submit-evidence", bytes.NewReader(evidenceBody))
+	lateEvidenceReq.Header.Set("Authorization", authHeader)
+	lateEvidenceReq.Header.Set("Content-Type", "application/json")
+	lateEvidenceRec := httptest.NewRecorder()
+	mux.ServeHTTP(lateEvidenceRec, lateEvidenceReq)
+	if lateEvidenceRec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("late evidence: expected 422, got %d body=%s", lateEvidenceRec.Code, lateEvidenceRec.Body.String())
+	}
+
+	resolveBody, _ := json.Marshal(map[string]any{
+		"outcome": "won",
+		"notes":   "issuer reversed chargeback",
+	})
+	resolveReq := httptest.NewRequest(http.MethodPost, "/v1/disputes/"+disputeID+"/resolve", bytes.NewReader(resolveBody))
+	resolveReq.Header.Set("Authorization", authHeader)
+	resolveReq.Header.Set("Content-Type", "application/json")
+	resolveRec := httptest.NewRecorder()
+	mux.ServeHTTP(resolveRec, resolveReq)
+	if resolveRec.Code != http.StatusOK {
+		t.Fatalf("resolve dispute: expected 200, got %d body=%s", resolveRec.Code, resolveRec.Body.String())
+	}
+
+	acceptReq := httptest.NewRequest(http.MethodPost, "/v1/disputes/"+disputeID+"/accept", nil)
+	acceptReq.Header.Set("Authorization", authHeader)
+	acceptRec := httptest.NewRecorder()
+	mux.ServeHTTP(acceptRec, acceptReq)
+	if acceptRec.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("accept terminal dispute: expected 422, got %d body=%s", acceptRec.Code, acceptRec.Body.String())
+	}
+
+	var createdEvents, wonEvents int
+	if err := db.QueryRow(ctx, `SELECT COUNT(*) FROM public.outbox WHERE aggregate_id = $1 AND event_type = 'dispute.created'`, disputeID).Scan(&createdEvents); err != nil {
+		t.Fatalf("count dispute.created events: %v", err)
+	}
+	if err := db.QueryRow(ctx, `SELECT COUNT(*) FROM public.outbox WHERE aggregate_id = $1 AND event_type = 'dispute.won'`, disputeID).Scan(&wonEvents); err != nil {
+		t.Fatalf("count dispute.won events: %v", err)
+	}
+	if createdEvents != 1 || wonEvents != 1 {
+		t.Fatalf("expected 1 dispute.created and 1 dispute.won event, got created=%d won=%d", createdEvents, wonEvents)
+	}
+}

--- a/tests/integration/payout_integration_test.go
+++ b/tests/integration/payout_integration_test.go
@@ -1,0 +1,117 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sanskarpan/PayGate/internal/ledger"
+	"github.com/sanskarpan/PayGate/internal/merchant"
+	"github.com/sanskarpan/PayGate/internal/order"
+	"github.com/sanskarpan/PayGate/internal/payment"
+	"github.com/sanskarpan/PayGate/internal/settlement"
+)
+
+func TestIntegrationPayoutCompletesAndWritesLedger(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	mux, merchantSvc, orderSvc, paymentSvc := buildGatewayMux(db)
+	ctx := context.Background()
+
+	createdMerchant, err := merchantSvc.CreateMerchant(ctx, merchant.CreateMerchantInput{
+		Name: "Payout Merchant", Email: "payout@test.com", BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+	key, err := merchantSvc.CreateAPIKey(ctx, createdMerchant.ID, merchant.CreateAPIKeyInput{
+		Mode: merchant.APIKeyModeTest, Scope: merchant.APIKeyScopeWrite,
+	})
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+	authHeader := basicAuth(key.KeyID, key.KeySecret)
+
+	o, err := orderSvc.Create(ctx, order.CreateInput{
+		MerchantID: createdMerchant.ID,
+		Amount:     10000,
+		Currency:   "INR",
+		Receipt:    "payout-1",
+	})
+	if err != nil {
+		t.Fatalf("create order: %v", err)
+	}
+	auth, err := paymentSvc.Authorize(ctx, payment.AuthorizeInput{
+		MerchantID: createdMerchant.ID,
+		OrderID:    o.ID,
+		Amount:     o.Amount,
+		Currency:   o.Currency,
+		Method:     "card",
+	})
+	if err != nil {
+		t.Fatalf("authorize payment: %v", err)
+	}
+	if _, err := paymentSvc.CaptureForMerchant(ctx, createdMerchant.ID, auth.PaymentID, o.Amount); err != nil {
+		t.Fatalf("capture payment: %v", err)
+	}
+
+	ledgerSvc := ledger.NewService(ledger.NewRepository(db))
+	settlementSvc := settlement.NewService(settlement.NewPostgresRepository(db, ledgerSvc))
+	sttl, err := settlementSvc.RunBatch(ctx, createdMerchant.ID, time.Unix(0, 0), time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("run settlement batch: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/settlements/"+sttl.ID+"/payout", nil)
+	req.Header.Set("Authorization", authHeader)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("initiate payout: expected 201, got %d body=%s", rec.Code, rec.Body.String())
+	}
+
+	var payoutID string
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if err := db.QueryRow(ctx, `
+SELECT id
+FROM paygate_payouts.payouts
+WHERE merchant_id = $1 AND settlement_id = $2 AND status = 'completed'
+`, createdMerchant.ID, sttl.ID).Scan(&payoutID); err == nil {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if payoutID == "" {
+		t.Fatal("expected payout to complete within 5s")
+	}
+
+	var bankReference string
+	if err := db.QueryRow(ctx, `
+SELECT bank_reference
+FROM paygate_payouts.payouts
+WHERE id = $1
+`, payoutID).Scan(&bankReference); err != nil {
+		t.Fatalf("query payout: %v", err)
+	}
+	if bankReference == "" {
+		t.Fatal("expected completed payout to have a bank reference")
+	}
+
+	var ledgerEntries int
+	if err := db.QueryRow(ctx, `
+SELECT COUNT(*)
+FROM paygate_ledger.ledger_entries
+WHERE source_id = $1
+`, payoutID).Scan(&ledgerEntries); err != nil {
+		t.Fatalf("count payout ledger entries: %v", err)
+	}
+	if ledgerEntries != 2 {
+		t.Fatalf("expected 2 payout ledger entries, got %d", ledgerEntries)
+	}
+}


### PR DESCRIPTION
## Summary
This PR closes correctness and lifecycle gaps in dispute validation, payout initiation/completion, reconciliation reporting, and related operator-facing integration coverage.

## Includes
- stricter dispute state and validation rules
- settlement-hold enforcement on payouts
- payout simulation hardening
- richer reconciliation mismatch reporting
- order pagination response correction
- dispute and payout integration tests

## Tracking
Refs #400
Stacked on #406

## Review Note
This PR is intentionally stacked to preserve granular one-file commits and keep each review boundary aligned with a single operational theme.