### PR TITLE
[#417] Stabilize outbox replay, webhook delivery, and async resilience

### DIFF
--- a/cmd/outbox-relay/main.go
+++ b/cmd/outbox-relay/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/sanskarpan/PayGate/internal/common/config"
 	"github.com/sanskarpan/PayGate/internal/common/logger"
+	"github.com/sanskarpan/PayGate/internal/eventschema"
 	"github.com/sanskarpan/PayGate/internal/outbox"
 )
 
@@ -33,7 +34,11 @@ func run() error {
 	publisher := outbox.NewKafkaPublisher(cfg.KafkaBrokers)
 	defer func() { _ = publisher.Close() }()
 
-	relay := outbox.NewRelay(db, publisher, time.Second, logger.New("outbox-relay"))
+	schemaSvc := eventschema.NewService(eventschema.NewPostgresRepository(db), logger.New("event-schema"))
+	if err := schemaSvc.BootstrapFromFixtures(ctx, "schemas/events", "platform"); err != nil {
+		return err
+	}
+	relay := outbox.NewRelay(db, publisher, time.Second, logger.New("outbox-relay")).WithSchemaVersionResolver(schemaSvc)
 	relay.Start(ctx)
 	return nil
 }

--- a/cmd/outbox-relay/main.go
+++ b/cmd/outbox-relay/main.go
@@ -10,7 +10,6 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/sanskarpan/PayGate/internal/common/config"
 	"github.com/sanskarpan/PayGate/internal/common/logger"
-	"github.com/sanskarpan/PayGate/internal/eventschema"
 	"github.com/sanskarpan/PayGate/internal/outbox"
 )
 
@@ -34,11 +33,7 @@ func run() error {
 	publisher := outbox.NewKafkaPublisher(cfg.KafkaBrokers)
 	defer func() { _ = publisher.Close() }()
 
-	schemaSvc := eventschema.NewService(eventschema.NewPostgresRepository(db), logger.New("event-schema"))
-	if err := schemaSvc.BootstrapFromFixtures(ctx, "schemas/events", "platform"); err != nil {
-		return err
-	}
-	relay := outbox.NewRelay(db, publisher, time.Second, logger.New("outbox-relay")).WithSchemaVersionResolver(schemaSvc)
+	relay := outbox.NewRelay(db, publisher, time.Second, logger.New("outbox-relay"))
 	relay.Start(ctx)
 	return nil
 }

--- a/internal/outbox/relay.go
+++ b/internal/outbox/relay.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
-	appmetrics "github.com/sanskarpan/PayGate/internal/common/metrics"
 )
 
 type Publisher interface {
@@ -143,7 +142,6 @@ FOR UPDATE SKIP LOCKED
 			if err := publishWithRetry(ctx, r.publisher, topic, rec.MerchantID, payload); err != nil {
 				return 0, err
 			}
-			appmetrics.EventSchemaPublishesTotal.WithLabelValues(topic, rec.EventType, schema.Subject, schema.Version).Inc()
 		}
 		if _, err := tx.Exec(ctx, `UPDATE public.outbox SET published_at = NOW() WHERE id = $1`, rec.ID); err != nil {
 			return 0, fmt.Errorf("mark outbox published: %w", err)

--- a/internal/outbox/relay.go
+++ b/internal/outbox/relay.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
+	appmetrics "github.com/sanskarpan/PayGate/internal/common/metrics"
 )
 
 type Publisher interface {
@@ -21,6 +22,16 @@ type Relay struct {
 	publisher Publisher
 	logger    *slog.Logger
 	interval  time.Duration
+	resolver  SchemaVersionResolver
+}
+
+type PublishSchemaVersion struct {
+	Subject string
+	Version string
+}
+
+type SchemaVersionResolver interface {
+	ResolvePublishVersions(ctx context.Context, subject string) ([]PublishSchemaVersion, error)
 }
 
 type Record struct {
@@ -41,6 +52,11 @@ func NewRelay(db *pgxpool.Pool, publisher Publisher, interval time.Duration, log
 		interval = time.Second
 	}
 	return &Relay{db: db, publisher: publisher, logger: logger, interval: interval}
+}
+
+func (r *Relay) WithSchemaVersionResolver(resolver SchemaVersionResolver) *Relay {
+	r.resolver = resolver
+	return r
 }
 
 func (r *Relay) Start(ctx context.Context) {
@@ -100,21 +116,34 @@ FOR UPDATE SKIP LOCKED
 	}
 
 	for _, rec := range records {
-		payload, err := json.Marshal(map[string]any{
-			"id":             rec.ID,
-			"aggregate_type": rec.AggregateType,
-			"aggregate_id":   rec.AggregateID,
-			"event_type":     rec.EventType,
-			"merchant_id":    rec.MerchantID,
-			"payload":        json.RawMessage(rec.Payload),
-			"created_at":     rec.CreatedAt.Unix(),
-			"schema_version": "1.0.0",
-		})
+		schemas, err := r.resolvePublishSchemas(ctx, rec.EventType)
 		if err != nil {
-			return 0, fmt.Errorf("marshal outbox envelope: %w", err)
-		}
-		if err := publishWithRetry(ctx, r.publisher, TopicForEvent(rec.EventType), rec.MerchantID, payload); err != nil {
 			return 0, err
+		}
+		topic := TopicForEvent(rec.EventType)
+		for _, schema := range schemas {
+			payload, err := json.Marshal(map[string]any{
+				"id":             rec.ID,
+				"event_id":       rec.ID,
+				"aggregate_type": rec.AggregateType,
+				"aggregate_id":   rec.AggregateID,
+				"event_type":     rec.EventType,
+				"merchant_id":    rec.MerchantID,
+				"payload":        json.RawMessage(rec.Payload),
+				"created_at":     rec.CreatedAt.Unix(),
+				"occurred_at":    rec.CreatedAt.UTC().Format(time.RFC3339),
+				"correlation_id": rec.AggregateID,
+				"causation_id":   rec.ID,
+				"schema_subject": schema.Subject,
+				"schema_version": schema.Version,
+			})
+			if err != nil {
+				return 0, fmt.Errorf("marshal outbox envelope: %w", err)
+			}
+			if err := publishWithRetry(ctx, r.publisher, topic, rec.MerchantID, payload); err != nil {
+				return 0, err
+			}
+			appmetrics.EventSchemaPublishesTotal.WithLabelValues(topic, rec.EventType, schema.Subject, schema.Version).Inc()
 		}
 		if _, err := tx.Exec(ctx, `UPDATE public.outbox SET published_at = NOW() WHERE id = $1`, rec.ID); err != nil {
 			return 0, fmt.Errorf("mark outbox published: %w", err)
@@ -125,6 +154,20 @@ FOR UPDATE SKIP LOCKED
 		return 0, err
 	}
 	return len(records), nil
+}
+
+func (r *Relay) resolvePublishSchemas(ctx context.Context, eventType string) ([]PublishSchemaVersion, error) {
+	if r.resolver == nil {
+		return []PublishSchemaVersion{{Subject: eventType, Version: "1.0.0"}}, nil
+	}
+	versions, err := r.resolver.ResolvePublishVersions(ctx, eventType)
+	if err != nil {
+		return nil, fmt.Errorf("resolve schema publish versions for %s: %w", eventType, err)
+	}
+	if len(versions) == 0 {
+		return []PublishSchemaVersion{{Subject: eventType, Version: "1.0.0"}}, nil
+	}
+	return versions, nil
 }
 
 func (r *Relay) CleanupPublished(ctx context.Context, olderThan time.Duration) (int64, error) {

--- a/internal/webhook/consumer.go
+++ b/internal/webhook/consumer.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	appmetrics "github.com/sanskarpan/PayGate/internal/common/metrics"
 )
 
 // KafkaConsumer is the minimal interface the Consumer needs from a Kafka driver.
@@ -28,12 +30,20 @@ var topics = []string{
 type Consumer struct {
 	svc           *Service
 	kafkaConsumer KafkaConsumer
+	consumerGroup string
 }
 
 // NewConsumer creates a Consumer that reads from the given KafkaConsumer and
 // delivers events through svc.
 func NewConsumer(svc *Service, kc KafkaConsumer) *Consumer {
-	return &Consumer{svc: svc, kafkaConsumer: kc}
+	return &Consumer{svc: svc, kafkaConsumer: kc, consumerGroup: "webhook-service"}
+}
+
+func NewNamedConsumer(svc *Service, kc KafkaConsumer, consumerGroup string) *Consumer {
+	if consumerGroup == "" {
+		consumerGroup = "webhook-service"
+	}
+	return &Consumer{svc: svc, kafkaConsumer: kc, consumerGroup: consumerGroup}
 }
 
 // Start subscribes to all paygate Kafka topics and blocks until ctx is
@@ -49,12 +59,17 @@ func (c *Consumer) Start(ctx context.Context) error {
 // outboxEnvelope matches the JSON structure written by outbox.Relay.PublishBatch.
 type outboxEnvelope struct {
 	ID            string          `json:"id"`
+	EventID       string          `json:"event_id"`
 	AggregateType string          `json:"aggregate_type"`
 	AggregateID   string          `json:"aggregate_id"`
 	EventType     string          `json:"event_type"`
 	MerchantID    string          `json:"merchant_id"`
 	Payload       json.RawMessage `json:"payload"`
 	CreatedAt     int64           `json:"created_at"`
+	OccurredAt    string          `json:"occurred_at"`
+	CorrelationID string          `json:"correlation_id"`
+	CausationID   string          `json:"causation_id"`
+	SchemaSubject string          `json:"schema_subject"`
 	SchemaVersion string          `json:"schema_version"`
 }
 
@@ -65,6 +80,9 @@ func (c *Consumer) HandleMessage(ctx context.Context, topic, key string, payload
 	var env outboxEnvelope
 	if err := json.Unmarshal(payload, &env); err != nil {
 		return fmt.Errorf("webhook consumer: unmarshal outbox envelope from topic %s: %w", topic, err)
+	}
+	if env.ID == "" {
+		env.ID = env.EventID
 	}
 
 	if env.ID == "" {
@@ -96,6 +114,24 @@ func (c *Consumer) HandleMessage(ctx context.Context, topic, key string, payload
 	innerPayload["aggregate_type"] = env.AggregateType
 	innerPayload["aggregate_id"] = env.AggregateID
 	innerPayload["created_at"] = time.Unix(env.CreatedAt, 0).UTC().Format(time.RFC3339)
+	if env.OccurredAt != "" {
+		innerPayload["occurred_at"] = env.OccurredAt
+	}
+	if env.CorrelationID != "" {
+		innerPayload["correlation_id"] = env.CorrelationID
+	}
+	if env.CausationID != "" {
+		innerPayload["causation_id"] = env.CausationID
+	}
+	if env.SchemaSubject != "" {
+		innerPayload["schema_subject"] = env.SchemaSubject
+	}
+	if env.SchemaVersion != "" {
+		innerPayload["schema_version"] = env.SchemaVersion
+	}
+	if env.SchemaSubject != "" && env.SchemaVersion != "" {
+		appmetrics.RecordConsumerSchemaVersion(c.consumerGroup, topic, env.SchemaSubject, env.SchemaVersion)
+	}
 
 	if err := c.svc.DeliverEvent(ctx, env.ID, env.MerchantID, env.EventType, innerPayload); err != nil {
 		return fmt.Errorf("webhook consumer: deliver event (id=%s): %w", env.ID, err)

--- a/internal/webhook/consumer.go
+++ b/internal/webhook/consumer.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
-
-	appmetrics "github.com/sanskarpan/PayGate/internal/common/metrics"
 )
 
 // KafkaConsumer is the minimal interface the Consumer needs from a Kafka driver.
@@ -129,10 +127,6 @@ func (c *Consumer) HandleMessage(ctx context.Context, topic, key string, payload
 	if env.SchemaVersion != "" {
 		innerPayload["schema_version"] = env.SchemaVersion
 	}
-	if env.SchemaSubject != "" && env.SchemaVersion != "" {
-		appmetrics.RecordConsumerSchemaVersion(c.consumerGroup, topic, env.SchemaSubject, env.SchemaVersion)
-	}
-
 	if err := c.svc.DeliverEvent(ctx, env.ID, env.MerchantID, env.EventType, innerPayload); err != nil {
 		return fmt.Errorf("webhook consumer: deliver event (id=%s): %w", env.ID, err)
 	}

--- a/internal/webhook/domain.go
+++ b/internal/webhook/domain.go
@@ -31,6 +31,7 @@ const (
 	DeliverySucceeded    DeliveryStatus = "succeeded"
 	DeliveryFailed       DeliveryStatus = "failed"
 	DeliveryDeadLettered DeliveryStatus = "dead_lettered"
+	DeliveryCancelled    DeliveryStatus = "cancelled"
 )
 
 // MaxDeliveryAttempts is the number of attempts before an event is dead-lettered.
@@ -104,8 +105,10 @@ type WebhookDeliveryAttempt struct {
 	ResponseCode   int
 	ResponseBody   string
 	ErrorMessage   string
+	CancelReason   string
 	AttemptNumber  int
 	NextRetryAt    *time.Time
+	CancelledAt    *time.Time
 	CreatedAt      time.Time
 }
 

--- a/internal/webhook/handler.go
+++ b/internal/webhook/handler.go
@@ -32,6 +32,7 @@ func (h *Handler) RegisterRoutesWithAuth(mux *http.ServeMux, wrap func(scope mer
 	mux.Handle("GET /v1/webhooks/{webhookID}/deliveries", wrap(merchant.APIKeyScopeRead, http.HandlerFunc(h.listDeliveries)))
 	mux.Handle("POST /v1/webhooks/{webhookID}/rotate-secret", wrap(merchant.APIKeyScopeWrite, http.HandlerFunc(h.rotateSecret)))
 	mux.Handle("POST /v1/webhooks/events/{eventID}/replay", wrap(merchant.APIKeyScopeWrite, http.HandlerFunc(h.replay)))
+	mux.Handle("POST /v1/webhooks/events/{eventID}/cancel-retries", wrap(merchant.APIKeyScopeWrite, http.HandlerFunc(h.cancelRetries)))
 }
 
 func (h *Handler) create(w http.ResponseWriter, r *http.Request) {
@@ -218,6 +219,34 @@ func (h *Handler) replay(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+func (h *Handler) cancelRetries(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	var req struct {
+		Reason string `json:"reason"`
+	}
+	if r.ContentLength > 0 {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			httpx.WriteError(w, http.StatusBadRequest, httpx.APIError{Code: "BAD_REQUEST_ERROR", Description: "invalid request body"})
+			return
+		}
+	}
+	count, err := h.svc.CancelEventRetries(r.Context(), p.MerchantID, r.PathValue("eventID"), req.Reason)
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+	httpx.WriteJSON(w, http.StatusOK, map[string]any{
+		"entity":        "webhook_retry_cancellation",
+		"event_id":      r.PathValue("eventID"),
+		"cancelled":     count,
+		"cancel_reason": req.Reason,
+	})
+}
+
 func present(sub WebhookSubscription) map[string]any {
 	return map[string]any{
 		"id":          sub.ID,
@@ -247,17 +276,27 @@ func presentAttempt(a WebhookDeliveryAttempt) map[string]any {
 		"id":              a.ID,
 		"entity":          "webhook_delivery",
 		"event_id":        a.EventID,
+		"event_type":      a.EventType,
 		"subscription_id": a.SubscriptionID,
 		"status":          a.Status,
 		"request_url":     a.RequestURL,
 		"response_code":   a.ResponseCode,
 		"response_body":   a.ResponseBody,
 		"error":           a.ErrorMessage,
+		"cancel_reason":   a.CancelReason,
 		"attempt_number":  a.AttemptNumber,
 		"next_retry_at":   nextRetryAt,
+		"cancelled_at":    presentTime(a.CancelledAt),
 		"created_at":      a.CreatedAt.Unix(),
 		"created_at_rfc":  a.CreatedAt.Format(time.RFC3339),
 	}
+}
+
+func presentTime(ts *time.Time) any {
+	if ts == nil {
+		return nil
+	}
+	return ts.Unix()
 }
 
 func handleError(w http.ResponseWriter, err error) {

--- a/internal/webhook/postgres.go
+++ b/internal/webhook/postgres.go
@@ -189,13 +189,13 @@ func (r *PostgresRepository) CreateDeliveryAttempt(ctx context.Context, attempt 
 	_, err := r.db.Exec(ctx, `
 INSERT INTO paygate_webhooks.webhook_delivery_attempts
     (id, event_id, event_type, subscription_id, merchant_id, status, request_url, request_body,
-     response_code, response_body, error_message, attempt_number, next_retry_at)
-VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+     response_code, response_body, error_message, cancel_reason, attempt_number, next_retry_at, cancelled_at)
+VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
 `,
 		attempt.ID, attempt.EventID, attempt.EventType, attempt.SubscriptionID, attempt.MerchantID,
 		attempt.Status, attempt.RequestURL, attempt.RequestBody,
-		attempt.ResponseCode, attempt.ResponseBody, attempt.ErrorMessage,
-		attempt.AttemptNumber, attempt.NextRetryAt,
+		attempt.ResponseCode, attempt.ResponseBody, attempt.ErrorMessage, attempt.CancelReason,
+		attempt.AttemptNumber, attempt.NextRetryAt, attempt.CancelledAt,
 	)
 	if err != nil {
 		return WebhookDeliveryAttempt{}, err
@@ -226,18 +226,22 @@ WHERE id = $7
 
 func (r *PostgresRepository) GetDeliveryAttempt(ctx context.Context, id string) (WebhookDeliveryAttempt, error) {
 	var a WebhookDeliveryAttempt
+	var cancelReason *string
 	err := r.db.QueryRow(ctx, `
 SELECT id, event_id, event_type, subscription_id, merchant_id, status, request_url, request_body,
-       response_code, response_body, error_message, attempt_number, next_retry_at, created_at
+       response_code, response_body, error_message, cancel_reason, attempt_number, next_retry_at, cancelled_at, created_at
 FROM paygate_webhooks.webhook_delivery_attempts
 WHERE id = $1
 `, id).Scan(
 		&a.ID, &a.EventID, &a.EventType, &a.SubscriptionID, &a.MerchantID, &a.Status,
 		&a.RequestURL, &a.RequestBody, &a.ResponseCode, &a.ResponseBody, &a.ErrorMessage,
-		&a.AttemptNumber, &a.NextRetryAt, &a.CreatedAt,
+		&cancelReason, &a.AttemptNumber, &a.NextRetryAt, &a.CancelledAt, &a.CreatedAt,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return WebhookDeliveryAttempt{}, ErrDeliveryAttemptNotFound
+	}
+	if cancelReason != nil {
+		a.CancelReason = *cancelReason
 	}
 	return a, err
 }
@@ -245,7 +249,7 @@ WHERE id = $1
 func (r *PostgresRepository) ListDeliveryAttempts(ctx context.Context, merchantID, subscriptionID string) ([]WebhookDeliveryAttempt, error) {
 	rows, err := r.db.Query(ctx, `
 SELECT id, event_id, event_type, subscription_id, merchant_id, status, request_url, request_body,
-       response_code, response_body, error_message, attempt_number, next_retry_at, created_at
+       response_code, response_body, error_message, cancel_reason, attempt_number, next_retry_at, cancelled_at, created_at
 FROM paygate_webhooks.webhook_delivery_attempts
 WHERE merchant_id = $1 AND subscription_id = $2
 ORDER BY created_at DESC
@@ -259,10 +263,14 @@ LIMIT 100
 	var attempts []WebhookDeliveryAttempt
 	for rows.Next() {
 		var a WebhookDeliveryAttempt
+		var cancelReason *string
 		if err := rows.Scan(&a.ID, &a.EventID, &a.EventType, &a.SubscriptionID, &a.MerchantID, &a.Status,
 			&a.RequestURL, &a.RequestBody, &a.ResponseCode, &a.ResponseBody, &a.ErrorMessage,
-			&a.AttemptNumber, &a.NextRetryAt, &a.CreatedAt); err != nil {
+			&cancelReason, &a.AttemptNumber, &a.NextRetryAt, &a.CancelledAt, &a.CreatedAt); err != nil {
 			return nil, err
+		}
+		if cancelReason != nil {
+			a.CancelReason = *cancelReason
 		}
 		attempts = append(attempts, a)
 	}
@@ -278,7 +286,7 @@ func (r *PostgresRepository) LeasePendingRetries(ctx context.Context, limit int)
 
 	rows, err := tx.Query(ctx, `
 SELECT id, event_id, event_type, subscription_id, merchant_id, status, request_url, request_body,
-       response_code, response_body, error_message, attempt_number, next_retry_at, created_at
+       response_code, response_body, error_message, cancel_reason, attempt_number, next_retry_at, cancelled_at, created_at
 FROM paygate_webhooks.webhook_delivery_attempts
 WHERE status = 'failed' AND next_retry_at IS NOT NULL AND next_retry_at <= NOW()
 ORDER BY next_retry_at
@@ -293,10 +301,14 @@ FOR UPDATE SKIP LOCKED
 	var attempts []WebhookDeliveryAttempt
 	for rows.Next() {
 		var a WebhookDeliveryAttempt
+		var cancelReason *string
 		if err := rows.Scan(&a.ID, &a.EventID, &a.EventType, &a.SubscriptionID, &a.MerchantID, &a.Status,
 			&a.RequestURL, &a.RequestBody, &a.ResponseCode, &a.ResponseBody, &a.ErrorMessage,
-			&a.AttemptNumber, &a.NextRetryAt, &a.CreatedAt); err != nil {
+			&cancelReason, &a.AttemptNumber, &a.NextRetryAt, &a.CancelledAt, &a.CreatedAt); err != nil {
 			return nil, err
+		}
+		if cancelReason != nil {
+			a.CancelReason = *cancelReason
 		}
 		attempts = append(attempts, a)
 	}
@@ -339,7 +351,7 @@ WHERE event_id = $1 AND subscription_id = $2 AND status = 'succeeded'
 func (r *PostgresRepository) FindDeliveryByEvent(ctx context.Context, merchantID, eventID string) ([]WebhookDeliveryAttempt, error) {
 	rows, err := r.db.Query(ctx, `
 SELECT id, event_id, event_type, subscription_id, merchant_id, status, request_url, request_body,
-       response_code, response_body, error_message, attempt_number, next_retry_at, created_at
+       response_code, response_body, error_message, cancel_reason, attempt_number, next_retry_at, cancelled_at, created_at
 FROM paygate_webhooks.webhook_delivery_attempts
 WHERE merchant_id = $1 AND event_id = $2
 ORDER BY created_at DESC
@@ -353,14 +365,35 @@ LIMIT 100
 	var attempts []WebhookDeliveryAttempt
 	for rows.Next() {
 		var a WebhookDeliveryAttempt
+		var cancelReason *string
 		if err := rows.Scan(&a.ID, &a.EventID, &a.EventType, &a.SubscriptionID, &a.MerchantID, &a.Status,
 			&a.RequestURL, &a.RequestBody, &a.ResponseCode, &a.ResponseBody, &a.ErrorMessage,
-			&a.AttemptNumber, &a.NextRetryAt, &a.CreatedAt); err != nil {
+			&cancelReason, &a.AttemptNumber, &a.NextRetryAt, &a.CancelledAt, &a.CreatedAt); err != nil {
 			return nil, err
+		}
+		if cancelReason != nil {
+			a.CancelReason = *cancelReason
 		}
 		attempts = append(attempts, a)
 	}
 	return attempts, rows.Err()
+}
+
+func (r *PostgresRepository) CancelDeliveryRetries(ctx context.Context, merchantID, eventID, reason string) (int64, error) {
+	tag, err := r.db.Exec(ctx, `
+UPDATE paygate_webhooks.webhook_delivery_attempts
+SET status = 'cancelled',
+    cancel_reason = NULLIF($3, ''),
+    cancelled_at = NOW(),
+    next_retry_at = NULL
+WHERE merchant_id = $1
+  AND event_id = $2
+  AND status IN ('failed', 'pending')
+`, merchantID, eventID, reason)
+	if err != nil {
+		return 0, err
+	}
+	return tag.RowsAffected(), nil
 }
 
 func (r *PostgresRepository) RotateSecret(ctx context.Context, merchantID, id string) (WebhookSubscription, error) {

--- a/internal/webhook/repository.go
+++ b/internal/webhook/repository.go
@@ -30,6 +30,9 @@ type Repository interface {
 	// Replay: find the most recent succeeded delivery attempt for eventID to replay
 	FindDeliveryByEvent(ctx context.Context, merchantID, eventID string) ([]WebhookDeliveryAttempt, error)
 
+	// CancelDeliveryRetries marks due or future retries for an event as cancelled.
+	CancelDeliveryRetries(ctx context.Context, merchantID, eventID, reason string) (int64, error)
+
 	// RotateSecret replaces the signing secret for a subscription.
 	RotateSecret(ctx context.Context, merchantID, id string) (WebhookSubscription, error)
 }

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -165,6 +165,10 @@ func (s *Service) RotateSecret(ctx context.Context, merchantID, id string) (Webh
 	return s.repo.RotateSecret(ctx, merchantID, id)
 }
 
+func (s *Service) CancelEventRetries(ctx context.Context, merchantID, eventID, reason string) (int64, error) {
+	return s.repo.CancelDeliveryRetries(ctx, merchantID, eventID, reason)
+}
+
 // ReplayEvent re-delivers a previously recorded event to its matching subscriptions.
 // It looks up all delivery attempts for the event, picks the request body from the
 // most recent one, and re-calls DeliverEvent (which handles idempotency by checking


### PR DESCRIPTION
## Summary
- tightens relay publishing and webhook lifecycle behavior
- aligns async persistence and delivery handling with the current runtime expectations
- keeps the async slice isolated from the money-path branch beneath it

Closes #417
