### PR TITLE
[#402] Add advanced dashboard controls, live actions, and observability depth

### DIFF
--- a/dashboard/app/api-keys/[keyId]/page.tsx
+++ b/dashboard/app/api-keys/[keyId]/page.tsx
@@ -1,5 +1,7 @@
-import { requireViewer } from "../../../lib/api";
-import IPAllowlistManager from "../../../components/ip-allowlist-manager";
+import { notFound } from "next/navigation";
+
+import { getAPIKeys, requireViewer } from "../../../lib/api";
+import APIKeyDetailManager from "../../../components/api-key-detail-manager";
 import { getApiBaseUrl } from "../../../lib/api";
 
 interface Props {
@@ -8,10 +10,10 @@ interface Props {
 
 export default async function APIKeyAllowlistPage({ params }: Props) {
   await requireViewer();
-  return (
-    <IPAllowlistManager
-      keyId={params.keyId}
-      apiBaseUrl={getApiBaseUrl()}
-    />
-  );
+  const keys = await getAPIKeys();
+  const key = keys.items.find((item) => item.id === params.keyId);
+  if (!key) {
+    notFound();
+  }
+  return <APIKeyDetailManager apiBaseUrl={getApiBaseUrl()} item={key} />;
 }

--- a/dashboard/app/disputes/[id]/page.tsx
+++ b/dashboard/app/disputes/[id]/page.tsx
@@ -1,5 +1,6 @@
-import { getDispute, requireViewer } from "../../../lib/api";
-import { formatMoney, formatTime } from "../../../lib/types";
+import DisputeActionPanel from "../../../components/dispute-action-panel";
+import { getApiBaseUrl, getDispute, requireViewer } from "../../../lib/api";
+import { formatMoney, formatTime, truncateMiddle } from "../../../lib/types";
 
 function statusBadge(status: string) {
   switch (status) {
@@ -16,70 +17,95 @@ export default async function DisputeDetailPage({ params }: { params: { id: stri
   const dispute = await getDispute(params.id);
 
   const isTerminal = ["won", "lost", "accepted"].includes(dispute.status);
+  const submitted = Boolean(dispute.evidence_submitted_at);
+  const reviewStarted = dispute.status === "under_review" || isTerminal;
+  const resolved = Boolean(dispute.resolved_at);
+  const timeline = [
+    { label: "Opened", at: dispute.created_at, active: true },
+    { label: "Evidence submitted", at: dispute.evidence_submitted_at ?? 0, active: submitted },
+    { label: "Under review", at: reviewStarted ? dispute.created_at : 0, active: reviewStarted },
+    { label: "Resolved", at: dispute.resolved_at ?? 0, active: resolved },
+  ];
 
   return (
-    <section className="stack">
+    <section className="stack fade-up">
       <div className="hero-card">
         <div className="eyebrow">Dispute Detail</div>
-        <h1>{dispute.id}</h1>
+        <h1>{truncateMiddle(dispute.id, 14, 8)}</h1>
+        <p className="mono" style={{ margin: "0 0 8px" }}>{dispute.id}</p>
         <p className="lede">
-          <span className={statusBadge(dispute.status)}>{dispute.status}</span>
+          <span className={statusBadge(dispute.status)}>{dispute.status}</span>{" "}
+          for {formatMoney(dispute.amount, dispute.currency)} tied to payment{" "}
+          {truncateMiddle(dispute.payment_id)}.
         </p>
       </div>
 
-      <div className="detail-card">
-        <dl className="detail-list">
-          <div><dt>Payment ID</dt><dd>{dispute.payment_id}</dd></div>
-          <div><dt>Amount</dt><dd>{formatMoney(dispute.amount, dispute.currency)}</dd></div>
-          <div><dt>Reason</dt><dd>{dispute.reason}</dd></div>
-          <div><dt>Status</dt><dd><span className={statusBadge(dispute.status)}>{dispute.status}</span></dd></div>
-          {dispute.due_by && (
-            <div><dt>Evidence Due By</dt><dd>{formatTime(dispute.due_by)}</dd></div>
-          )}
-          {dispute.evidence_submitted_at && (
-            <div><dt>Evidence Submitted</dt><dd>{formatTime(dispute.evidence_submitted_at)}</dd></div>
-          )}
-          {dispute.resolved_at && (
-            <div><dt>Resolved At</dt><dd>{formatTime(dispute.resolved_at)}</dd></div>
-          )}
-          {dispute.settlement_id && (
-            <div><dt>Settlement ID</dt><dd>{dispute.settlement_id}</dd></div>
-          )}
-          {dispute.notes && (
-            <div><dt>Notes</dt><dd>{dispute.notes}</dd></div>
-          )}
-          <div><dt>Created At</dt><dd>{formatTime(dispute.created_at)}</dd></div>
-        </dl>
-
-        {dispute.evidence && Object.keys(dispute.evidence).length > 0 && (
-          <div style={{ marginTop: "1.5rem" }}>
-            <h3>Submitted Evidence</h3>
-            <pre style={{ background: "var(--surface)", padding: "1rem", borderRadius: "0.5rem", overflow: "auto", fontSize: "0.85rem" }}>
-              {JSON.stringify(dispute.evidence, null, 2)}
-            </pre>
-          </div>
-        )}
-
-        {!isTerminal && (
-          <div style={{ marginTop: "1.5rem" }}>
-            <p className="muted">
-              Use the API to submit evidence, start review, or resolve this dispute.
-            </p>
-            <div className="row-meta" style={{ marginTop: "0.5rem" }}>
-              {dispute.status === "open" && (
-                <>
-                  <code>POST /v1/disputes/{dispute.id}/submit-evidence</code>
-                  <code>POST /v1/disputes/{dispute.id}/review</code>
-                  <code>POST /v1/disputes/{dispute.id}/accept</code>
-                </>
-              )}
-              {dispute.status === "under_review" && (
-                <code>POST /v1/disputes/{dispute.id}/resolve {`{"outcome":"won"}`}</code>
-              )}
-            </div>
-          </div>
-        )}
+      <div className="key-facts">
+        <div className="key-fact">
+          <span className="eyebrow">Status</span>
+          <strong>{dispute.status}</strong>
+        </div>
+        <div className="key-fact">
+          <span className="eyebrow">Reason</span>
+          <strong>{dispute.reason}</strong>
+        </div>
+        <div className="key-fact">
+          <span className="eyebrow">Evidence</span>
+          <strong>{submitted ? "Submitted" : "Pending"}</strong>
+        </div>
       </div>
+
+      <div className="detail-grid">
+        <div className="detail-card">
+          <h2>Case summary</h2>
+          <dl className="detail-list">
+            <div><dt>Payment ID</dt><dd>{truncateMiddle(dispute.payment_id)}</dd></div>
+            <div><dt>Amount</dt><dd>{formatMoney(dispute.amount, dispute.currency)}</dd></div>
+            <div><dt>Reason</dt><dd>{dispute.reason}</dd></div>
+            <div><dt>Status</dt><dd><span className={statusBadge(dispute.status)}>{dispute.status}</span></dd></div>
+            {dispute.due_by && (
+              <div><dt>Evidence due by</dt><dd>{formatTime(dispute.due_by)}</dd></div>
+            )}
+            {dispute.evidence_submitted_at && (
+              <div><dt>Evidence submitted</dt><dd>{formatTime(dispute.evidence_submitted_at)}</dd></div>
+            )}
+            {dispute.resolved_at && (
+              <div><dt>Resolved at</dt><dd>{formatTime(dispute.resolved_at)}</dd></div>
+            )}
+            {dispute.settlement_id && (
+              <div><dt>Settlement ID</dt><dd>{truncateMiddle(dispute.settlement_id)}</dd></div>
+            )}
+            {dispute.notes && (
+              <div><dt>Notes</dt><dd>{dispute.notes}</dd></div>
+            )}
+            <div><dt>Created at</dt><dd>{formatTime(dispute.created_at)}</dd></div>
+          </dl>
+        </div>
+
+        <div className="detail-card">
+          <h2>Case progress</h2>
+          <div className="timeline">
+            {timeline.map((entry) => (
+              <div className={`timeline-item${entry.active ? " active" : ""}`} key={entry.label}>
+                <div className="timeline-dot" />
+                <div>
+                  <div className="row-title">{entry.label}</div>
+                  <div className="muted">{entry.active ? formatTime(entry.at) : "Pending"}</div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {dispute.evidence && Object.keys(dispute.evidence).length > 0 && (
+        <div className="detail-card">
+          <h2>Submitted evidence payload</h2>
+          <pre>{JSON.stringify(dispute.evidence, null, 2)}</pre>
+        </div>
+      )}
+
+      <DisputeActionPanel apiBaseUrl={getApiBaseUrl()} dispute={dispute} />
     </section>
   );
 }

--- a/dashboard/app/gateway/page.tsx
+++ b/dashboard/app/gateway/page.tsx
@@ -1,4 +1,5 @@
-import { getActiveGatewayScenario, getGatewayScenarios, requireViewer } from "../../lib/api";
+import GatewayScenarioControl from "../../components/gateway-scenario-control";
+import { getActiveGatewayScenario, getApiBaseUrl, getGatewayScenarios, requireViewer } from "../../lib/api";
 import { formatTime } from "../../lib/types";
 
 function modeBadge(mode: string) {
@@ -33,13 +34,24 @@ export default async function GatewaySimulatorPage() {
   ]);
 
   return (
-    <section className="stack">
+    <section className="stack fade-up">
       <div className="hero-card">
         <div className="eyebrow">Gateway Simulator</div>
         <h1>Payment Gateway Control Panel</h1>
         <p className="lede">
-          Configure the simulated payment gateway behavior for testing failure paths and edge cases.
+          Configure simulated gateway behavior for failure-path testing, latency drills, and
+          callback timing edge cases.
         </p>
+        <div className="metric-strip">
+          <div className="metric-chip">
+            <span className="metric-chip-label">Active mode</span>
+            <strong>{active?.mode ?? "success"}</strong>
+          </div>
+          <div className="metric-chip">
+            <span className="metric-chip-label">Saved scenarios</span>
+            <strong>{scenarios.count}</strong>
+          </div>
+        </div>
       </div>
 
       {active && (
@@ -58,70 +70,31 @@ export default async function GatewaySimulatorPage() {
         </div>
       )}
 
-      <div className="detail-card">
-        <h2>Change Scenario</h2>
-        <p className="muted">Use the API to configure the gateway simulator:</p>
-        <div style={{ marginTop: "1rem", display: "flex", flexDirection: "column", gap: "0.75rem" }}>
-          {[
-            { mode: "success", label: "Happy Path", desc: "All payments succeed" },
-            { mode: "slow", label: "Slow Gateway", desc: "3 second delay" },
-            { mode: "flaky", label: "Flaky (30%)", desc: "30% random failures" },
-            { mode: "decline", label: "All Declined", desc: "All payments fail" },
-            { mode: "timeout", label: "Timeout", desc: "No response at all" },
-          ].map(({ mode, label, desc }) => (
-            <div key={mode} className="list-row" style={{ cursor: "default" }}>
-              <div>
-                <div className="row-title">{label}</div>
-                <div className="row-meta">
-                  <span className={modeBadge(mode)}>{mode}</span>
-                  <span>{desc}</span>
-                </div>
-              </div>
-              <code style={{ fontSize: "0.75rem", opacity: 0.7 }}>
-                POST /v1/gateway/scenarios
-              </code>
-            </div>
-          ))}
-        </div>
+      <GatewayScenarioControl
+        apiBaseUrl={getApiBaseUrl()}
+        initialActive={active}
+        initialItems={scenarios.items}
+      />
 
-        <div style={{ marginTop: "1.5rem" }}>
-          <h3>API Example</h3>
-          <pre style={{ background: "var(--surface)", padding: "1rem", borderRadius: "0.5rem", overflow: "auto", fontSize: "0.85rem" }}>
-{`# Switch to flaky mode (30% failure rate)
+      <div className="detail-card">
+        <h2>API Example</h2>
+        <pre>
+{`# These endpoints require an admin API key or an admin dashboard session.
+# Switch to flaky mode (30% failure rate)
 curl -X POST http://localhost:8090/v1/gateway/scenarios \\
+  -u "$ADMIN_KEY_ID:$ADMIN_KEY_SECRET" \\
   -H 'Content-Type: application/json' \\
   -d '{"mode":"flaky","failure_rate":0.30,"delay_ms":0}'
 
 # Switch back to success mode
 curl -X POST http://localhost:8090/v1/gateway/scenarios \\
+  -u "$ADMIN_KEY_ID:$ADMIN_KEY_SECRET" \\
   -d '{"mode":"success"}'
 
 # Check active scenario
-curl http://localhost:8090/v1/gateway/scenarios/active`}
-          </pre>
-        </div>
-      </div>
-
-      <div className="list-card">
-        <h2 style={{ padding: "1rem 1rem 0" }}>Scenario History</h2>
-        {scenarios.items.length === 0 ? (
-          <p className="muted" style={{ padding: "1rem" }}>No scenarios configured yet. Using default (success) mode.</p>
-        ) : (
-          scenarios.items.map((sc) => (
-            <div className="list-row" key={sc.id}>
-              <div>
-                <div className="row-title">{sc.merchant_id || "Global"}</div>
-                <div className="row-meta">
-                  <span className={modeBadge(sc.mode)}>{sc.mode}</span>
-                  {sc.mode === "flaky" && <span>{Math.round(sc.failure_rate * 100)}% failure</span>}
-                  {(sc.mode === "slow" || sc.mode === "late_callback") && <span>{sc.delay_ms}ms delay</span>}
-                  {sc.active && <span className="badge-success">active</span>}
-                  <span>{formatTime(sc.created_at)}</span>
-                </div>
-              </div>
-            </div>
-          ))
-        )}
+curl -u "$ADMIN_KEY_ID:$ADMIN_KEY_SECRET" \\
+  http://localhost:8090/v1/gateway/scenarios/active`}
+        </pre>
       </div>
     </section>
   );

--- a/dashboard/app/observability/page.tsx
+++ b/dashboard/app/observability/page.tsx
@@ -1,4 +1,5 @@
 import { requireViewer, getPrometheusMetricSum } from "../../lib/api";
+import { formatCompactNumber } from "../../lib/types";
 
 export default async function ObservabilityPage() {
   await requireViewer();
@@ -39,19 +40,69 @@ export default async function ObservabilityPage() {
     ? "badge-warning"
     : "badge-success";
 
+  const counters = [
+    { label: "Payments", value: paymentsTotal ?? 0, note: "attempts" },
+    { label: "Orders", value: ordersTotal ?? 0, note: "created" },
+    { label: "Refunds", value: refundsTotal ?? 0, note: "issued" },
+    { label: "Webhook Deliveries", value: webhookDeliveries ?? 0, note: "attempts" },
+    { label: "Disputes", value: disputesTotal ?? 0, note: "cases" },
+    { label: "Payouts", value: payoutsTotal ?? 0, note: "transfers" },
+  ];
+  const maxCounter = Math.max(...counters.map((item) => item.value), 1);
+
   return (
-    <section className="stack">
+    <section className="stack fade-up">
       <div className="hero-card">
         <div className="eyebrow">System Health</div>
         <h1>Observability</h1>
         <p className="lede">
-          Cumulative metrics since last restart. For time-series charts and
-          alerting, open Grafana on{" "}
+          Cumulative platform counters since last restart. Use this surface for rapid operator
+          orientation, then move into Grafana for time-series and alert detail on{" "}
           <a href="http://localhost:3100" target="_blank" rel="noreferrer">
             localhost:3100
-          </a>{" "}
-          (admin / paygate).
+          </a>.
         </p>
+        <div className="metric-strip">
+          <div className="metric-chip">
+            <span className="metric-chip-label">Outbox</span>
+            <strong>{outboxUnpublished ?? 0}</strong>
+          </div>
+          <div className="metric-chip">
+            <span className="metric-chip-label">Traffic</span>
+            <strong>{formatCompactNumber(httpRequests)}</strong>
+          </div>
+          <div className="metric-chip">
+            <span className="metric-chip-label">Webhook attempts</span>
+            <strong>{formatCompactNumber(webhookDeliveries)}</strong>
+          </div>
+        </div>
+      </div>
+
+      <div className="triple-grid">
+        <div className="spotlight-card">
+          <div className="eyebrow">Delivery Health</div>
+          <h2>Async pipeline</h2>
+          <div className={outboxBadge}>{outboxOk ? "Healthy" : outboxUnpublished === null ? "Unknown" : "Needs attention"}</div>
+          <p className="muted">
+            Outbox backlog is {outboxUnpublished ?? "unknown"} and webhook delivery attempts total {fmt(webhookDeliveries)}.
+          </p>
+        </div>
+        <div className="spotlight-card">
+          <div className="eyebrow">Traffic Posture</div>
+          <h2>Request volume</h2>
+          <div className="stat-value">{fmt(httpRequests)}</div>
+          <p className="muted">
+            Aggregate request count since process start across authenticated dashboard and API traffic.
+          </p>
+        </div>
+        <div className="spotlight-card">
+          <div className="eyebrow">Money Flow</div>
+          <h2>Commercial load</h2>
+          <div className="stat-value">{fmt(paymentsTotal)}</div>
+          <p className="muted">
+            Payment attempts remain the strongest leading indicator for downstream webhook, refund, and settlement activity.
+          </p>
+        </div>
       </div>
 
       <div className="detail-grid">
@@ -119,6 +170,34 @@ export default async function ObservabilityPage() {
       </div>
 
       <div className="detail-card">
+        <div className="section-head">
+          <div>
+            <h2>Counter distribution</h2>
+            <div className="section-kicker">Relative scale across major platform counters</div>
+          </div>
+        </div>
+        <div className="stack" style={{ marginTop: "16px" }}>
+          {counters.map((item) => (
+            <div className="signal-row" key={item.label}>
+              <div className="signal-head">
+                <div className="row-title">{item.label}</div>
+                <div className="row-meta">
+                  <span>{fmt(item.value)}</span>
+                  <span>{item.note}</span>
+                </div>
+              </div>
+              <div className="signal-track">
+                <div
+                  className="signal-fill"
+                  style={{ width: `${Math.max(8, (item.value / maxCounter) * 100)}%` }}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="detail-card">
         <h2>Grafana Dashboards</h2>
         <p className="muted" style={{ marginBottom: "1rem" }}>
           These pre-built dashboards are provisioned automatically when you start the monitoring stack.
@@ -162,7 +241,7 @@ export default async function ObservabilityPage() {
       </div>
 
       <div className="detail-card">
-        <h2>Start Monitoring Stack</h2>
+        <h2>Monitoring Stack</h2>
         <p className="muted">
           Prometheus, Grafana, and Alertmanager are defined in <code>docker-compose.yml</code>.
         </p>

--- a/dashboard/app/recon/page.tsx
+++ b/dashboard/app/recon/page.tsx
@@ -1,5 +1,5 @@
 import { getReconMismatches, requireViewer } from "../../lib/api";
-import { formatTime } from "../../lib/types";
+import { formatCompactNumber, formatTime, truncateMiddle } from "../../lib/types";
 
 export default async function ReconPage() {
   const viewer = await requireViewer();
@@ -16,28 +16,63 @@ export default async function ReconPage() {
     payment_settled_not_in_batch: "Settled Without Batch",
   };
 
+  const groupedOpen = open.reduce<Record<string, number>>((acc, item) => {
+    acc[item.mismatch_type] = (acc[item.mismatch_type] ?? 0) + 1;
+    return acc;
+  }, {});
+
   return (
-    <section className="stack">
+    <section className="stack fade-up">
       <div className="hero-card">
         <div className="eyebrow">Reconciliation</div>
-        <h1>Recon Dashboard</h1>
+        <h1>Reconciliation Control</h1>
         <p className="lede">
           {open.length} open mismatch{open.length !== 1 ? "es" : ""} · {resolved.length} resolved
           for {viewer.merchant_id}.
         </p>
+        <div className="metric-strip">
+          <div className="metric-chip">
+            <span className="metric-chip-label">Open</span>
+            <strong>{formatCompactNumber(open.length)}</strong>
+          </div>
+          <div className="metric-chip">
+            <span className="metric-chip-label">Resolved</span>
+            <strong>{formatCompactNumber(resolved.length)}</strong>
+          </div>
+          <div className="metric-chip">
+            <span className="metric-chip-label">Distinct mismatch types</span>
+            <strong>{Object.keys(groupedOpen).length}</strong>
+          </div>
+        </div>
       </div>
+
+      {open.length > 0 ? (
+        <div className="summary-grid">
+          {Object.entries(groupedOpen).map(([type, count]) => (
+            <div className="metric-card" key={type}>
+              <div className="eyebrow">Mismatch Type</div>
+              <div className="stat-value">{count}</div>
+              <div className="stat-label">{mismatchTypeLabel[type] ?? type}</div>
+            </div>
+          ))}
+        </div>
+      ) : null}
 
       {open.length > 0 && (
         <div className="list-card">
-          <h2 className="section-heading">
-            Open Mismatches ({open.length})
-          </h2>
+          <div className="section-head">
+            <div>
+              <h2>Open mismatches</h2>
+              <div className="section-kicker">Expected value, actual value, entity scope, and detection time</div>
+            </div>
+          </div>
           {open.map((mm) => (
             <div className="list-row list-row-error" key={mm.id}>
-              <div>
+              <div className="entity-primary">
                 <div className="row-title">
                   {mismatchTypeLabel[mm.mismatch_type] ?? mm.mismatch_type}
                 </div>
+                <div className="mono">{truncateMiddle(mm.id)}</div>
                 <div className="row-meta">
                   <span>{mm.entity_type}: {mm.entity_id}</span>
                   <span>Expected: {mm.expected_value}</span>
@@ -52,22 +87,27 @@ export default async function ReconPage() {
       )}
 
       {open.length === 0 && (
-        <div className="hero-card-success">
+        <div className="success-panel">
+          <div className="eyebrow">Healthy State</div>
           <p className="lede">All reconciliation checks passed. No open mismatches.</p>
         </div>
       )}
 
       {resolved.length > 0 && (
         <div className="list-card">
-          <h2 className="section-heading">
-            Resolved ({resolved.length})
-          </h2>
+          <div className="section-head">
+            <div>
+              <h2>Resolved mismatches</h2>
+              <div className="section-kicker">Historical anomalies already acknowledged or corrected</div>
+            </div>
+          </div>
           {resolved.map((mm) => (
             <div className="list-row" key={mm.id}>
-              <div>
+              <div className="entity-primary">
                 <div className="row-title">
                   {mismatchTypeLabel[mm.mismatch_type] ?? mm.mismatch_type}
                 </div>
+                <div className="mono">{truncateMiddle(mm.id)}</div>
                 <div className="row-meta">
                   <span>{mm.entity_type}: {mm.entity_id}</span>
                   <span>{formatTime(mm.created_at)}</span>

--- a/dashboard/components/api-key-detail-manager.tsx
+++ b/dashboard/components/api-key-detail-manager.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useState } from "react";
+
+import IPAllowlistManager from "./ip-allowlist-manager";
+import { formatTime, type APIKeyItem } from "../lib/types";
+
+type RotateKeyResponse = {
+  key_id: string;
+  key_secret: string;
+  mode: string;
+  scope: string;
+};
+
+export default function APIKeyDetailManager({
+  apiBaseUrl,
+  item,
+}: {
+  apiBaseUrl: string;
+  item: APIKeyItem;
+}) {
+  const [pending, setPending] = useState(false);
+  const [message, setMessage] = useState("");
+  const [rotated, setRotated] = useState<RotateKeyResponse | null>(null);
+
+  async function rotateKey() {
+    setPending(true);
+    setMessage("");
+    setRotated(null);
+    try {
+      const response = await fetch(`${apiBaseUrl}/v1/merchants/me/api-keys/${item.id}/rotate`, {
+        method: "POST",
+        credentials: "include",
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        setMessage((data as { error?: { description?: string } }).error?.description ?? "Key rotation failed");
+        return;
+      }
+      setRotated(data as RotateKeyResponse);
+    } catch {
+      setMessage("Network error while rotating the key.");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <section className="stack fade-up">
+      <div className="hero-card">
+        <div className="eyebrow">Credential Detail</div>
+        <h1>{item.id}</h1>
+        <p className="lede">
+          Review lifecycle metadata, rotate the credential, and manage its source-IP policy.
+        </p>
+        <div className="metric-strip">
+          <div className="metric-chip">
+            <span className="metric-chip-label">Mode</span>
+            <strong>{item.mode}</strong>
+          </div>
+          <div className="metric-chip">
+            <span className="metric-chip-label">Scope</span>
+            <strong>{item.scope}</strong>
+          </div>
+          <div className="metric-chip">
+            <span className="metric-chip-label">Status</span>
+            <strong>{item.status}</strong>
+          </div>
+        </div>
+      </div>
+
+      <div className="detail-grid">
+        <div className="detail-card">
+          <h2>Lifecycle</h2>
+          <dl className="detail-list">
+            <div>
+              <dt>Created</dt>
+              <dd>{formatTime(item.created_at)}</dd>
+            </div>
+            <div>
+              <dt>Last used</dt>
+              <dd>{item.last_used_at ? formatTime(item.last_used_at) : "Not yet used"}</dd>
+            </div>
+            <div>
+              <dt>Revoked at</dt>
+              <dd>{item.revoked_at ? formatTime(item.revoked_at) : "Active"}</dd>
+            </div>
+            <div>
+              <dt>Allowed IP entries</dt>
+              <dd>{item.allowed_ips?.length ?? 0}</dd>
+            </div>
+          </dl>
+        </div>
+
+        <div className="detail-card">
+          <h2>Rotate key</h2>
+          <p className="muted">
+            Rotation revokes the current credential and issues a replacement with the same mode and scope.
+          </p>
+          <div className="hero-actions">
+            <button
+              className="primary-button"
+              disabled={pending || item.status !== "active"}
+              onClick={rotateKey}
+              type="button"
+            >
+              {pending ? "Rotating..." : "Rotate Credential"}
+            </button>
+          </div>
+          {message ? <p className="notice error">{message}</p> : null}
+          {rotated ? (
+            <div className="secret-card" style={{ marginTop: "16px" }}>
+              <div className="eyebrow">Replacement Secret Shown Once</div>
+              <code>{rotated.key_id}</code>
+              <code>{rotated.key_secret}</code>
+            </div>
+          ) : null}
+        </div>
+      </div>
+
+      <IPAllowlistManager
+        apiBaseUrl={apiBaseUrl}
+        initialIPs={item.allowed_ips ?? []}
+        keyId={item.id}
+      />
+    </section>
+  );
+}

--- a/dashboard/components/api-key-manager.tsx
+++ b/dashboard/components/api-key-manager.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useDeferredValue, useMemo, useState } from "react";
 
-import type { APIKeyItem } from "../lib/types";
+import { formatTime, type APIKeyItem } from "../lib/types";
 
 type CreateKeyResponse = {
   key_id: string;
@@ -21,14 +21,32 @@ export default function APIKeyManager({
   const [items, setItems] = useState(initialItems);
   const [mode, setMode] = useState("test");
   const [scope, setScope] = useState("write");
+  const [statusFilter, setStatusFilter] = useState<"all" | "active" | "revoked">("all");
+  const [query, setQuery] = useState("");
   const [pending, setPending] = useState(false);
   const [message, setMessage] = useState("");
   const [created, setCreated] = useState<CreateKeyResponse | null>(null);
+  const deferredQuery = useDeferredValue(query);
 
   const activeCount = useMemo(
     () => items.filter((item) => item.status === "active").length,
     [items],
   );
+
+  const visibleItems = useMemo(() => {
+    const lowered = deferredQuery.trim().toLowerCase();
+    return items.filter((item) => {
+      if (statusFilter !== "all" && item.status !== statusFilter) {
+        return false;
+      }
+      if (!lowered) {
+        return true;
+      }
+      return [item.id, item.mode, item.scope, item.status].some((value) =>
+        value.toLowerCase().includes(lowered),
+      );
+    });
+  }, [items, statusFilter, deferredQuery]);
 
   async function createKey() {
     setPending(true);
@@ -91,13 +109,52 @@ export default function APIKeyManager({
   }
 
   return (
-    <section className="stack">
+    <section className="stack fade-up">
       <div className="hero-card">
         <div className="eyebrow">Access Surface</div>
         <h1>API Keys</h1>
         <p className="lede">
           Manage live credentials for integrations. Active keys: {activeCount}.
         </p>
+        <div className="metric-strip">
+          <div className="metric-chip">
+            <span className="metric-chip-label">Total keys</span>
+            <strong>{items.length}</strong>
+          </div>
+          <div className="metric-chip">
+            <span className="metric-chip-label">Active</span>
+            <strong>{activeCount}</strong>
+          </div>
+        </div>
+        <div className="inline-form">
+          <label style={{ minWidth: "220px" }}>
+            Search
+            <input
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Filter by key id, mode, scope, or status"
+              type="text"
+              value={query}
+            />
+          </label>
+          <div className="filter-bar" role="tablist" aria-label="API key status filter">
+            {[
+              ["all", `All (${items.length})`],
+              ["active", `Active (${activeCount})`],
+              ["revoked", `Revoked (${items.length - activeCount})`],
+            ].map(([value, label]) => (
+              <button
+                aria-selected={statusFilter === value}
+                className={`filter-pill${statusFilter === value ? " active" : ""}`}
+                key={value}
+                onClick={() => setStatusFilter(value as "all" | "active" | "revoked")}
+                role="tab"
+                type="button"
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
         <div className="inline-form">
           <label>
             Mode
@@ -129,27 +186,43 @@ export default function APIKeyManager({
       </div>
 
       <div className="list-card">
-        {items.length === 0 ? (
-          <p className="muted">No keys issued yet.</p>
+        {visibleItems.length === 0 ? (
+          <div className="empty-state">
+            <strong>{items.length === 0 ? "No keys issued yet" : "No keys match this filter"}</strong>
+            <span className="muted">
+              {items.length === 0
+                ? "Create read, write, or admin credentials for merchant integrations."
+                : "Change the filter or search text to broaden the result set."}
+            </span>
+          </div>
         ) : (
-          items.map((item) => (
+          visibleItems.map((item) => (
             <article className="list-row" key={item.id}>
-              <div>
+              <div className="entity-primary">
                 <div className="row-title">{item.id}</div>
                 <div className="row-meta">
-                  <span>{item.mode}</span>
-                  <span>{item.scope}</span>
-                  <span>{item.status}</span>
+                  <span className="badge-neutral">{item.mode}</span>
+                  <span className="badge-info">{item.scope}</span>
+                  <span className={item.status === "active" ? "badge-success" : "badge-warning"}>
+                    {item.status}
+                  </span>
+                  {item.allowed_ips?.length ? <span>{item.allowed_ips.length} allowlisted IP entries</span> : null}
+                  <span>{item.last_used_at ? `Last used ${formatTime(item.last_used_at)}` : "Never used"}</span>
                 </div>
               </div>
-              <button
-                className="ghost-button"
-                disabled={pending || item.status !== "active"}
-                onClick={() => revokeKey(item.id)}
-                type="button"
-              >
-                Revoke
-              </button>
+              <div className="row-actions">
+                <a className="ghost-button" href={`/api-keys/${item.id}`}>
+                  IP Allowlist
+                </a>
+                <button
+                  className="ghost-button"
+                  disabled={pending || item.status !== "active"}
+                  onClick={() => revokeKey(item.id)}
+                  type="button"
+                >
+                  Revoke
+                </button>
+              </div>
             </article>
           ))
         )}

--- a/dashboard/components/dispute-action-panel.tsx
+++ b/dashboard/components/dispute-action-panel.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+import type { DisputeItem } from "../lib/types";
+
+export default function DisputeActionPanel({
+  apiBaseUrl,
+  dispute,
+}: {
+  apiBaseUrl: string;
+  dispute: DisputeItem;
+}) {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+  const [message, setMessage] = useState("");
+  const [evidenceText, setEvidenceText] = useState(
+    JSON.stringify(
+      {
+        customer_contacted: true,
+        delivery_status: "fulfilled",
+        note: "Attach merchant evidence here",
+      },
+      null,
+      2,
+    ),
+  );
+  const [resolveOutcome, setResolveOutcome] = useState("won");
+  const [notes, setNotes] = useState("");
+
+  async function run(path: string, body?: unknown) {
+    setPending(true);
+    setMessage("");
+    try {
+      const response = await fetch(`${apiBaseUrl}${path}`, {
+        method: "POST",
+        credentials: "include",
+        headers: body ? { "Content-Type": "application/json" } : undefined,
+        body: body ? JSON.stringify(body) : undefined,
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        setMessage((data as { error?: { description?: string } }).error?.description ?? "Action failed");
+        return;
+      }
+      setMessage("Action completed.");
+      router.refresh();
+    } catch {
+      setMessage("Network error while executing the dispute action.");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function submitEvidence() {
+    try {
+      const parsed = JSON.parse(evidenceText);
+      await run(`/v1/disputes/${dispute.id}/submit-evidence`, parsed);
+    } catch {
+      setMessage("Evidence must be valid JSON.");
+    }
+  }
+
+  if (["won", "lost", "accepted"].includes(dispute.status)) {
+    return null;
+  }
+
+  return (
+    <div className="detail-card">
+      <div className="section-head">
+        <div>
+          <h2>Inline actions</h2>
+          <div className="section-kicker">Execute dispute operations directly from the dashboard</div>
+        </div>
+      </div>
+
+      <div className="stack" style={{ marginTop: "16px" }}>
+        {dispute.status === "open" ? (
+          <>
+            <div className="spotlight-card">
+              <div className="row-title">Submit evidence</div>
+              <textarea
+                onChange={(event) => setEvidenceText(event.target.value)}
+                rows={10}
+                style={{ width: "100%" }}
+                value={evidenceText}
+              />
+              <div className="hero-actions">
+                <button className="primary-button" disabled={pending} onClick={submitEvidence} type="button">
+                  {pending ? "Submitting..." : "Submit Evidence"}
+                </button>
+              </div>
+            </div>
+
+            <div className="detail-grid">
+              <div className="spotlight-card">
+                <div className="row-title">Move to review</div>
+                <div className="muted">Use once evidence is ready for adjudication.</div>
+                <button
+                  className="ghost-button"
+                  disabled={pending}
+                  onClick={() => run(`/v1/disputes/${dispute.id}/review`)}
+                  type="button"
+                >
+                  Start Review
+                </button>
+              </div>
+              <div className="spotlight-card">
+                <div className="row-title">Accept dispute</div>
+                <div className="muted">Concede the dispute without contesting the outcome.</div>
+                <button
+                  className="ghost-button"
+                  disabled={pending}
+                  onClick={() => run(`/v1/disputes/${dispute.id}/accept`)}
+                  type="button"
+                >
+                  Accept Liability
+                </button>
+              </div>
+            </div>
+          </>
+        ) : null}
+
+        {dispute.status === "under_review" ? (
+          <div className="spotlight-card">
+            <div className="row-title">Resolve dispute</div>
+            <div className="inline-form">
+              <label>
+                Outcome
+                <select onChange={(event) => setResolveOutcome(event.target.value)} value={resolveOutcome}>
+                  <option value="won">won</option>
+                  <option value="lost">lost</option>
+                  <option value="accepted">accepted</option>
+                </select>
+              </label>
+              <label style={{ minWidth: "320px" }}>
+                Notes
+                <input onChange={(event) => setNotes(event.target.value)} type="text" value={notes} />
+              </label>
+            </div>
+            <div className="hero-actions">
+              <button
+                className="primary-button"
+                disabled={pending}
+                onClick={() =>
+                  run(`/v1/disputes/${dispute.id}/resolve`, {
+                    outcome: resolveOutcome,
+                    notes,
+                  })
+                }
+                type="button"
+              >
+                {pending ? "Resolving..." : "Resolve Dispute"}
+              </button>
+            </div>
+          </div>
+        ) : null}
+
+        {message ? (
+          <p className={`notice ${message === "Action completed." ? "success" : "error"}`}>{message}</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/components/gateway-scenario-control.tsx
+++ b/dashboard/components/gateway-scenario-control.tsx
@@ -1,0 +1,188 @@
+"use client";
+
+import { useState } from "react";
+
+import type { GatewayScenario } from "../lib/types";
+
+const presets = [
+  { mode: "success", label: "Happy Path", desc: "All authorizations succeed", failureRate: 0, delayMs: 0, declineCode: "CARD_DECLINED" },
+  { mode: "slow", label: "Slow Gateway", desc: "3 second delay before approval", failureRate: 0, delayMs: 3000, declineCode: "CARD_DECLINED" },
+  { mode: "flaky", label: "Flaky 30%", desc: "Randomized failure conditions", failureRate: 0.3, delayMs: 0, declineCode: "BANK_UNAVAILABLE" },
+  { mode: "decline", label: "Decline All", desc: "Every authorization declines", failureRate: 0, delayMs: 0, declineCode: "CARD_DECLINED" },
+  { mode: "timeout", label: "Timeout", desc: "No gateway response", failureRate: 0, delayMs: 0, declineCode: "GATEWAY_TIMEOUT" },
+  { mode: "late_callback", label: "Late Callback", desc: "Approval after long callback lag", failureRate: 0, delayMs: 4500, declineCode: "CARD_DECLINED" },
+] as const;
+
+export default function GatewayScenarioControl({
+  apiBaseUrl,
+  initialActive,
+  initialItems,
+}: {
+  apiBaseUrl: string;
+  initialActive: GatewayScenario | null;
+  initialItems: GatewayScenario[];
+}) {
+  const [active, setActive] = useState<GatewayScenario | null>(initialActive);
+  const [items, setItems] = useState(initialItems);
+  const [mode, setMode] = useState(initialActive?.mode ?? "success");
+  const [delayMs, setDelayMs] = useState(initialActive?.delay_ms ?? 0);
+  const [failureRate, setFailureRate] = useState(initialActive?.failure_rate ?? 0);
+  const [declineCode, setDeclineCode] = useState(initialActive?.decline_code ?? "CARD_DECLINED");
+  const [pending, setPending] = useState(false);
+  const [message, setMessage] = useState("");
+
+  async function applyScenario(payload: {
+    mode: string;
+    delay_ms?: number;
+    failure_rate?: number;
+    decline_code?: string;
+  }) {
+    setPending(true);
+    setMessage("");
+    try {
+      const response = await fetch(`${apiBaseUrl}/v1/gateway/scenarios`, {
+        method: "POST",
+        credentials: "include",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        setMessage((data as { error?: { description?: string } }).error?.description ?? "Failed to update gateway scenario");
+        return;
+      }
+      const scenario = data as GatewayScenario;
+      setActive(scenario);
+      setItems((current) => [scenario, ...current.filter((item) => item.id !== scenario.id)]);
+      setMode(scenario.mode);
+      setDelayMs(scenario.delay_ms);
+      setFailureRate(scenario.failure_rate);
+      setDeclineCode(scenario.decline_code);
+      setMessage("Gateway scenario updated.");
+    } catch {
+      setMessage("Network error while updating gateway scenario.");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  return (
+    <div className="stack">
+      <div className="detail-card">
+        <div className="section-head">
+          <div>
+            <h2>Inline scenario control</h2>
+            <div className="section-kicker">Apply known failure modes without leaving the dashboard</div>
+          </div>
+        </div>
+        <div className="triple-grid" style={{ marginTop: "16px" }}>
+          {presets.map((preset) => (
+            <button
+              className={`spotlight-card${active?.mode === preset.mode ? " active-card" : ""}`}
+              disabled={pending}
+              key={preset.mode}
+              onClick={() =>
+                applyScenario({
+                  mode: preset.mode,
+                  delay_ms: preset.delayMs,
+                  failure_rate: preset.failureRate,
+                  decline_code: preset.declineCode,
+                })
+              }
+              style={{ textAlign: "left", cursor: "pointer" }}
+              type="button"
+            >
+              <div className="row-title">{preset.label}</div>
+              <div className="row-meta">
+                <span>{preset.mode}</span>
+              </div>
+              <div className="muted">{preset.desc}</div>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="detail-card">
+        <div className="section-head">
+          <div>
+            <h2>Custom scenario</h2>
+            <div className="section-kicker">Tune latency, failure rate, and decline behavior</div>
+          </div>
+        </div>
+        <div className="inline-form" style={{ marginTop: "16px" }}>
+          <label>
+            Mode
+            <select onChange={(event) => setMode(event.target.value)} value={mode}>
+              <option value="success">success</option>
+              <option value="slow">slow</option>
+              <option value="flaky">flaky</option>
+              <option value="decline">decline</option>
+              <option value="timeout">timeout</option>
+              <option value="late_callback">late_callback</option>
+            </select>
+          </label>
+          <label>
+            Delay (ms)
+            <input min={0} onChange={(event) => setDelayMs(Number(event.target.value) || 0)} type="number" value={delayMs} />
+          </label>
+          <label>
+            Failure Rate
+            <input max={1} min={0} onChange={(event) => setFailureRate(Number(event.target.value) || 0)} step="0.05" type="number" value={failureRate} />
+          </label>
+          <label>
+            Decline Code
+            <input onChange={(event) => setDeclineCode(event.target.value)} type="text" value={declineCode} />
+          </label>
+        </div>
+        <div className="hero-actions">
+          <button
+            className="primary-button"
+            disabled={pending}
+            onClick={() =>
+              applyScenario({
+                mode,
+                delay_ms: delayMs,
+                failure_rate: failureRate,
+                decline_code: declineCode,
+              })
+            }
+            type="button"
+          >
+            {pending ? "Applying..." : "Apply Custom Scenario"}
+          </button>
+          {message ? <span className="micro-copy">{message}</span> : null}
+        </div>
+      </div>
+
+      <div className="list-card">
+        <div className="section-head">
+          <div>
+            <h2>Scenario history</h2>
+            <div className="section-kicker">Most recent control changes</div>
+          </div>
+        </div>
+        {items.length === 0 ? (
+          <div className="empty-state">
+            <strong>No scenarios configured</strong>
+            <span className="muted">Default behavior remains the success path until a scenario is applied.</span>
+          </div>
+        ) : (
+          items.map((sc) => (
+            <div className="list-row" key={sc.id}>
+              <div className="entity-primary">
+                <div className="row-title">{sc.merchant_id || "Global"}</div>
+                <div className="row-meta">
+                  <span>{sc.mode}</span>
+                  {sc.failure_rate > 0 ? <span>{Math.round(sc.failure_rate * 100)}% failure</span> : null}
+                  {sc.delay_ms > 0 ? <span>{sc.delay_ms}ms delay</span> : null}
+                  {sc.active ? <span className="badge-success">active</span> : null}
+                  <span>{new Date(sc.created_at * 1000).toLocaleString("en-IN", { dateStyle: "medium", timeStyle: "short" })}</span>
+                </div>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/components/ip-allowlist-manager.tsx
+++ b/dashboard/components/ip-allowlist-manager.tsx
@@ -24,16 +24,19 @@ function isValidIPOrCIDR(value: string): boolean {
 export default function IPAllowlistManager({
   keyId,
   apiBaseUrl,
+  initialIPs,
 }: {
   keyId: string;
   apiBaseUrl: string;
+  initialIPs: string[];
 }) {
-  const [ips, setIps] = useState<string[]>([]);
+  const [ips, setIps] = useState<string[]>(initialIPs);
   const [input, setInput] = useState("");
   const [inputError, setInputError] = useState("");
   const [pending, setPending] = useState(false);
   const [message, setMessage] = useState("");
   const [messageType, setMessageType] = useState<"error" | "success">("error");
+  const dirty = JSON.stringify(ips) !== JSON.stringify(initialIPs);
 
   function addIP() {
     const trimmed = input.trim();
@@ -53,6 +56,13 @@ export default function IPAllowlistManager({
 
   function removeIP(ip: string) {
     setIps((current) => current.filter((item) => item !== ip));
+  }
+
+  function reset() {
+    setIps(initialIPs);
+    setInput("");
+    setInputError("");
+    setMessage("");
   }
 
   function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
@@ -103,10 +113,20 @@ export default function IPAllowlistManager({
           Restrict this API key to requests originating from specific IP
           addresses or CIDR ranges. Leave the list empty to allow all IPs.
         </p>
-        <p className="row-meta">
-          <span>Key ID:</span>
-          <code>{keyId}</code>
-        </p>
+        <div className="metric-strip">
+          <div className="metric-chip">
+            <span className="metric-chip-label">Key</span>
+            <code>{keyId}</code>
+          </div>
+          <div className="metric-chip">
+            <span className="metric-chip-label">Entries</span>
+            <strong>{ips.length}</strong>
+          </div>
+          <div className="metric-chip">
+            <span className="metric-chip-label">Policy</span>
+            <strong>{ips.length === 0 ? "Open" : "Restricted"}</strong>
+          </div>
+        </div>
       </div>
 
       <div className="list-card">
@@ -135,11 +155,17 @@ export default function IPAllowlistManager({
           </div>
         </div>
         {inputError ? <p className="notice error">{inputError}</p> : null}
+        <div className="row-meta">
+          <span>Examples: 203.0.113.8, 198.51.100.0/24, 2001:db8::/32</span>
+        </div>
       </div>
 
       <div className="list-card">
         {ips.length === 0 ? (
-          <p className="muted">No IPs added — all source addresses are currently allowed.</p>
+          <div className="empty-state">
+            <strong>No IP restrictions</strong>
+            <span className="muted">All source addresses are currently allowed for this key.</span>
+          </div>
         ) : (
           ips.map((ip) => (
             <div className="list-row" key={ip}>
@@ -161,14 +187,27 @@ export default function IPAllowlistManager({
 
       <div className="list-card">
         <div className="list-row">
-          <button
-            className="primary-button"
-            type="button"
-            disabled={pending}
-            onClick={save}
-          >
-            {pending ? "Saving..." : "Save Allowlist"}
-          </button>
+          <div className="row-actions">
+            <button
+              className="primary-button"
+              type="button"
+              disabled={pending || !dirty}
+              onClick={save}
+            >
+              {pending ? "Saving..." : "Save Allowlist"}
+            </button>
+            <button
+              className="ghost-button"
+              type="button"
+              disabled={pending || !dirty}
+              onClick={reset}
+            >
+              Reset Changes
+            </button>
+          </div>
+          <div className="micro-copy">
+            {dirty ? "Unsaved changes" : "Saved state matches the server snapshot used to open this page"}
+          </div>
         </div>
         {message ? (
           <p className={`notice ${messageType === "success" ? "success" : "error"}`}>

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -328,7 +328,6 @@ export async function getPrometheusMetricSum(metricName: string): Promise<number
   try {
     const res = await fetch(`${getApiBaseUrl()}/metrics`, {
       cache: 'no-store',
-      next: { revalidate: 0 },
     });
     if (!res.ok) return null;
     const text = await res.text();

--- a/internal/merchant/handler.go
+++ b/internal/merchant/handler.go
@@ -292,6 +292,7 @@ func (h *Handler) listOwnAPIKeys(w http.ResponseWriter, r *http.Request) {
 			"mode":         key.Mode,
 			"scope":        key.Scope,
 			"status":       key.Status,
+			"allowed_ips":  key.AllowedIPs,
 			"last_used_at": lastUsedAt,
 			"revoked_at":   revokedAt,
 			"created_at":   key.CreatedAt.Unix(),
@@ -428,13 +429,13 @@ func (h *Handler) inviteUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	httpx.WriteJSON(w, http.StatusCreated, map[string]any{
-		"id":          inv.ID,
-		"email":       inv.Email,
-		"role":        inv.Role,
-		"status":      inv.Status,
-		"token":       token,
-		"expires_at":  inv.ExpiresAt.Unix(),
-		"created_at":  inv.CreatedAt.Unix(),
+		"id":         inv.ID,
+		"email":      inv.Email,
+		"role":       inv.Role,
+		"status":     inv.Status,
+		"token":      token,
+		"expires_at": inv.ExpiresAt.Unix(),
+		"created_at": inv.CreatedAt.Unix(),
 	})
 }
 


### PR DESCRIPTION
## Summary
This PR pushes the dashboard beyond polished CRUD into a richer operator console with inline controls, live actions, denser observability, and API key workflow depth.

## Includes
- inline gateway simulator controls
- inline dispute actions
- API key filtering, detail, rotation, and allowlist depth
- stronger reconciliation and observability operator surfaces
- merchant API support for surfaced allowlist metadata

## Tracking
Refs #402
Stacked on #408

## Review Note
This PR intentionally layers on top of the dashboard foundation branch to keep the UX/control changes isolated from the shell redesign.