### PR TITLE
[#419] Implement ledger holds and merchant balance gating as first-class controls

### DIFF
--- a/cmd/api-gateway/main.go
+++ b/cmd/api-gateway/main.go
@@ -150,7 +150,7 @@ func run() error {
 	// Payout workflow
 	payoutRepo := payout.NewPostgresRepository(db, ledgerSvc)
 	payoutSvc := payout.NewService(payoutRepo, l)
-	payoutHandler := payout.NewHandler(payoutSvc, settlementSvc)
+	payoutHandler := payout.NewHandler(payoutSvc, settlementSvc, ledgerSvc)
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", httpx.Healthz)

--- a/internal/ledger/hold_domain.go
+++ b/internal/ledger/hold_domain.go
@@ -1,0 +1,77 @@
+package ledger
+
+import (
+	"errors"
+	"time"
+)
+
+type HoldStatus string
+
+const (
+	HoldStatusActive    HoldStatus = "active"
+	HoldStatusReleased  HoldStatus = "released"
+	HoldStatusCommitted HoldStatus = "committed"
+	HoldStatusExpired   HoldStatus = "expired"
+)
+
+var (
+	ErrHoldNotFound       = errors.New("ledger hold not found")
+	ErrHoldNotActive      = errors.New("ledger hold is not active")
+	ErrHoldInsufficient   = errors.New("insufficient payoutable balance")
+	ErrHoldAlreadyHandled = errors.New("ledger hold is already finalized")
+)
+
+type Hold struct {
+	ID                string
+	MerchantID        string
+	AccountCode       string
+	SourceType        string
+	SourceID          string
+	Reason            string
+	Currency          string
+	Amount            int64
+	Status            HoldStatus
+	IdempotencyKey    string
+	TargetAccountCode string
+	Description       string
+	ExpiresAt         *time.Time
+	ReleasedAt        *time.Time
+	CommittedAt       *time.Time
+	CreatedAt         time.Time
+	UpdatedAt         time.Time
+}
+
+type CreateHoldInput struct {
+	MerchantID     string
+	AccountCode    string
+	SourceType     string
+	SourceID       string
+	Reason         string
+	Currency       string
+	Amount         int64
+	IdempotencyKey string
+	ExpiresAt      *time.Time
+}
+
+type ReleaseHoldInput struct {
+	MerchantID string
+	HoldID     string
+}
+
+type ExtendHoldInput struct {
+	MerchantID string
+	HoldID     string
+	ExpiresAt  *time.Time
+}
+
+type CommitHoldInput struct {
+	MerchantID        string
+	HoldID            string
+	TargetAccountCode string
+	Description       string
+}
+
+type ExpireHoldInput struct {
+	MerchantID string
+	HoldID     string
+}

--- a/internal/ledger/hold_handler.go
+++ b/internal/ledger/hold_handler.go
@@ -1,0 +1,255 @@
+package ledger
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+
+	httpx "github.com/sanskarpan/PayGate/internal/common/http"
+	"github.com/sanskarpan/PayGate/internal/merchant"
+)
+
+type HoldHandler struct {
+	svc *Service
+}
+
+func NewHoldHandler(svc *Service) *HoldHandler {
+	return &HoldHandler{svc: svc}
+}
+
+func (h *HoldHandler) RegisterRoutesWithAuth(mux *http.ServeMux, wrap func(scope merchant.APIKeyScope, next http.Handler) http.Handler) {
+	mux.Handle("POST /v1/ledger/holds", wrap(merchant.APIKeyScopeWrite, http.HandlerFunc(h.create)))
+	mux.Handle("GET /v1/ledger/holds", wrap(merchant.APIKeyScopeRead, http.HandlerFunc(h.list)))
+	mux.Handle("GET /v1/ledger/holds/{holdID}", wrap(merchant.APIKeyScopeRead, http.HandlerFunc(h.get)))
+	mux.Handle("POST /v1/ledger/holds/{holdID}/extend", wrap(merchant.APIKeyScopeWrite, http.HandlerFunc(h.extend)))
+	mux.Handle("POST /v1/ledger/holds/{holdID}/release", wrap(merchant.APIKeyScopeWrite, http.HandlerFunc(h.release)))
+	mux.Handle("POST /v1/ledger/holds/{holdID}/commit", wrap(merchant.APIKeyScopeWrite, http.HandlerFunc(h.commit)))
+	mux.Handle("POST /v1/ledger/holds/{holdID}/expire", wrap(merchant.APIKeyScopeWrite, http.HandlerFunc(h.expire)))
+}
+
+func (h *HoldHandler) create(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	var req struct {
+		AccountCode string `json:"account_code"`
+		SourceType  string `json:"source_type"`
+		SourceID    string `json:"source_id"`
+		Reason      string `json:"reason"`
+		Currency    string `json:"currency"`
+		Amount      int64  `json:"amount"`
+		ExpiresAt   *int64 `json:"expires_at"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpx.WriteError(w, http.StatusBadRequest, httpx.APIError{Code: "BAD_REQUEST_ERROR", Description: "invalid request body"})
+		return
+	}
+	var expiresAt *time.Time
+	if req.ExpiresAt != nil {
+		tm := time.Unix(*req.ExpiresAt, 0).UTC()
+		expiresAt = &tm
+	}
+	out, err := h.svc.CreateHold(r.Context(), CreateHoldInput{
+		MerchantID:     p.MerchantID,
+		AccountCode:    req.AccountCode,
+		SourceType:     req.SourceType,
+		SourceID:       req.SourceID,
+		Reason:         req.Reason,
+		Currency:       req.Currency,
+		Amount:         req.Amount,
+		IdempotencyKey: r.Header.Get("Idempotency-Key"),
+		ExpiresAt:      expiresAt,
+	})
+	if err != nil {
+		handleHoldError(w, err)
+		return
+	}
+	httpx.WriteJSON(w, http.StatusCreated, presentHold(out))
+}
+
+func (h *HoldHandler) list(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	limit, _ := strconv.Atoi(r.URL.Query().Get("count"))
+	items, err := h.svc.ListHolds(r.Context(), p.MerchantID, limit)
+	if err != nil {
+		handleHoldError(w, err)
+		return
+	}
+	payload := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		payload = append(payload, presentHold(item))
+	}
+	httpx.WriteJSON(w, http.StatusOK, map[string]any{
+		"entity": "collection",
+		"count":  len(payload),
+		"items":  payload,
+	})
+}
+
+func (h *HoldHandler) get(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	item, err := h.svc.GetHold(r.Context(), p.MerchantID, r.PathValue("holdID"))
+	if err != nil {
+		handleHoldError(w, err)
+		return
+	}
+	httpx.WriteJSON(w, http.StatusOK, presentHold(item))
+}
+
+func (h *HoldHandler) release(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	item, err := h.svc.ReleaseHold(r.Context(), ReleaseHoldInput{
+		MerchantID: p.MerchantID,
+		HoldID:     r.PathValue("holdID"),
+	})
+	if err != nil {
+		handleHoldError(w, err)
+		return
+	}
+	httpx.WriteJSON(w, http.StatusOK, presentHold(item))
+}
+
+func (h *HoldHandler) extend(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	var req struct {
+		ExpiresAt *int64 `json:"expires_at"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpx.WriteError(w, http.StatusBadRequest, httpx.APIError{Code: "BAD_REQUEST_ERROR", Description: "invalid request body"})
+		return
+	}
+	var expiresAt *time.Time
+	if req.ExpiresAt != nil {
+		tm := time.Unix(*req.ExpiresAt, 0).UTC()
+		expiresAt = &tm
+	}
+	item, err := h.svc.ExtendHold(r.Context(), ExtendHoldInput{
+		MerchantID: p.MerchantID,
+		HoldID:     r.PathValue("holdID"),
+		ExpiresAt:  expiresAt,
+	})
+	if err != nil {
+		handleHoldError(w, err)
+		return
+	}
+	httpx.WriteJSON(w, http.StatusOK, presentHold(item))
+}
+
+func (h *HoldHandler) commit(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	var req struct {
+		TargetAccountCode string `json:"target_account_code"`
+		Description       string `json:"description"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpx.WriteError(w, http.StatusBadRequest, httpx.APIError{Code: "BAD_REQUEST_ERROR", Description: "invalid request body"})
+		return
+	}
+	item, err := h.svc.CommitHold(r.Context(), CommitHoldInput{
+		MerchantID:        p.MerchantID,
+		HoldID:            r.PathValue("holdID"),
+		TargetAccountCode: req.TargetAccountCode,
+		Description:       req.Description,
+	})
+	if err != nil {
+		handleHoldError(w, err)
+		return
+	}
+	httpx.WriteJSON(w, http.StatusOK, presentHold(item))
+}
+
+func (h *HoldHandler) expire(w http.ResponseWriter, r *http.Request) {
+	p, ok := httpx.PrincipalFromContext(r.Context())
+	if !ok {
+		httpx.WriteError(w, http.StatusUnauthorized, httpx.APIError{Code: "UNAUTHORIZED", Description: "missing principal"})
+		return
+	}
+	item, err := h.svc.ExpireHold(r.Context(), ExpireHoldInput{
+		MerchantID: p.MerchantID,
+		HoldID:     r.PathValue("holdID"),
+	})
+	if err != nil {
+		handleHoldError(w, err)
+		return
+	}
+	httpx.WriteJSON(w, http.StatusOK, presentHold(item))
+}
+
+func presentHold(h Hold) map[string]any {
+	var expiresAt any
+	var releasedAt any
+	var committedAt any
+	if h.ExpiresAt != nil {
+		expiresAt = h.ExpiresAt.Unix()
+	}
+	if h.ReleasedAt != nil {
+		releasedAt = h.ReleasedAt.Unix()
+	}
+	if h.CommittedAt != nil {
+		committedAt = h.CommittedAt.Unix()
+	}
+	return map[string]any{
+		"entity":              "ledger_hold",
+		"id":                  h.ID,
+		"merchant_id":         h.MerchantID,
+		"account_code":        h.AccountCode,
+		"source_type":         h.SourceType,
+		"source_id":           h.SourceID,
+		"reason":              h.Reason,
+		"currency":            h.Currency,
+		"amount":              h.Amount,
+		"status":              h.Status,
+		"idempotency_key":     h.IdempotencyKey,
+		"target_account_code": h.TargetAccountCode,
+		"description":         h.Description,
+		"business_reference": map[string]any{
+			"source_type": h.SourceType,
+			"source_id":   h.SourceID,
+		},
+		"ledger_reference": map[string]any{
+			"commit_source_type": "ledger_hold_commit",
+			"commit_source_id":   h.ID,
+		},
+		"expires_at":   expiresAt,
+		"released_at":  releasedAt,
+		"committed_at": committedAt,
+		"created_at":   h.CreatedAt.Unix(),
+	}
+}
+
+func handleHoldError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrHoldNotFound):
+		httpx.WriteError(w, http.StatusNotFound, httpx.APIError{Code: "NOT_FOUND", Description: err.Error()})
+	case errors.Is(err, ErrHoldNotActive), errors.Is(err, ErrHoldAlreadyHandled):
+		httpx.WriteError(w, http.StatusConflict, httpx.APIError{Code: "INVALID_STATE", Description: err.Error()})
+	case errors.Is(err, ErrHoldInsufficient):
+		httpx.WriteError(w, http.StatusConflict, httpx.APIError{Code: "INSUFFICIENT_FUNDS", Description: err.Error()})
+	default:
+		httpx.WriteError(w, http.StatusInternalServerError, httpx.APIError{Code: "SERVER_ERROR", Description: "internal server error"})
+	}
+}

--- a/internal/ledger/hold_sweeper.go
+++ b/internal/ledger/hold_sweeper.go
@@ -1,0 +1,43 @@
+package ledger
+
+import (
+	"context"
+	"log/slog"
+	"time"
+)
+
+type HoldSweeper struct {
+	svc      *Service
+	interval time.Duration
+	logger   *slog.Logger
+}
+
+func NewHoldSweeper(svc *Service, interval time.Duration, logger *slog.Logger) *HoldSweeper {
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &HoldSweeper{svc: svc, interval: interval, logger: logger}
+}
+
+func (s *HoldSweeper) Start(ctx context.Context) {
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			expired, err := s.svc.ExpireDueHolds(ctx, 100)
+			if err != nil {
+				s.logger.Error("expire ledger holds failed", "error", err)
+				continue
+			}
+			if expired > 0 {
+				s.logger.Info("expired ledger holds", "count", expired)
+			}
+		}
+	}
+}

--- a/internal/ledger/repository.go
+++ b/internal/ledger/repository.go
@@ -2,6 +2,7 @@ package ledger
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/jackc/pgx/v5"
@@ -70,4 +71,290 @@ WHERE merchant_id = $1 AND account_code = $2
 		return 0, fmt.Errorf("query ledger balance: %w", err)
 	}
 	return balance, nil
+}
+
+func (r *Repository) GetBalanceByCurrency(ctx context.Context, merchantID, accountCode, currency string) (int64, error) {
+	var balance int64
+	err := r.db.QueryRow(ctx, `
+SELECT COALESCE(SUM(debit_amount - credit_amount), 0)
+FROM paygate_ledger.ledger_entries
+WHERE merchant_id = $1 AND account_code = $2 AND currency = $3
+`, merchantID, accountCode, currency).Scan(&balance)
+	if err != nil {
+		return 0, fmt.Errorf("query ledger balance by currency: %w", err)
+	}
+	return balance, nil
+}
+
+func (r *Repository) CreateHold(ctx context.Context, in CreateHoldInput) (Hold, error) {
+	id := idgen.New("hold")
+	if in.Currency == "" {
+		in.Currency = "INR"
+	}
+	row := r.db.QueryRow(ctx, `
+INSERT INTO paygate_ledger.ledger_holds
+    (id, merchant_id, account_code, source_type, source_id, reason, currency, amount, status, idempotency_key, expires_at)
+VALUES
+    ($1, $2, $3, $4, $5, $6, $7, $8, 'active', $9, $10)
+RETURNING id, merchant_id, account_code, source_type, source_id, reason, currency, amount, status,
+          idempotency_key, target_account_code, description, expires_at, released_at, committed_at, created_at, updated_at
+`, id, in.MerchantID, in.AccountCode, in.SourceType, in.SourceID, in.Reason, in.Currency, in.Amount, in.IdempotencyKey, in.ExpiresAt)
+	hold, err := scanHold(row)
+	if err != nil {
+		return Hold{}, fmt.Errorf("insert ledger hold: %w", err)
+	}
+	return hold, nil
+}
+
+func (r *Repository) GetHold(ctx context.Context, merchantID, holdID string) (Hold, error) {
+	row := r.db.QueryRow(ctx, `
+SELECT id, merchant_id, account_code, source_type, source_id, reason, currency, amount, status,
+       idempotency_key, target_account_code, description, expires_at, released_at, committed_at, created_at, updated_at
+FROM paygate_ledger.ledger_holds
+WHERE id = $1 AND merchant_id = $2
+`, holdID, merchantID)
+	hold, err := scanHold(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Hold{}, ErrHoldNotFound
+	}
+	if err != nil {
+		return Hold{}, err
+	}
+	return hold, nil
+}
+
+func (r *Repository) ListHolds(ctx context.Context, merchantID string, limit int) ([]Hold, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 25
+	}
+	rows, err := r.db.Query(ctx, `
+SELECT id, merchant_id, account_code, source_type, source_id, reason, currency, amount, status,
+       idempotency_key, target_account_code, description, expires_at, released_at, committed_at, created_at, updated_at
+FROM paygate_ledger.ledger_holds
+WHERE merchant_id = $1
+ORDER BY created_at DESC
+LIMIT $2
+`, merchantID, limit)
+	if err != nil {
+		return nil, fmt.Errorf("list ledger holds: %w", err)
+	}
+	defer rows.Close()
+
+	var holds []Hold
+	for rows.Next() {
+		hold, err := scanHold(rows)
+		if err != nil {
+			return nil, err
+		}
+		holds = append(holds, hold)
+	}
+	return holds, rows.Err()
+}
+
+func (r *Repository) SumActiveHolds(ctx context.Context, merchantID, accountCode, currency string) (int64, error) {
+	var amount int64
+	err := r.db.QueryRow(ctx, `
+SELECT COALESCE(SUM(amount), 0)
+FROM paygate_ledger.ledger_holds
+WHERE merchant_id = $1
+  AND account_code = $2
+  AND currency = $3
+  AND status = 'active'
+  AND (expires_at IS NULL OR expires_at > NOW())
+`, merchantID, accountCode, currency).Scan(&amount)
+	if err != nil {
+		return 0, fmt.Errorf("sum active holds: %w", err)
+	}
+	return amount, nil
+}
+
+func (r *Repository) ReleaseHold(ctx context.Context, merchantID, holdID string) (Hold, error) {
+	row := r.db.QueryRow(ctx, `
+UPDATE paygate_ledger.ledger_holds
+SET status = 'released', released_at = NOW(), updated_at = NOW()
+WHERE id = $1 AND merchant_id = $2 AND status = 'active'
+RETURNING id, merchant_id, account_code, source_type, source_id, reason, currency, amount, status,
+          idempotency_key, target_account_code, description, expires_at, released_at, committed_at, created_at, updated_at
+`, holdID, merchantID)
+	hold, err := scanHold(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		existing, getErr := r.GetHold(ctx, merchantID, holdID)
+		if getErr != nil {
+			return Hold{}, getErr
+		}
+		if existing.Status == HoldStatusReleased {
+			return existing, nil
+		}
+		if existing.Status != HoldStatusActive {
+			return Hold{}, ErrHoldNotActive
+		}
+		return Hold{}, err
+	}
+	if err != nil {
+		return Hold{}, fmt.Errorf("release ledger hold: %w", err)
+	}
+	return hold, nil
+}
+
+func (r *Repository) ExtendHold(ctx context.Context, in ExtendHoldInput) (Hold, error) {
+	row := r.db.QueryRow(ctx, `
+UPDATE paygate_ledger.ledger_holds
+SET expires_at = $3, updated_at = NOW()
+WHERE id = $1 AND merchant_id = $2 AND status = 'active'
+RETURNING id, merchant_id, account_code, source_type, source_id, reason, currency, amount, status,
+          idempotency_key, target_account_code, description, expires_at, released_at, committed_at, created_at, updated_at
+`, in.HoldID, in.MerchantID, in.ExpiresAt)
+	hold, err := scanHold(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		existing, getErr := r.GetHold(ctx, in.MerchantID, in.HoldID)
+		if getErr != nil {
+			return Hold{}, getErr
+		}
+		if existing.Status != HoldStatusActive {
+			return Hold{}, ErrHoldNotActive
+		}
+		return Hold{}, err
+	}
+	if err != nil {
+		return Hold{}, fmt.Errorf("extend ledger hold: %w", err)
+	}
+	return hold, nil
+}
+
+func (r *Repository) CommitHold(ctx context.Context, in CommitHoldInput) (Hold, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return Hold{}, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var hold Hold
+	row := tx.QueryRow(ctx, `
+SELECT id, merchant_id, account_code, source_type, source_id, reason, currency, amount, status,
+       idempotency_key, target_account_code, description, expires_at, released_at, committed_at, created_at, updated_at
+FROM paygate_ledger.ledger_holds
+WHERE id = $1 AND merchant_id = $2
+FOR UPDATE
+`, in.HoldID, in.MerchantID)
+	hold, err = scanHold(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Hold{}, ErrHoldNotFound
+	}
+	if err != nil {
+		return Hold{}, err
+	}
+	if hold.Status == HoldStatusCommitted {
+		return hold, nil
+	}
+	if hold.Status != HoldStatusActive {
+		return Hold{}, ErrHoldNotActive
+	}
+
+	entries := []Entry{
+		{AccountCode: hold.AccountCode, DebitAmount: hold.Amount, Currency: hold.Currency, Description: in.Description},
+		{AccountCode: in.TargetAccountCode, CreditAmount: hold.Amount, Currency: hold.Currency, Description: in.Description},
+	}
+	if err := ValidateEntries(entries); err != nil {
+		return Hold{}, err
+	}
+	txnID := idgen.New("txn")
+	if err := r.InsertTransactionWithEntriesTx(ctx, tx, txnID, hold.MerchantID, "ledger_hold_commit", hold.ID, in.Description, entries); err != nil {
+		return Hold{}, err
+	}
+
+	row = tx.QueryRow(ctx, `
+UPDATE paygate_ledger.ledger_holds
+SET status = 'committed',
+    target_account_code = $3,
+    description = $4,
+    committed_at = NOW(),
+    updated_at = NOW()
+WHERE id = $1 AND merchant_id = $2
+RETURNING id, merchant_id, account_code, source_type, source_id, reason, currency, amount, status,
+          idempotency_key, target_account_code, description, expires_at, released_at, committed_at, created_at, updated_at
+`, in.HoldID, in.MerchantID, in.TargetAccountCode, in.Description)
+	hold, err = scanHold(row)
+	if err != nil {
+		return Hold{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return Hold{}, err
+	}
+	return hold, nil
+}
+
+func (r *Repository) ExpireHold(ctx context.Context, merchantID, holdID string) (Hold, error) {
+	row := r.db.QueryRow(ctx, `
+UPDATE paygate_ledger.ledger_holds
+SET status = 'expired', updated_at = NOW()
+WHERE id = $1 AND merchant_id = $2 AND status = 'active'
+RETURNING id, merchant_id, account_code, source_type, source_id, reason, currency, amount, status,
+          idempotency_key, target_account_code, description, expires_at, released_at, committed_at, created_at, updated_at
+`, holdID, merchantID)
+	hold, err := scanHold(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		existing, getErr := r.GetHold(ctx, merchantID, holdID)
+		if getErr != nil {
+			return Hold{}, getErr
+		}
+		if existing.Status == HoldStatusExpired {
+			return existing, nil
+		}
+		if existing.Status != HoldStatusActive {
+			return Hold{}, ErrHoldNotActive
+		}
+		return Hold{}, err
+	}
+	if err != nil {
+		return Hold{}, fmt.Errorf("expire ledger hold: %w", err)
+	}
+	return hold, nil
+}
+
+func (r *Repository) ExpireDueHolds(ctx context.Context, limit int) (int64, error) {
+	if limit <= 0 {
+		limit = 100
+	}
+	tag, err := r.db.Exec(ctx, `
+WITH expired AS (
+    SELECT id
+    FROM paygate_ledger.ledger_holds
+    WHERE status = 'active' AND expires_at IS NOT NULL AND expires_at <= NOW()
+    ORDER BY expires_at ASC
+    LIMIT $1
+)
+UPDATE paygate_ledger.ledger_holds h
+SET status = 'expired', updated_at = NOW()
+FROM expired e
+WHERE h.id = e.id
+`, limit)
+	if err != nil {
+		return 0, fmt.Errorf("expire ledger holds: %w", err)
+	}
+	return tag.RowsAffected(), nil
+}
+
+type holdScannable interface {
+	Scan(dest ...any) error
+}
+
+func scanHold(row holdScannable) (Hold, error) {
+	var hold Hold
+	var targetAccountCode *string
+	var description *string
+	err := row.Scan(
+		&hold.ID, &hold.MerchantID, &hold.AccountCode, &hold.SourceType, &hold.SourceID, &hold.Reason,
+		&hold.Currency, &hold.Amount, &hold.Status, &hold.IdempotencyKey, &targetAccountCode, &description,
+		&hold.ExpiresAt, &hold.ReleasedAt, &hold.CommittedAt, &hold.CreatedAt, &hold.UpdatedAt,
+	)
+	if err != nil {
+		return Hold{}, err
+	}
+	if targetAccountCode != nil {
+		hold.TargetAccountCode = *targetAccountCode
+	}
+	if description != nil {
+		hold.Description = *description
+	}
+	return hold, nil
 }

--- a/internal/ledger/service.go
+++ b/internal/ledger/service.go
@@ -3,6 +3,8 @@ package ledger
 import (
 	"context"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/sanskarpan/PayGate/internal/common/idgen"
@@ -46,4 +48,104 @@ func (s *Service) CreateEntries(ctx context.Context, merchantID, sourceType, sou
 
 func (s *Service) GetBalance(ctx context.Context, merchantID, accountCode string) (int64, error) {
 	return s.repo.GetBalance(ctx, merchantID, accountCode)
+}
+
+func (s *Service) GetBalanceByCurrency(ctx context.Context, merchantID, accountCode, currency string) (int64, error) {
+	if currency == "" {
+		currency = "INR"
+	}
+	return s.repo.GetBalanceByCurrency(ctx, merchantID, accountCode, currency)
+}
+
+func (s *Service) CreateHold(ctx context.Context, in CreateHoldInput) (Hold, error) {
+	if in.Currency == "" {
+		in.Currency = "INR"
+	}
+	in.AccountCode = strings.TrimSpace(in.AccountCode)
+	in.SourceType = strings.TrimSpace(in.SourceType)
+	in.SourceID = strings.TrimSpace(in.SourceID)
+	if in.AccountCode == "" || in.SourceType == "" || in.SourceID == "" || in.Amount <= 0 {
+		return Hold{}, fmt.Errorf("invalid hold input")
+	}
+	return s.repo.CreateHold(ctx, in)
+}
+
+func (s *Service) GetHold(ctx context.Context, merchantID, holdID string) (Hold, error) {
+	return s.repo.GetHold(ctx, merchantID, holdID)
+}
+
+func (s *Service) ListHolds(ctx context.Context, merchantID string, limit int) ([]Hold, error) {
+	return s.repo.ListHolds(ctx, merchantID, limit)
+}
+
+func (s *Service) ReleaseHold(ctx context.Context, in ReleaseHoldInput) (Hold, error) {
+	return s.repo.ReleaseHold(ctx, in.MerchantID, in.HoldID)
+}
+
+func (s *Service) ExtendHold(ctx context.Context, in ExtendHoldInput) (Hold, error) {
+	return s.repo.ExtendHold(ctx, in)
+}
+
+func (s *Service) CommitHold(ctx context.Context, in CommitHoldInput) (Hold, error) {
+	if strings.TrimSpace(in.TargetAccountCode) == "" {
+		return Hold{}, fmt.Errorf("target account code is required")
+	}
+	if strings.TrimSpace(in.Description) == "" {
+		in.Description = "ledger hold commit"
+	}
+	return s.repo.CommitHold(ctx, in)
+}
+
+func (s *Service) ExpireDueHolds(ctx context.Context, limit int) (int64, error) {
+	return s.repo.ExpireDueHolds(ctx, limit)
+}
+
+func (s *Service) ExpireHold(ctx context.Context, in ExpireHoldInput) (Hold, error) {
+	return s.repo.ExpireHold(ctx, in.MerchantID, in.HoldID)
+}
+
+func (s *Service) GetReservedBalance(ctx context.Context, merchantID, accountCode, currency string) (int64, error) {
+	if currency == "" {
+		currency = "INR"
+	}
+	return s.repo.SumActiveHolds(ctx, merchantID, accountCode, currency)
+}
+
+func (s *Service) GetPayoutableBalance(ctx context.Context, merchantID, currency string) (int64, error) {
+	balance, err := s.GetBalanceByCurrency(ctx, merchantID, "SETTLEMENT_CLEARING", currency)
+	if err != nil {
+		return 0, err
+	}
+	reserved, err := s.GetReservedBalance(ctx, merchantID, "SETTLEMENT_CLEARING", currency)
+	if err != nil {
+		return 0, err
+	}
+	available := int64(0)
+	if balance < 0 {
+		available = -balance
+	}
+	available -= reserved
+	if available < 0 {
+		return 0, nil
+	}
+	return available, nil
+}
+
+func (s *Service) CanReserveForPayout(ctx context.Context, merchantID, currency string, amount int64) error {
+	available, err := s.GetPayoutableBalance(ctx, merchantID, currency)
+	if err != nil {
+		return err
+	}
+	if available < amount {
+		return ErrHoldInsufficient
+	}
+	return nil
+}
+
+func (s *Service) DefaultHoldExpiry(after time.Duration) *time.Time {
+	if after <= 0 {
+		return nil
+	}
+	tm := time.Now().Add(after).UTC()
+	return &tm
 }

--- a/internal/payout/handler.go
+++ b/internal/payout/handler.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	httpx "github.com/sanskarpan/PayGate/internal/common/http"
+	"github.com/sanskarpan/PayGate/internal/ledger"
 	"github.com/sanskarpan/PayGate/internal/merchant"
 	"github.com/sanskarpan/PayGate/internal/settlement"
 )
@@ -15,11 +16,12 @@ import (
 type Handler struct {
 	svc        *Service
 	settlement *settlement.Service
+	ledger     *ledger.Service
 }
 
 // NewHandler creates a Handler.
-func NewHandler(svc *Service, settlementSvc *settlement.Service) *Handler {
-	return &Handler{svc: svc, settlement: settlementSvc}
+func NewHandler(svc *Service, settlementSvc *settlement.Service, ledgerSvc *ledger.Service) *Handler {
+	return &Handler{svc: svc, settlement: settlementSvc, ledger: ledgerSvc}
 }
 
 // RegisterRoutesWithAuth wires payout endpoints into mux under auth.
@@ -46,6 +48,12 @@ func (h *Handler) initiate(w http.ResponseWriter, r *http.Request) {
 	if sttl.OnHold {
 		handleError(w, ErrSettlementOnHold)
 		return
+	}
+	if h.ledger != nil {
+		if err := h.ledger.CanReserveForPayout(r.Context(), p.MerchantID, sttl.Currency, sttl.NetAmount); err != nil {
+			handleError(w, err)
+			return
+		}
 	}
 
 	pout, err := h.svc.InitiatePayoutForSettlement(r.Context(), p.MerchantID, settlementID, sttl.NetAmount, sttl.Currency)
@@ -136,6 +144,8 @@ func handleError(w http.ResponseWriter, err error) {
 	case errors.Is(err, ErrSettlementNotProcessed):
 		httpx.WriteError(w, http.StatusUnprocessableEntity, httpx.APIError{Code: "SETTLEMENT_NOT_PROCESSED", Description: err.Error()})
 	case errors.Is(err, ErrSettlementOnHold):
+		httpx.WriteError(w, http.StatusConflict, httpx.APIError{Code: "SETTLEMENT_ON_HOLD", Description: err.Error()})
+	case errors.Is(err, ledger.ErrHoldInsufficient):
 		httpx.WriteError(w, http.StatusConflict, httpx.APIError{Code: "SETTLEMENT_ON_HOLD", Description: err.Error()})
 	default:
 		// Check for settlement not found too.

--- a/migrations/000023_create_ledger_holds.down.sql
+++ b/migrations/000023_create_ledger_holds.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS paygate_ledger.idx_ledger_holds_account_status;
+DROP INDEX IF EXISTS paygate_ledger.idx_ledger_holds_merchant_status;
+DROP TABLE IF EXISTS paygate_ledger.ledger_holds;

--- a/migrations/000023_create_ledger_holds.up.sql
+++ b/migrations/000023_create_ledger_holds.up.sql
@@ -1,0 +1,25 @@
+CREATE TABLE IF NOT EXISTS paygate_ledger.ledger_holds (
+    id                  TEXT PRIMARY KEY,
+    merchant_id         TEXT NOT NULL,
+    account_code        TEXT NOT NULL,
+    source_type         TEXT NOT NULL,
+    source_id           TEXT NOT NULL,
+    reason              TEXT NOT NULL DEFAULT '',
+    currency            TEXT NOT NULL DEFAULT 'INR',
+    amount              BIGINT NOT NULL CHECK (amount > 0),
+    status              TEXT NOT NULL CHECK (status IN ('active', 'released', 'committed', 'expired')),
+    idempotency_key     TEXT NOT NULL DEFAULT '',
+    target_account_code TEXT,
+    description         TEXT NOT NULL DEFAULT '',
+    expires_at          TIMESTAMPTZ,
+    released_at         TIMESTAMPTZ,
+    committed_at        TIMESTAMPTZ,
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ledger_holds_merchant_status
+    ON paygate_ledger.ledger_holds (merchant_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ledger_holds_account_status
+    ON paygate_ledger.ledger_holds (merchant_id, account_code, currency, status);

--- a/tests/integration/backend_hardening_integration_test.go
+++ b/tests/integration/backend_hardening_integration_test.go
@@ -300,7 +300,7 @@ func buildGatewayMux(db *pgxpool.Pool) (*http.ServeMux, *merchant.Service, *orde
 	refundHandler := refund.NewHandler(refundSvc)
 	webhookHandler := webhook.NewHandler(webhookSvc)
 	settlementHandler := settlement.NewHandler(settlementSvc)
-	payoutHandler := payout.NewHandler(payoutSvc, settlementSvc)
+	payoutHandler := payout.NewHandler(payoutSvc, settlementSvc, ledgerSvc)
 	disputeHandler := dispute.NewHandler(disputeSvc)
 	holdHandler := ledger.NewHoldHandler(ledgerSvc)
 

--- a/tests/integration/backend_hardening_integration_test.go
+++ b/tests/integration/backend_hardening_integration_test.go
@@ -302,6 +302,7 @@ func buildGatewayMux(db *pgxpool.Pool) (*http.ServeMux, *merchant.Service, *orde
 	settlementHandler := settlement.NewHandler(settlementSvc)
 	payoutHandler := payout.NewHandler(payoutSvc, settlementSvc)
 	disputeHandler := dispute.NewHandler(disputeSvc)
+	holdHandler := ledger.NewHoldHandler(ledgerSvc)
 
 	protected := func(scope merchant.APIKeyScope, next http.Handler) http.Handler {
 		return authMw.RequireScope(scope, idemMw.Wrap(next))
@@ -317,6 +318,7 @@ func buildGatewayMux(db *pgxpool.Pool) (*http.ServeMux, *merchant.Service, *orde
 	payoutHandler.RegisterRoutesWithAuth(mux, protected)
 	webhookHandler.RegisterRoutesWithAuth(mux, protected)
 	disputeHandler.RegisterRoutesWithAuth(mux, protected)
+	holdHandler.RegisterRoutesWithAuth(mux, protected)
 	mux.Handle("GET /v1/merchants/me", authMw.RequireScope(merchant.APIKeyScopeRead, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		p, _ := httpx.PrincipalFromContext(r.Context())
 		httpx.WriteJSON(w, http.StatusOK, map[string]any{"merchant_id": p.MerchantID})

--- a/tests/integration/ledger_hold_integration_test.go
+++ b/tests/integration/ledger_hold_integration_test.go
@@ -1,0 +1,310 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sanskarpan/PayGate/internal/ledger"
+	"github.com/sanskarpan/PayGate/internal/merchant"
+	"github.com/sanskarpan/PayGate/internal/order"
+	"github.com/sanskarpan/PayGate/internal/payment"
+	"github.com/sanskarpan/PayGate/internal/settlement"
+)
+
+func TestIntegrationLedgerHoldCommitPostsExactlyOnce(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+	ctx := context.Background()
+
+	mux, merchantSvc, _, _ := buildGatewayMux(db)
+
+	m, err := merchantSvc.CreateMerchant(ctx, merchant.CreateMerchantInput{
+		Name: "Hold Commit Merchant", Email: "hold-commit@test.com", BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+	key, err := merchantSvc.CreateAPIKey(ctx, m.ID, merchant.CreateAPIKeyInput{
+		Mode: merchant.APIKeyModeTest, Scope: merchant.APIKeyScopeWrite,
+	})
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+	authHeader := basicAuth(key.KeyID, key.KeySecret)
+
+	createBody := []byte(`{"account_code":"SETTLEMENT_CLEARING","source_type":"payout_hold","source_id":"settlement_demo","reason":"ops review","currency":"INR","amount":4900}`)
+	createReq := httptest.NewRequest(http.MethodPost, "/v1/ledger/holds", bytes.NewReader(createBody))
+	createReq.Header.Set("Authorization", authHeader)
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq.Header.Set("Idempotency-Key", "hold-create-1")
+	createRec := httptest.NewRecorder()
+	mux.ServeHTTP(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("create hold: expected 201, got %d body=%s", createRec.Code, createRec.Body.String())
+	}
+	var created map[string]any
+	if err := json.Unmarshal(createRec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode hold create: %v", err)
+	}
+	holdID, _ := created["id"].(string)
+	if holdID == "" {
+		t.Fatal("expected hold id in create response")
+	}
+
+	commitBody := []byte(`{"target_account_code":"MERCHANT_BANK_PAYOUT","description":"release payout funds"}`)
+	commitReq := httptest.NewRequest(http.MethodPost, "/v1/ledger/holds/"+holdID+"/commit", bytes.NewReader(commitBody))
+	commitReq.Header.Set("Authorization", authHeader)
+	commitReq.Header.Set("Content-Type", "application/json")
+	commitRec := httptest.NewRecorder()
+	mux.ServeHTTP(commitRec, commitReq)
+	if commitRec.Code != http.StatusOK {
+		t.Fatalf("commit hold: expected 200, got %d body=%s", commitRec.Code, commitRec.Body.String())
+	}
+
+	var status string
+	if err := db.QueryRow(ctx, `
+SELECT status
+FROM paygate_ledger.ledger_holds
+WHERE id = $1
+`, holdID).Scan(&status); err != nil {
+		t.Fatalf("query hold status: %v", err)
+	}
+	if status != "committed" {
+		t.Fatalf("expected committed hold, got %s", status)
+	}
+
+	var entries int
+	if err := db.QueryRow(ctx, `
+SELECT COUNT(*)
+FROM paygate_ledger.ledger_entries
+WHERE source_type = 'ledger_hold_commit' AND source_id = $1
+`, holdID).Scan(&entries); err != nil {
+		t.Fatalf("count hold commit entries: %v", err)
+	}
+	if entries != 2 {
+		t.Fatalf("expected 2 hold commit ledger entries, got %d", entries)
+	}
+
+	repeatReq := httptest.NewRequest(http.MethodPost, "/v1/ledger/holds/"+holdID+"/commit", bytes.NewReader(commitBody))
+	repeatReq.Header.Set("Authorization", authHeader)
+	repeatReq.Header.Set("Content-Type", "application/json")
+	repeatRec := httptest.NewRecorder()
+	mux.ServeHTTP(repeatRec, repeatReq)
+	if repeatRec.Code != http.StatusOK {
+		t.Fatalf("repeat commit: expected 200, got %d body=%s", repeatRec.Code, repeatRec.Body.String())
+	}
+
+	var entriesAfter int
+	if err := db.QueryRow(ctx, `
+SELECT COUNT(*)
+FROM paygate_ledger.ledger_entries
+WHERE source_type = 'ledger_hold_commit' AND source_id = $1
+`, holdID).Scan(&entriesAfter); err != nil {
+		t.Fatalf("recount hold commit entries: %v", err)
+	}
+	if entriesAfter != 2 {
+		t.Fatalf("expected 2 hold commit ledger entries after duplicate commit, got %d", entriesAfter)
+	}
+}
+
+func TestIntegrationPayoutBlockedByActiveLedgerHoldUntilRelease(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+	ctx := context.Background()
+
+	mux, merchantSvc, orderSvc, paymentSvc := buildGatewayMux(db)
+
+	m, err := merchantSvc.CreateMerchant(ctx, merchant.CreateMerchantInput{
+		Name: "Hold Block Merchant", Email: "hold-block@test.com", BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+	key, err := merchantSvc.CreateAPIKey(ctx, m.ID, merchant.CreateAPIKeyInput{
+		Mode: merchant.APIKeyModeTest, Scope: merchant.APIKeyScopeWrite,
+	})
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+	authHeader := basicAuth(key.KeyID, key.KeySecret)
+
+	o, err := orderSvc.Create(ctx, order.CreateInput{
+		MerchantID: m.ID, Amount: 10000, Currency: "INR", Receipt: "ledger-hold-payout",
+	})
+	if err != nil {
+		t.Fatalf("create order: %v", err)
+	}
+	authOut, err := paymentSvc.Authorize(ctx, payment.AuthorizeInput{
+		MerchantID: m.ID, OrderID: o.ID, Amount: o.Amount, Currency: o.Currency, Method: "card",
+	})
+	if err != nil {
+		t.Fatalf("authorize payment: %v", err)
+	}
+	if _, err := paymentSvc.CaptureForMerchant(ctx, m.ID, authOut.PaymentID, o.Amount); err != nil {
+		t.Fatalf("capture payment: %v", err)
+	}
+
+	ledgerSvc := ledger.NewService(ledger.NewRepository(db))
+	settlementSvc := settlement.NewService(settlement.NewPostgresRepository(db, ledgerSvc))
+	sttl, err := settlementSvc.RunBatch(ctx, m.ID, time.Unix(0, 0), time.Now().Add(time.Hour))
+	if err != nil {
+		t.Fatalf("run settlement batch: %v", err)
+	}
+
+	createBody, _ := json.Marshal(map[string]any{
+		"account_code": "SETTLEMENT_CLEARING",
+		"source_type":  "payout_hold",
+		"source_id":    sttl.ID,
+		"reason":       "manual finance review",
+		"currency":     sttl.Currency,
+		"amount":       sttl.NetAmount,
+	})
+	createReq := httptest.NewRequest(http.MethodPost, "/v1/ledger/holds", bytes.NewReader(createBody))
+	createReq.Header.Set("Authorization", authHeader)
+	createReq.Header.Set("Content-Type", "application/json")
+	createReq.Header.Set("Idempotency-Key", "hold-create-payout-block")
+	createRec := httptest.NewRecorder()
+	mux.ServeHTTP(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("create hold: expected 201, got %d body=%s", createRec.Code, createRec.Body.String())
+	}
+	var holdResp map[string]any
+	if err := json.Unmarshal(createRec.Body.Bytes(), &holdResp); err != nil {
+		t.Fatalf("decode hold create response: %v", err)
+	}
+	holdID, _ := holdResp["id"].(string)
+	if holdID == "" {
+		t.Fatal("expected hold id")
+	}
+
+	payoutReq := httptest.NewRequest(http.MethodPost, "/v1/settlements/"+sttl.ID+"/payout", nil)
+	payoutReq.Header.Set("Authorization", authHeader)
+	payoutRec := httptest.NewRecorder()
+	mux.ServeHTTP(payoutRec, payoutReq)
+	if payoutRec.Code != http.StatusConflict {
+		t.Fatalf("expected 409 when ledger hold blocks payout, got %d body=%s", payoutRec.Code, payoutRec.Body.String())
+	}
+
+	releaseReq := httptest.NewRequest(http.MethodPost, "/v1/ledger/holds/"+holdID+"/release", nil)
+	releaseReq.Header.Set("Authorization", authHeader)
+	releaseRec := httptest.NewRecorder()
+	mux.ServeHTTP(releaseRec, releaseReq)
+	if releaseRec.Code != http.StatusOK {
+		t.Fatalf("release hold: expected 200, got %d body=%s", releaseRec.Code, releaseRec.Body.String())
+	}
+	releaseReq = httptest.NewRequest(http.MethodPost, "/v1/ledger/holds/"+holdID+"/release", nil)
+	releaseReq.Header.Set("Authorization", authHeader)
+	releaseRec = httptest.NewRecorder()
+	mux.ServeHTTP(releaseRec, releaseReq)
+	if releaseRec.Code != http.StatusOK {
+		t.Fatalf("repeat release hold: expected 200, got %d body=%s", releaseRec.Code, releaseRec.Body.String())
+	}
+
+	payoutReq = httptest.NewRequest(http.MethodPost, "/v1/settlements/"+sttl.ID+"/payout", nil)
+	payoutReq.Header.Set("Authorization", authHeader)
+	payoutRec = httptest.NewRecorder()
+	mux.ServeHTTP(payoutRec, payoutReq)
+	if payoutRec.Code != http.StatusCreated {
+		t.Fatalf("expected payout to succeed after hold release, got %d body=%s", payoutRec.Code, payoutRec.Body.String())
+	}
+}
+
+func TestIntegrationLedgerHoldExtendAndForceExpire(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+	ctx := context.Background()
+
+	mux, merchantSvc, _, _ := buildGatewayMux(db)
+
+	m, err := merchantSvc.CreateMerchant(ctx, merchant.CreateMerchantInput{
+		Name: "Hold Extend Merchant", Email: "hold-extend@test.com", BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+	key, err := merchantSvc.CreateAPIKey(ctx, m.ID, merchant.CreateAPIKeyInput{
+		Mode: merchant.APIKeyModeTest, Scope: merchant.APIKeyScopeWrite,
+	})
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+	authHeader := basicAuth(key.KeyID, key.KeySecret)
+
+	initialExpiry := time.Now().Add(10 * time.Minute).Unix()
+	createBody, _ := json.Marshal(map[string]any{
+		"account_code": "SETTLEMENT_CLEARING",
+		"source_type":  "reserve_hold",
+		"source_id":    "reserve_123",
+		"reason":       "reserve review",
+		"currency":     "INR",
+		"amount":       2500,
+		"expires_at":   initialExpiry,
+	})
+	createReq := httptest.NewRequest(http.MethodPost, "/v1/ledger/holds", bytes.NewReader(createBody))
+	createReq.Header.Set("Authorization", authHeader)
+	createReq.Header.Set("Content-Type", "application/json")
+	createRec := httptest.NewRecorder()
+	mux.ServeHTTP(createRec, createReq)
+	if createRec.Code != http.StatusCreated {
+		t.Fatalf("create hold: expected 201, got %d body=%s", createRec.Code, createRec.Body.String())
+	}
+
+	var created map[string]any
+	if err := json.Unmarshal(createRec.Body.Bytes(), &created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	holdID, _ := created["id"].(string)
+	if holdID == "" {
+		t.Fatal("expected hold id")
+	}
+
+	extendedExpiry := time.Now().Add(45 * time.Minute).Unix()
+	extendBody, _ := json.Marshal(map[string]any{"expires_at": extendedExpiry})
+	extendReq := httptest.NewRequest(http.MethodPost, "/v1/ledger/holds/"+holdID+"/extend", bytes.NewReader(extendBody))
+	extendReq.Header.Set("Authorization", authHeader)
+	extendReq.Header.Set("Content-Type", "application/json")
+	extendRec := httptest.NewRecorder()
+	mux.ServeHTTP(extendRec, extendReq)
+	if extendRec.Code != http.StatusOK {
+		t.Fatalf("extend hold: expected 200, got %d body=%s", extendRec.Code, extendRec.Body.String())
+	}
+
+	var expiresAt time.Time
+	if err := db.QueryRow(ctx, `SELECT expires_at FROM paygate_ledger.ledger_holds WHERE id = $1`, holdID).Scan(&expiresAt); err != nil {
+		t.Fatalf("query extended expires_at: %v", err)
+	}
+	if expiresAt.Unix() != extendedExpiry {
+		t.Fatalf("expected expires_at %d, got %d", extendedExpiry, expiresAt.Unix())
+	}
+
+	expireReq := httptest.NewRequest(http.MethodPost, "/v1/ledger/holds/"+holdID+"/expire", nil)
+	expireReq.Header.Set("Authorization", authHeader)
+	expireRec := httptest.NewRecorder()
+	mux.ServeHTTP(expireRec, expireReq)
+	if expireRec.Code != http.StatusOK {
+		t.Fatalf("expire hold: expected 200, got %d body=%s", expireRec.Code, expireRec.Body.String())
+	}
+
+	var status string
+	if err := db.QueryRow(ctx, `SELECT status FROM paygate_ledger.ledger_holds WHERE id = $1`, holdID).Scan(&status); err != nil {
+		t.Fatalf("query expired hold status: %v", err)
+	}
+	if status != string(ledger.HoldStatusExpired) {
+		t.Fatalf("expected expired hold, got %s", status)
+	}
+
+	expireReq = httptest.NewRequest(http.MethodPost, "/v1/ledger/holds/"+holdID+"/expire", nil)
+	expireReq.Header.Set("Authorization", authHeader)
+	expireRec = httptest.NewRecorder()
+	mux.ServeHTTP(expireRec, expireReq)
+	if expireRec.Code != http.StatusOK {
+		t.Fatalf("repeat expire hold: expected 200, got %d body=%s", expireRec.Code, expireRec.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- adds ledger hold domain, handler, sweeper, repository, and service behavior
- introduces the ledger-hold migration and integration coverage for hold lifecycles
- keeps balance-gating work isolated from later payout and schema slices

Closes #419
