### PR TITLE
[#420] Govern event schemas, rollout compatibility, and consumer contract enforcement

### DIFF
--- a/internal/common/metrics/schema.go
+++ b/internal/common/metrics/schema.go
@@ -1,0 +1,43 @@
+package metrics
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	eventSchemaConsumerVersions = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "paygate_event_schema_consumer_version_active",
+		Help: "Active schema version markers observed by consumer group and topic",
+	}, []string{"consumer_group", "topic", "schema_subject", "schema_version"})
+	deprecatedSchemaAlerts = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "paygate_event_schema_deprecated_version_overdue",
+		Help: "Deprecated schema version cutovers that remain overdue per consumer",
+	}, []string{"schema_subject", "from_version", "to_version", "consumer_name"})
+	registerSchemaMetricsOnce sync.Once
+)
+
+func RecordConsumerSchemaVersion(consumerGroup, topic, schemaSubject, schemaVersion string) {
+	registerSchemaMetricsOnce.Do(func() {
+		prometheus.MustRegister(eventSchemaConsumerVersions)
+		prometheus.MustRegister(deprecatedSchemaAlerts)
+	})
+	eventSchemaConsumerVersions.WithLabelValues(consumerGroup, topic, schemaSubject, schemaVersion).Set(1)
+}
+
+func RecordDeprecatedSchemaAlert(schemaSubject, fromVersion, toVersion, consumerName string) {
+	registerSchemaMetricsOnce.Do(func() {
+		prometheus.MustRegister(eventSchemaConsumerVersions)
+		prometheus.MustRegister(deprecatedSchemaAlerts)
+	})
+	deprecatedSchemaAlerts.WithLabelValues(schemaSubject, fromVersion, toVersion, consumerName).Set(1)
+}
+
+func ResetDeprecatedSchemaAlerts() {
+	registerSchemaMetricsOnce.Do(func() {
+		prometheus.MustRegister(eventSchemaConsumerVersions)
+		prometheus.MustRegister(deprecatedSchemaAlerts)
+	})
+	deprecatedSchemaAlerts.Reset()
+}

--- a/internal/eventschema/alerts.go
+++ b/internal/eventschema/alerts.go
@@ -1,0 +1,53 @@
+package eventschema
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/sanskarpan/PayGate/internal/common/metrics"
+)
+
+type AlertChecker struct {
+	svc      *Service
+	interval time.Duration
+	logger   *slog.Logger
+}
+
+func NewAlertChecker(svc *Service, interval time.Duration, logger *slog.Logger) *AlertChecker {
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &AlertChecker{svc: svc, interval: interval, logger: logger}
+}
+
+func (c *AlertChecker) Start(ctx context.Context) {
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			if err := c.runOnce(ctx); err != nil && ctx.Err() == nil {
+				c.logger.Error("event schema alert check failed", "error", err)
+			}
+		}
+	}
+}
+
+func (c *AlertChecker) runOnce(ctx context.Context) error {
+	alerts, err := c.svc.ListDeprecatedVersionAlerts(ctx)
+	if err != nil {
+		return err
+	}
+	metrics.ResetDeprecatedSchemaAlerts()
+	for _, alert := range alerts {
+		metrics.RecordDeprecatedSchemaAlert(alert.Subject, alert.FromVersion, alert.ToVersion, alert.ConsumerName)
+	}
+	return nil
+}

--- a/internal/eventschema/bootstrap.go
+++ b/internal/eventschema/bootstrap.go
@@ -1,0 +1,191 @@
+package eventschema
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/sanskarpan/PayGate/internal/outbox"
+)
+
+// BootstrapFromFixtures ensures the checked-in schema fixtures are present in
+// the registry and that a clean environment has an active version per subject.
+func (s *Service) BootstrapFromFixtures(ctx context.Context, rootDir, owner string) error {
+	entries, err := os.ReadDir(rootDir)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		subject := entry.Name()
+		subjectDir := filepath.Join(rootDir, subject)
+
+		if _, err := s.repo.GetSchema(ctx, subject); err != nil {
+			if !errors.Is(err, ErrSchemaNotFound) {
+				return err
+			}
+			if _, err := s.repo.CreateSchema(ctx, CreateSchemaInput{
+				Subject:    subject,
+				EventType:  subject,
+				TopicName:  outbox.TopicForEvent(subject),
+				Owner:      owner,
+				ReviewLink: filepath.ToSlash(filepath.Join("schemas", "events", subject)),
+			}); err != nil {
+				return fmt.Errorf("create schema %s: %w", subject, err)
+			}
+		}
+
+		versions, err := fixtureVersions(subjectDir)
+		if err != nil {
+			return fmt.Errorf("load schema fixture versions for %s: %w", subject, err)
+		}
+		if len(versions) == 0 {
+			continue
+		}
+
+		activeVersion := ""
+		hasActive := false
+		active, err := s.repo.GetActiveVersion(ctx, subject)
+		switch {
+		case err == nil:
+			activeVersion = active.Version
+			hasActive = true
+		case errors.Is(err, ErrNoActiveSchemaVersion):
+		default:
+			return err
+		}
+
+		for i, version := range versions {
+			if _, err := s.repo.GetVersion(ctx, subject, version); err != nil {
+				if !errors.Is(err, ErrSchemaVersionNotFound) {
+					return err
+				}
+				document, sample, err := loadFixtureVersion(subjectDir, version)
+				if err != nil {
+					return fmt.Errorf("load schema fixture %s/%s: %w", subject, version, err)
+				}
+				if _, _, err := s.RegisterVersion(ctx, CreateVersionInput{
+					Subject:       subject,
+					Version:       version,
+					Schema:        document,
+					SamplePayload: sample,
+					ReviewLink:    filepath.ToSlash(filepath.Join("schemas", "events", subject, version+".schema.json")),
+				}); err != nil {
+					return fmt.Errorf("register schema fixture %s/%s: %w", subject, version, err)
+				}
+			}
+
+			// In a clean registry, activate the earliest fixture first so later
+			// versions register against a real baseline instead of "no active".
+			if !hasActive && i == 0 {
+				if _, err := s.ActivateVersion(ctx, ActivateVersionInput{Subject: subject, Version: version}); err != nil {
+					return fmt.Errorf("activate bootstrap baseline %s/%s: %w", subject, version, err)
+				}
+				activeVersion = version
+				hasActive = true
+			}
+		}
+
+		latest := versions[len(versions)-1]
+		if hasActive && activeVersion != latest {
+			if _, err := s.ActivateVersion(ctx, ActivateVersionInput{Subject: subject, Version: latest}); err != nil {
+				return fmt.Errorf("activate latest bootstrap version %s/%s: %w", subject, latest, err)
+			}
+		}
+	}
+	return nil
+}
+
+func fixtureVersions(subjectDir string) ([]string, error) {
+	entries, err := os.ReadDir(subjectDir)
+	if err != nil {
+		return nil, err
+	}
+
+	seen := map[string]bool{}
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		switch {
+		case strings.HasSuffix(name, ".schema.json"):
+			seen[strings.TrimSuffix(name, ".schema.json")] = true
+		case strings.HasSuffix(name, ".sample.json"):
+			seen[strings.TrimSuffix(name, ".sample.json")] = true
+		}
+	}
+
+	versions := make([]string, 0, len(seen))
+	for version := range seen {
+		schemaPath := filepath.Join(subjectDir, version+".schema.json")
+		samplePath := filepath.Join(subjectDir, version+".sample.json")
+		if _, err := os.Stat(schemaPath); err != nil {
+			return nil, fmt.Errorf("missing schema fixture %s", schemaPath)
+		}
+		if _, err := os.Stat(samplePath); err != nil {
+			return nil, fmt.Errorf("missing sample fixture %s", samplePath)
+		}
+		versions = append(versions, version)
+	}
+	slices.SortFunc(versions, compareVersions)
+	return versions, nil
+}
+
+func loadFixtureVersion(subjectDir, version string) (Document, map[string]any, error) {
+	var document Document
+	var sample map[string]any
+
+	schemaRaw, err := os.ReadFile(filepath.Join(subjectDir, version+".schema.json"))
+	if err != nil {
+		return Document{}, nil, err
+	}
+	if err := json.Unmarshal(schemaRaw, &document); err != nil {
+		return Document{}, nil, err
+	}
+
+	sampleRaw, err := os.ReadFile(filepath.Join(subjectDir, version+".sample.json"))
+	if err != nil {
+		return Document{}, nil, err
+	}
+	if err := json.Unmarshal(sampleRaw, &sample); err != nil {
+		return Document{}, nil, err
+	}
+
+	return document, sample, nil
+}
+
+func compareVersions(a, b string) int {
+	ap := strings.Split(a, ".")
+	bp := strings.Split(b, ".")
+	maxParts := len(ap)
+	if len(bp) > maxParts {
+		maxParts = len(bp)
+	}
+	for i := 0; i < maxParts; i++ {
+		ai := 0
+		bi := 0
+		if i < len(ap) {
+			ai, _ = strconv.Atoi(ap[i])
+		}
+		if i < len(bp) {
+			bi, _ = strconv.Atoi(bp[i])
+		}
+		if ai < bi {
+			return -1
+		}
+		if ai > bi {
+			return 1
+		}
+	}
+	return 0
+}

--- a/internal/eventschema/bootstrap.go
+++ b/internal/eventschema/bootstrap.go
@@ -145,7 +145,7 @@ func loadFixtureVersion(subjectDir, version string) (Document, map[string]any, e
 	var document Document
 	var sample map[string]any
 
-	schemaRaw, err := os.ReadFile(filepath.Join(subjectDir, version+".schema.json"))
+	schemaRaw, err := fixtureReadFile(subjectDir, version+".schema.json")
 	if err != nil {
 		return Document{}, nil, err
 	}
@@ -153,7 +153,7 @@ func loadFixtureVersion(subjectDir, version string) (Document, map[string]any, e
 		return Document{}, nil, err
 	}
 
-	sampleRaw, err := os.ReadFile(filepath.Join(subjectDir, version+".sample.json"))
+	sampleRaw, err := fixtureReadFile(subjectDir, version+".sample.json")
 	if err != nil {
 		return Document{}, nil, err
 	}
@@ -162,6 +162,12 @@ func loadFixtureVersion(subjectDir, version string) (Document, map[string]any, e
 	}
 
 	return document, sample, nil
+}
+
+func fixtureReadFile(dir, name string) ([]byte, error) {
+	path := filepath.Join(dir, filepath.Clean(name))
+	// #nosec G304 -- schema fixtures are repo-local files resolved from controlled directories.
+	return os.ReadFile(path)
 }
 
 func compareVersions(a, b string) int {

--- a/internal/eventschema/compat.go
+++ b/internal/eventschema/compat.go
@@ -1,0 +1,165 @@
+package eventschema
+
+import (
+	"fmt"
+	"sort"
+)
+
+var requiredEnvelopeFields = []string{
+	"event_id",
+	"event_type",
+	"occurred_at",
+	"correlation_id",
+	"causation_id",
+	"schema_version",
+	"merchant_id",
+	"payload",
+}
+
+type CompatibilityResult struct {
+	Compatible bool
+	Summary    string
+	Details    map[string]any
+}
+
+func ValidateDocument(doc Document) error {
+	if doc.Type != "object" {
+		return fmt.Errorf("%w: top-level schema must be an object", ErrInvalidSchemaDocument)
+	}
+	required := setOf(doc.Required)
+	for _, field := range requiredEnvelopeFields {
+		def, ok := doc.Properties[field]
+		if !ok {
+			return fmt.Errorf("%w: missing required envelope field %q", ErrInvalidSchemaDocument, field)
+		}
+		if !required[field] {
+			return fmt.Errorf("%w: envelope field %q must be required", ErrInvalidSchemaDocument, field)
+		}
+		if field == "payload" && def.Type != "object" {
+			return fmt.Errorf("%w: payload must be an object", ErrInvalidSchemaDocument)
+		}
+	}
+	return nil
+}
+
+func CheckCompatibility(previous, candidate Document) []CompatibilityCheck {
+	results := []CompatibilityCheck{
+		{
+			CheckType:  CheckTypeBackward,
+			Compatible: true,
+			Summary:    "backward compatible",
+			Details:    map[string]any{},
+		},
+		{
+			CheckType:  CheckTypeForward,
+			Compatible: true,
+			Summary:    "forward compatible",
+			Details:    map[string]any{},
+		},
+	}
+
+	backwardProblems := compareFields(previous, candidate, "")
+	forwardProblems := compareForwardCompatibleFields(candidate, previous, "")
+
+	results[0].Compatible = len(backwardProblems) == 0
+	results[1].Compatible = len(forwardProblems) == 0
+	if !results[0].Compatible {
+		results[0].Summary = "backward compatibility check failed"
+		results[0].Details["problems"] = backwardProblems
+	}
+	if !results[1].Compatible {
+		results[1].Summary = "forward compatibility check failed"
+		results[1].Details["problems"] = forwardProblems
+	}
+	return results
+}
+
+func compareFields(previous, candidate Document, prefix string) []string {
+	prevRequired := setOf(previous.Required)
+	candidateRequired := setOf(candidate.Required)
+	var problems []string
+
+	for field, prevDef := range previous.Properties {
+		path := joinPath(prefix, field)
+		candidateDef, ok := candidate.Properties[field]
+		if !ok {
+			problems = append(problems, fmt.Sprintf("missing field %s", path))
+			continue
+		}
+		if prevDef.Type != candidateDef.Type {
+			problems = append(problems, fmt.Sprintf("field %s changed type from %s to %s", path, prevDef.Type, candidateDef.Type))
+			continue
+		}
+		if prevRequired[field] && !candidateRequired[field] {
+			problems = append(problems, fmt.Sprintf("field %s is no longer required", path))
+		}
+		if !prevRequired[field] && candidateRequired[field] {
+			problems = append(problems, fmt.Sprintf("field %s became newly required", path))
+		}
+		if prevDef.Type == "object" {
+			nestedPrev := Document{Type: prevDef.Type, Properties: prevDef.Properties, Required: prevDef.Required}
+			nestedCandidate := Document{Type: candidateDef.Type, Properties: candidateDef.Properties, Required: candidateDef.Required}
+			problems = append(problems, compareFields(nestedPrev, nestedCandidate, path)...)
+		}
+	}
+
+	// Additive changes are allowed as long as the field is not required immediately.
+	for field := range candidate.Properties {
+		if _, ok := previous.Properties[field]; ok {
+			continue
+		}
+		if candidateRequired[field] {
+			problems = append(problems, fmt.Sprintf("new field %s is required", joinPath(prefix, field)))
+		}
+	}
+
+	sort.Strings(problems)
+	return problems
+}
+
+func compareForwardCompatibleFields(future, current Document, prefix string) []string {
+	futureRequired := setOf(future.Required)
+	currentRequired := setOf(current.Required)
+	var problems []string
+
+	for field, futureDef := range future.Properties {
+		path := joinPath(prefix, field)
+		currentDef, ok := current.Properties[field]
+		if !ok {
+			if futureRequired[field] {
+				problems = append(problems, fmt.Sprintf("missing required field %s", path))
+			}
+			continue
+		}
+		if futureDef.Type != currentDef.Type {
+			problems = append(problems, fmt.Sprintf("field %s changed type from %s to %s", path, currentDef.Type, futureDef.Type))
+			continue
+		}
+		if currentRequired[field] && !futureRequired[field] {
+			problems = append(problems, fmt.Sprintf("field %s is no longer required", path))
+		}
+		if futureDef.Type == "object" {
+			nestedFuture := Document{Type: futureDef.Type, Properties: futureDef.Properties, Required: futureDef.Required}
+			nestedCurrent := Document{Type: currentDef.Type, Properties: currentDef.Properties, Required: currentDef.Required}
+			problems = append(problems, compareForwardCompatibleFields(nestedFuture, nestedCurrent, path)...)
+		}
+	}
+
+	sort.Strings(problems)
+	return problems
+}
+
+func setOf(values []string) map[string]bool {
+	out := make(map[string]bool, len(values))
+	for _, value := range values {
+		out[value] = true
+	}
+	return out
+}
+
+func joinPath(prefix, field string) string {
+	if prefix == "" {
+		return field
+	}
+	return prefix + "." + field
+}

--- a/internal/eventschema/compat.go
+++ b/internal/eventschema/compat.go
@@ -97,8 +97,8 @@ func compareFields(previous, candidate Document, prefix string) []string {
 			problems = append(problems, fmt.Sprintf("field %s became newly required", path))
 		}
 		if prevDef.Type == "object" {
-			nestedPrev := Document{Type: prevDef.Type, Properties: prevDef.Properties, Required: prevDef.Required}
-			nestedCandidate := Document{Type: candidateDef.Type, Properties: candidateDef.Properties, Required: candidateDef.Required}
+			nestedPrev := Document(prevDef)
+			nestedCandidate := Document(candidateDef)
 			problems = append(problems, compareFields(nestedPrev, nestedCandidate, path)...)
 		}
 	}
@@ -139,8 +139,8 @@ func compareForwardCompatibleFields(future, current Document, prefix string) []s
 			problems = append(problems, fmt.Sprintf("field %s is no longer required", path))
 		}
 		if futureDef.Type == "object" {
-			nestedFuture := Document{Type: futureDef.Type, Properties: futureDef.Properties, Required: futureDef.Required}
-			nestedCurrent := Document{Type: currentDef.Type, Properties: currentDef.Properties, Required: currentDef.Required}
+			nestedFuture := Document(futureDef)
+			nestedCurrent := Document(currentDef)
 			problems = append(problems, compareForwardCompatibleFields(nestedFuture, nestedCurrent, path)...)
 		}
 	}

--- a/internal/eventschema/compat_fuzz_test.go
+++ b/internal/eventschema/compat_fuzz_test.go
@@ -1,0 +1,22 @@
+package eventschema
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func FuzzValidateDocument(f *testing.F) {
+	f.Add(`{"type":"object","required":["event_id","event_type","occurred_at","correlation_id","causation_id","schema_version","merchant_id","payload"],"properties":{"event_id":{"type":"string"},"event_type":{"type":"string"},"occurred_at":{"type":"string"},"correlation_id":{"type":"string"},"causation_id":{"type":"string"},"schema_version":{"type":"string"},"merchant_id":{"type":"string"},"payload":{"type":"object","properties":{},"required":[]}}}`)
+	f.Add(`{}`)
+	f.Add(`[]`)
+	f.Add(`"bad"`)
+
+	f.Fuzz(func(t *testing.T, raw string) {
+		var doc Document
+		err := json.Unmarshal([]byte(raw), &doc)
+		if err != nil {
+			return
+		}
+		_ = ValidateDocument(doc)
+	})
+}

--- a/internal/eventschema/contract_test.go
+++ b/internal/eventschema/contract_test.go
@@ -1,0 +1,167 @@
+package eventschema
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sanskarpan/PayGate/internal/webhook"
+)
+
+func TestWebhookConsumerAcceptsSchemaFixtureEnvelope(t *testing.T) {
+	schema, sample, _ := loadFixturePair(t, filepath.Join("..", "..", "schemas", "events", "payment.captured", "1.1.0.schema.json"))
+	if err := ValidateDocument(schema); err != nil {
+		t.Fatalf("validate schema: %v", err)
+	}
+
+	delivered := make(chan map[string]any, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		var body map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode delivered webhook body: %v", err)
+		}
+		delivered <- body
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	repo := &contractWebhookRepo{
+		subscriptions: []webhook.WebhookSubscription{
+			{
+				ID:         "sub_1",
+				MerchantID: "merch_456",
+				URL:        server.URL,
+				Events:     []string{"payment.captured"},
+				Secret:     "contract-secret",
+				Status:     webhook.StatusActive,
+			},
+		},
+	}
+	svc := webhook.NewService(repo)
+	consumer := webhook.NewNamedConsumer(svc, noopKafkaConsumer{}, "webhook-contract")
+
+	payloadMap, ok := sample["payload"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected payload fixture map, got %#v", sample["payload"])
+	}
+	payload, err := json.Marshal(payloadMap)
+	if err != nil {
+		t.Fatalf("marshal sample payload: %v", err)
+	}
+	envelope, err := json.Marshal(map[string]any{
+		"id":             "evt_payment_captured_contract",
+		"event_id":       "evt_payment_captured_contract",
+		"aggregate_type": "payment",
+		"aggregate_id":   "pay_456",
+		"event_type":     "payment.captured",
+		"merchant_id":    "merch_456",
+		"payload":        json.RawMessage(payload),
+		"created_at":     time.Now().Unix(),
+		"occurred_at":    time.Now().UTC().Format(time.RFC3339),
+		"correlation_id": "pay_456",
+		"causation_id":   "evt_payment_captured_contract",
+		"schema_subject": "payment.captured",
+		"schema_version": sample["schema_version"],
+	})
+	if err != nil {
+		t.Fatalf("marshal fixture envelope: %v", err)
+	}
+
+	if err := consumer.HandleMessage(context.Background(), "paygate.payments", "merch_456", envelope); err != nil {
+		t.Fatalf("handle schema fixture envelope: %v", err)
+	}
+
+	select {
+	case body := <-delivered:
+		if body["schema_subject"] != "payment.captured" {
+			t.Fatalf("expected delivered schema_subject payment.captured, got %#v", body["schema_subject"])
+		}
+		if body["schema_version"] != "1.1.0" {
+			t.Fatalf("expected delivered schema_version 1.1.0, got %#v", body["schema_version"])
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected webhook delivery from contract test")
+	}
+}
+
+type noopKafkaConsumer struct{}
+
+func (noopKafkaConsumer) Subscribe(context.Context, []string, func(topic, key string, payload []byte) error) error {
+	return nil
+}
+
+type contractWebhookRepo struct {
+	subscriptions []webhook.WebhookSubscription
+	attempts      []webhook.WebhookDeliveryAttempt
+}
+
+func (r *contractWebhookRepo) CreateSubscription(context.Context, webhook.CreateInput) (webhook.WebhookSubscription, error) {
+	panic("not used")
+}
+func (r *contractWebhookRepo) GetSubscription(ctx context.Context, merchantID, id string) (webhook.WebhookSubscription, error) {
+	for _, sub := range r.subscriptions {
+		if sub.MerchantID == merchantID && sub.ID == id {
+			return sub, nil
+		}
+	}
+	return webhook.WebhookSubscription{}, webhook.ErrSubscriptionNotFound
+}
+func (r *contractWebhookRepo) ListSubscriptions(context.Context, string) ([]webhook.WebhookSubscription, error) {
+	return r.subscriptions, nil
+}
+func (r *contractWebhookRepo) UpdateSubscription(context.Context, string, string, webhook.UpdateInput) (webhook.WebhookSubscription, error) {
+	panic("not used")
+}
+func (r *contractWebhookRepo) TransitionSubscription(context.Context, string, string, webhook.SubscriptionEvent) (webhook.WebhookSubscription, error) {
+	panic("not used")
+}
+func (r *contractWebhookRepo) DeleteSubscription(context.Context, string, string) error {
+	panic("not used")
+}
+func (r *contractWebhookRepo) FindActiveSubscriptions(_ context.Context, merchantID, eventType string) ([]webhook.WebhookSubscription, error) {
+	var out []webhook.WebhookSubscription
+	for _, sub := range r.subscriptions {
+		if sub.MerchantID == merchantID && sub.MatchesEvent(eventType) {
+			out = append(out, sub)
+		}
+	}
+	return out, nil
+}
+func (r *contractWebhookRepo) CreateDeliveryAttempt(_ context.Context, attempt webhook.WebhookDeliveryAttempt) (webhook.WebhookDeliveryAttempt, error) {
+	r.attempts = append(r.attempts, attempt)
+	return attempt, nil
+}
+func (r *contractWebhookRepo) UpdateDeliveryAttempt(context.Context, string, webhook.DeliveryStatus, int, string, string, *string, int) (webhook.WebhookDeliveryAttempt, error) {
+	panic("not used")
+}
+func (r *contractWebhookRepo) ListDeliveryAttempts(context.Context, string, string) ([]webhook.WebhookDeliveryAttempt, error) {
+	return r.attempts, nil
+}
+func (r *contractWebhookRepo) GetDeliveryAttempt(context.Context, string) (webhook.WebhookDeliveryAttempt, error) {
+	panic("not used")
+}
+func (r *contractWebhookRepo) LeasePendingRetries(context.Context, int) ([]webhook.WebhookDeliveryAttempt, error) {
+	return nil, nil
+}
+func (r *contractWebhookRepo) IsDelivered(_ context.Context, eventID, subscriptionID string) (bool, error) {
+	for _, attempt := range r.attempts {
+		if attempt.EventID == eventID && attempt.SubscriptionID == subscriptionID && attempt.Status == webhook.DeliverySucceeded {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+func (r *contractWebhookRepo) FindDeliveryByEvent(context.Context, string, string) ([]webhook.WebhookDeliveryAttempt, error) {
+	return r.attempts, nil
+}
+func (r *contractWebhookRepo) CancelDeliveryRetries(context.Context, string, string, string) (int64, error) {
+	return 0, nil
+}
+func (r *contractWebhookRepo) RotateSecret(context.Context, string, string) (webhook.WebhookSubscription, error) {
+	panic("not used")
+}

--- a/internal/eventschema/contract_test.go
+++ b/internal/eventschema/contract_test.go
@@ -20,7 +20,7 @@ func TestWebhookConsumerAcceptsSchemaFixtureEnvelope(t *testing.T) {
 
 	delivered := make(chan map[string]any, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer r.Body.Close()
+		defer func() { _ = r.Body.Close() }()
 		var body map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("decode delivered webhook body: %v", err)

--- a/internal/eventschema/domain.go
+++ b/internal/eventschema/domain.go
@@ -1,0 +1,111 @@
+package eventschema
+
+import "time"
+
+type Status string
+
+const (
+	StatusDraft      Status = "draft"
+	StatusActive     Status = "active"
+	StatusDeprecated Status = "deprecated"
+	StatusRetired    Status = "retired"
+)
+
+type CheckType string
+
+const (
+	CheckTypeBackward CheckType = "backward"
+	CheckTypeForward  CheckType = "forward"
+)
+
+type RolloutStatus string
+
+const (
+	RolloutStatusPlanned     RolloutStatus = "planned"
+	RolloutStatusDualPublish RolloutStatus = "dual_publish"
+	RolloutStatusCompleted   RolloutStatus = "completed"
+	RolloutStatusRolledBack  RolloutStatus = "rolled_back"
+)
+
+type Schema struct {
+	ID         string
+	Subject    string
+	EventType  string
+	TopicName  string
+	Owner      string
+	ReviewLink string
+	CreatedAt  time.Time
+	UpdatedAt  time.Time
+}
+
+type Version struct {
+	ID                   string
+	Subject              string
+	Version              string
+	Status               Status
+	Schema               Document
+	SamplePayload        map[string]any
+	ReviewLink           string
+	CompatibilitySummary string
+	CompatibilityDetails map[string]any
+	ActivatedAt          *time.Time
+	DeprecatedAt         *time.Time
+	CreatedAt            time.Time
+	UpdatedAt            time.Time
+}
+
+type CompatibilityCheck struct {
+	ID               string
+	Subject          string
+	CandidateVersion string
+	BaselineVersion  string
+	CheckType        CheckType
+	Compatible       bool
+	Summary          string
+	Details          map[string]any
+	CreatedAt        time.Time
+}
+
+type Rollout struct {
+	ID              string
+	Subject         string
+	FromVersion     string
+	ToVersion       string
+	Status          RolloutStatus
+	CutoverDeadline *time.Time
+	Notes           string
+	CreatedAt       time.Time
+	UpdatedAt       time.Time
+	Consumers       []RolloutConsumer
+}
+
+type RolloutConsumer struct {
+	ID                  string
+	RolloutID           string
+	ConsumerName        string
+	AcknowledgedVersion string
+	AcknowledgedAt      time.Time
+	CreatedAt           time.Time
+}
+
+type DeprecatedVersionAlert struct {
+	RolloutID           string
+	Subject             string
+	FromVersion         string
+	ToVersion           string
+	ConsumerName        string
+	AcknowledgedVersion string
+	CutoverDeadline     time.Time
+}
+
+type Document struct {
+	Type       string                 `json:"type"`
+	Properties map[string]FieldSchema `json:"properties,omitempty"`
+	Required   []string               `json:"required,omitempty"`
+}
+
+type FieldSchema struct {
+	Type       string                 `json:"type"`
+	Properties map[string]FieldSchema `json:"properties,omitempty"`
+	Required   []string               `json:"required,omitempty"`
+}

--- a/internal/eventschema/fixtures_test.go
+++ b/internal/eventschema/fixtures_test.go
@@ -62,6 +62,7 @@ func TestCheckCompatibilityAllowsAdditiveOptionalFields(t *testing.T) {
 
 func loadFixturePair(t *testing.T, schemaPath string) (Document, map[string]any, string) {
 	t.Helper()
+	// #nosec G304 -- schema fixtures are checked-in test assets under the repo.
 	rawSchema, err := os.ReadFile(schemaPath)
 	if err != nil {
 		t.Fatalf("read schema fixture: %v", err)
@@ -72,6 +73,7 @@ func loadFixturePair(t *testing.T, schemaPath string) (Document, map[string]any,
 	}
 
 	samplePath := strings.TrimSuffix(schemaPath, ".schema.json") + ".sample.json"
+	// #nosec G304 -- sample fixtures are checked-in test assets under the repo.
 	rawSample, err := os.ReadFile(samplePath)
 	if err != nil {
 		t.Fatalf("read sample fixture: %v", err)
@@ -131,11 +133,7 @@ func validateSampleAgainstRequiredFields(t *testing.T, schema Document, sample m
 			if !ok {
 				t.Fatalf("sample field %s must be object", joinPath(prefix, field))
 			}
-			validateSampleAgainstRequiredFields(t, Document{
-				Type:       fieldSchema.Type,
-				Properties: fieldSchema.Properties,
-				Required:   fieldSchema.Required,
-			}, nested, joinPath(prefix, field))
+			validateSampleAgainstRequiredFields(t, Document(fieldSchema), nested, joinPath(prefix, field))
 		}
 	}
 }

--- a/internal/eventschema/fixtures_test.go
+++ b/internal/eventschema/fixtures_test.go
@@ -1,0 +1,141 @@
+package eventschema
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func TestSchemaFixturesValidateAndHaveSamples(t *testing.T) {
+	root := filepath.Join("..", "..", "schemas", "events")
+	schemaFiles, err := filepath.Glob(filepath.Join(root, "*", "*.schema.json"))
+	if err != nil {
+		t.Fatalf("glob schema fixtures: %v", err)
+	}
+	sort.Strings(schemaFiles)
+	if len(schemaFiles) == 0 {
+		t.Fatal("expected schema fixtures")
+	}
+
+	gotSubjects := map[string]bool{}
+	for _, schemaPath := range schemaFiles {
+		subject := filepath.Base(filepath.Dir(schemaPath))
+		gotSubjects[subject] = true
+	}
+	for _, subject := range expectedSchemaFixtureSubjects() {
+		if !gotSubjects[subject] {
+			t.Fatalf("missing schema fixtures for subject %s", subject)
+		}
+	}
+
+	for _, schemaPath := range schemaFiles {
+		t.Run(strings.TrimPrefix(schemaPath, root+"/"), func(t *testing.T) {
+			schema, sample, version := loadFixturePair(t, schemaPath)
+			if err := ValidateDocument(schema); err != nil {
+				t.Fatalf("validate schema: %v", err)
+			}
+			if gotVersion, _ := sample["schema_version"].(string); gotVersion != version {
+				t.Fatalf("expected sample schema_version %q, got %#v", version, sample["schema_version"])
+			}
+			validateSampleAgainstRequiredFields(t, schema, sample, "")
+		})
+	}
+}
+
+func TestCheckCompatibilityAllowsAdditiveOptionalFields(t *testing.T) {
+	oldSchema, _, _ := loadFixturePair(t, filepath.Join("..", "..", "schemas", "events", "payment.captured", "1.0.0.schema.json"))
+	newSchema, _, _ := loadFixturePair(t, filepath.Join("..", "..", "schemas", "events", "payment.captured", "1.1.0.schema.json"))
+
+	checks := CheckCompatibility(oldSchema, newSchema)
+	if len(checks) != 2 {
+		t.Fatalf("expected 2 compatibility checks, got %d", len(checks))
+	}
+	for _, check := range checks {
+		if !check.Compatible {
+			t.Fatalf("expected additive optional field to be compatible for %s, got %+v", check.CheckType, check)
+		}
+	}
+}
+
+func loadFixturePair(t *testing.T, schemaPath string) (Document, map[string]any, string) {
+	t.Helper()
+	rawSchema, err := os.ReadFile(schemaPath)
+	if err != nil {
+		t.Fatalf("read schema fixture: %v", err)
+	}
+	var schema Document
+	if err := json.Unmarshal(rawSchema, &schema); err != nil {
+		t.Fatalf("decode schema fixture: %v", err)
+	}
+
+	samplePath := strings.TrimSuffix(schemaPath, ".schema.json") + ".sample.json"
+	rawSample, err := os.ReadFile(samplePath)
+	if err != nil {
+		t.Fatalf("read sample fixture: %v", err)
+	}
+	var sample map[string]any
+	if err := json.Unmarshal(rawSample, &sample); err != nil {
+		t.Fatalf("decode sample fixture: %v", err)
+	}
+	version := strings.TrimSuffix(filepath.Base(schemaPath), ".schema.json")
+	return schema, sample, version
+}
+
+func expectedSchemaFixtureSubjects() []string {
+	return []string{
+		"dispute.accepted",
+		"dispute.created",
+		"dispute.lost",
+		"dispute.updated",
+		"dispute.won",
+		"order.created",
+		"order.paid",
+		"payment.authorized",
+		"payment.authorization_reversed",
+		"payment.auto_refunded",
+		"payment.captured",
+		"payment.failed",
+		"payout.cancelled",
+		"payout.completed",
+		"payout.created",
+		"payout.failed",
+		"payout.initiated",
+		"payout.returned",
+		"payout.reversed",
+		"refund.created",
+		"refund.failed",
+		"refund.processed",
+		"refund.reversed",
+		"risk.alert",
+		"settlement.rollback_marked",
+		"settlement.processed",
+	}
+}
+
+func validateSampleAgainstRequiredFields(t *testing.T, schema Document, sample map[string]any, prefix string) {
+	t.Helper()
+	for _, field := range schema.Required {
+		value, ok := sample[field]
+		if !ok {
+			t.Fatalf("sample missing required field %s", joinPath(prefix, field))
+		}
+		fieldSchema, ok := schema.Properties[field]
+		if !ok {
+			t.Fatalf("schema missing definition for required field %s", joinPath(prefix, field))
+		}
+		if fieldSchema.Type == "object" {
+			nested, ok := value.(map[string]any)
+			if !ok {
+				t.Fatalf("sample field %s must be object", joinPath(prefix, field))
+			}
+			validateSampleAgainstRequiredFields(t, Document{
+				Type:       fieldSchema.Type,
+				Properties: fieldSchema.Properties,
+				Required:   fieldSchema.Required,
+			}, nested, joinPath(prefix, field))
+		}
+	}
+}

--- a/internal/eventschema/handler.go
+++ b/internal/eventschema/handler.go
@@ -356,7 +356,7 @@ func handleError(w http.ResponseWriter, err error) {
 		httpx.WriteError(w, http.StatusNotFound, httpx.APIError{Code: "NOT_FOUND", Description: err.Error()})
 	case errors.Is(err, ErrInvalidSchemaDocument), errors.Is(err, ErrInvalidSchemaRollout):
 		httpx.WriteError(w, http.StatusBadRequest, httpx.APIError{Code: "BAD_REQUEST", Description: err.Error()})
-	case errors.Is(err, ErrIncompatibleSchema), errors.Is(err, ErrNoActiveSchemaVersion):
+	case errors.Is(err, ErrIncompatibleSchema), errors.Is(err, ErrNoActiveSchemaVersion), errors.Is(err, ErrSchemaAlreadyExists), errors.Is(err, ErrSchemaVersionExists):
 		httpx.WriteError(w, http.StatusConflict, httpx.APIError{Code: "CONFLICT", Description: err.Error()})
 	default:
 		httpx.WriteError(w, http.StatusInternalServerError, httpx.APIError{Code: "SERVER_ERROR", Description: "internal server error"})

--- a/internal/eventschema/handler.go
+++ b/internal/eventschema/handler.go
@@ -178,17 +178,17 @@ func (h *Handler) createRollout(w http.ResponseWriter, r *http.Request) {
 	var req struct {
 		FromVersion     string `json:"from_version"`
 		ToVersion       string `json:"to_version"`
-		CutoverDeadline int64  `json:"cutover_deadline"`
+		CutoverDeadline any    `json:"cutover_deadline"`
 		Notes           string `json:"notes"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		httpx.WriteError(w, http.StatusBadRequest, httpx.APIError{Code: "BAD_REQUEST", Description: "invalid schema rollout request body"})
 		return
 	}
-	var deadlineTime *time.Time
-	if req.CutoverDeadline > 0 {
-		t := time.Unix(req.CutoverDeadline, 0).UTC()
-		deadlineTime = &t
+	deadlineTime, err := parseCutoverDeadline(req.CutoverDeadline)
+	if err != nil {
+		httpx.WriteError(w, http.StatusBadRequest, httpx.APIError{Code: "BAD_REQUEST", Description: "invalid cutover_deadline"})
+		return
 	}
 	item, err := h.svc.CreateRollout(r.Context(), CreateRolloutInput{
 		Subject:         r.PathValue("subject"),
@@ -202,6 +202,34 @@ func (h *Handler) createRollout(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	httpx.WriteJSON(w, http.StatusCreated, presentRollout(item))
+}
+
+func parseCutoverDeadline(raw any) (*time.Time, error) {
+	if raw == nil {
+		return nil, nil
+	}
+
+	switch value := raw.(type) {
+	case string:
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return nil, nil
+		}
+		t, err := time.Parse(time.RFC3339, value)
+		if err != nil {
+			return nil, err
+		}
+		utc := t.UTC()
+		return &utc, nil
+	case float64:
+		if value <= 0 {
+			return nil, nil
+		}
+		t := time.Unix(int64(value), 0).UTC()
+		return &t, nil
+	default:
+		return nil, errors.New("unsupported cutover deadline type")
+	}
 }
 
 func (h *Handler) getRollout(w http.ResponseWriter, r *http.Request) {

--- a/internal/eventschema/handler.go
+++ b/internal/eventschema/handler.go
@@ -1,0 +1,336 @@
+package eventschema
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"time"
+
+	httpx "github.com/sanskarpan/PayGate/internal/common/http"
+	"github.com/sanskarpan/PayGate/internal/merchant"
+)
+
+type Handler struct {
+	svc *Service
+}
+
+func NewHandler(svc *Service) *Handler {
+	return &Handler{svc: svc}
+}
+
+func (h *Handler) RegisterRoutesWithAuth(mux *http.ServeMux, wrap func(scope merchant.APIKeyScope, next http.Handler) http.Handler) {
+	mux.Handle("GET /v1/event-schemas", wrap(merchant.APIKeyScopeRead, http.HandlerFunc(h.listSchemas)))
+	mux.Handle("POST /v1/event-schemas", wrap(merchant.APIKeyScopeAdmin, http.HandlerFunc(h.createSchema)))
+	mux.Handle("GET /v1/event-schemas/{subject}", wrap(merchant.APIKeyScopeRead, http.HandlerFunc(h.getSchema)))
+	mux.Handle("POST /v1/event-schemas/{subject}/versions", wrap(merchant.APIKeyScopeAdmin, http.HandlerFunc(h.createVersion)))
+	mux.Handle("GET /v1/event-schemas/{subject}/versions/{version}", wrap(merchant.APIKeyScopeRead, http.HandlerFunc(h.getVersion)))
+	mux.Handle("POST /v1/event-schemas/{subject}/versions/{version}/activate", wrap(merchant.APIKeyScopeAdmin, http.HandlerFunc(h.activateVersion)))
+	mux.Handle("GET /v1/event-schemas/{subject}/compare", wrap(merchant.APIKeyScopeRead, http.HandlerFunc(h.compareVersions)))
+	mux.Handle("POST /v1/event-schemas/{subject}/rollouts", wrap(merchant.APIKeyScopeAdmin, http.HandlerFunc(h.createRollout)))
+	mux.Handle("GET /v1/event-schema-rollouts/{rolloutID}", wrap(merchant.APIKeyScopeRead, http.HandlerFunc(h.getRollout)))
+	mux.Handle("POST /v1/event-schema-rollouts/{rolloutID}/ack", wrap(merchant.APIKeyScopeAdmin, http.HandlerFunc(h.ackRollout)))
+}
+
+func (h *Handler) listSchemas(w http.ResponseWriter, r *http.Request) {
+	items, err := h.svc.ListSchemas(r.Context())
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+	out := make([]map[string]any, 0, len(items))
+	for _, item := range items {
+		out = append(out, presentSchema(item))
+	}
+	httpx.WriteJSON(w, http.StatusOK, map[string]any{"entity": "collection", "count": len(out), "items": out})
+}
+
+func (h *Handler) createSchema(w http.ResponseWriter, r *http.Request) {
+	var req CreateSchemaInput
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpx.WriteError(w, http.StatusBadRequest, httpx.APIError{Code: "BAD_REQUEST", Description: "invalid schema request body"})
+		return
+	}
+	req.Subject = strings.TrimSpace(req.Subject)
+	req.EventType = strings.TrimSpace(req.EventType)
+	req.TopicName = strings.TrimSpace(req.TopicName)
+	req.Owner = strings.TrimSpace(req.Owner)
+	if req.Subject == "" || req.EventType == "" || req.TopicName == "" || req.Owner == "" {
+		httpx.WriteError(w, http.StatusBadRequest, httpx.APIError{Code: "BAD_REQUEST", Description: "subject, event_type, topic_name, and owner are required"})
+		return
+	}
+	item, err := h.svc.CreateSchema(r.Context(), req)
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+	httpx.WriteJSON(w, http.StatusCreated, presentSchema(item))
+}
+
+func (h *Handler) getSchema(w http.ResponseWriter, r *http.Request) {
+	item, versions, checks, err := h.svc.GetSchema(r.Context(), r.PathValue("subject"))
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+	versionPayload := make([]map[string]any, 0, len(versions))
+	for _, version := range versions {
+		versionPayload = append(versionPayload, presentVersion(version))
+	}
+	checkPayload := make([]map[string]any, 0, len(checks))
+	for _, check := range checks {
+		checkPayload = append(checkPayload, presentCheck(check))
+	}
+	resp := presentSchema(item)
+	resp["versions"] = versionPayload
+	resp["checks"] = checkPayload
+	httpx.WriteJSON(w, http.StatusOK, resp)
+}
+
+func (h *Handler) createVersion(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Version       string         `json:"version"`
+		Schema        Document       `json:"schema"`
+		SamplePayload map[string]any `json:"sample_payload"`
+		ReviewLink    string         `json:"review_link"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpx.WriteError(w, http.StatusBadRequest, httpx.APIError{Code: "BAD_REQUEST", Description: "invalid schema version request body"})
+		return
+	}
+	version, checks, err := h.svc.RegisterVersion(r.Context(), CreateVersionInput{
+		Subject:       r.PathValue("subject"),
+		Version:       strings.TrimSpace(req.Version),
+		Schema:        req.Schema,
+		SamplePayload: req.SamplePayload,
+		ReviewLink:    strings.TrimSpace(req.ReviewLink),
+	})
+	if err != nil {
+		if errors.Is(err, ErrIncompatibleSchema) {
+			payload := make([]map[string]any, 0, len(checks))
+			for _, check := range checks {
+				payload = append(payload, presentCheck(check))
+			}
+			httpx.WriteError(w, http.StatusConflict, httpx.APIError{
+				Code:        "INCOMPATIBLE_SCHEMA",
+				Description: err.Error(),
+				Metadata:    map[string]any{"checks": payload},
+			})
+			return
+		}
+		handleError(w, err)
+		return
+	}
+	resp := presentVersion(version)
+	if len(checks) > 0 {
+		payload := make([]map[string]any, 0, len(checks))
+		for _, check := range checks {
+			payload = append(payload, presentCheck(check))
+		}
+		resp["checks"] = payload
+	}
+	httpx.WriteJSON(w, http.StatusCreated, resp)
+}
+
+func (h *Handler) getVersion(w http.ResponseWriter, r *http.Request) {
+	item, err := h.svc.GetVersion(r.Context(), r.PathValue("subject"), r.PathValue("version"))
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+	httpx.WriteJSON(w, http.StatusOK, presentVersion(item))
+}
+
+func (h *Handler) activateVersion(w http.ResponseWriter, r *http.Request) {
+	item, err := h.svc.ActivateVersion(r.Context(), ActivateVersionInput{
+		Subject: r.PathValue("subject"),
+		Version: r.PathValue("version"),
+	})
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+	httpx.WriteJSON(w, http.StatusAccepted, presentVersion(item))
+}
+
+func (h *Handler) compareVersions(w http.ResponseWriter, r *http.Request) {
+	checks, err := h.svc.CompareVersions(r.Context(), CompareVersionsInput{
+		Subject:     r.PathValue("subject"),
+		FromVersion: strings.TrimSpace(r.URL.Query().Get("from")),
+		ToVersion:   strings.TrimSpace(r.URL.Query().Get("to")),
+	})
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+	payload := make([]map[string]any, 0, len(checks))
+	for _, check := range checks {
+		payload = append(payload, presentCheck(check))
+	}
+	httpx.WriteJSON(w, http.StatusOK, map[string]any{
+		"entity":  "schema_comparison",
+		"subject": r.PathValue("subject"),
+		"checks":  payload,
+	})
+}
+
+func (h *Handler) createRollout(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		FromVersion     string `json:"from_version"`
+		ToVersion       string `json:"to_version"`
+		CutoverDeadline int64  `json:"cutover_deadline"`
+		Notes           string `json:"notes"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpx.WriteError(w, http.StatusBadRequest, httpx.APIError{Code: "BAD_REQUEST", Description: "invalid schema rollout request body"})
+		return
+	}
+	var deadlineTime *time.Time
+	if req.CutoverDeadline > 0 {
+		t := time.Unix(req.CutoverDeadline, 0).UTC()
+		deadlineTime = &t
+	}
+	item, err := h.svc.CreateRollout(r.Context(), CreateRolloutInput{
+		Subject:         r.PathValue("subject"),
+		FromVersion:     strings.TrimSpace(req.FromVersion),
+		ToVersion:       strings.TrimSpace(req.ToVersion),
+		CutoverDeadline: deadlineTime,
+		Notes:           strings.TrimSpace(req.Notes),
+	})
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+	httpx.WriteJSON(w, http.StatusCreated, presentRollout(item))
+}
+
+func (h *Handler) getRollout(w http.ResponseWriter, r *http.Request) {
+	item, err := h.svc.GetRollout(r.Context(), r.PathValue("rolloutID"))
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+	httpx.WriteJSON(w, http.StatusOK, presentRollout(item))
+}
+
+func (h *Handler) ackRollout(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		ConsumerName        string `json:"consumer_name"`
+		AcknowledgedVersion string `json:"acknowledged_version"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		httpx.WriteError(w, http.StatusBadRequest, httpx.APIError{Code: "BAD_REQUEST", Description: "invalid rollout ack request body"})
+		return
+	}
+	item, err := h.svc.AckRollout(r.Context(), AckRolloutInput{
+		RolloutID:           r.PathValue("rolloutID"),
+		ConsumerName:        strings.TrimSpace(req.ConsumerName),
+		AcknowledgedVersion: strings.TrimSpace(req.AcknowledgedVersion),
+	})
+	if err != nil {
+		handleError(w, err)
+		return
+	}
+	httpx.WriteJSON(w, http.StatusCreated, presentRolloutConsumer(item))
+}
+
+func presentSchema(item Schema) map[string]any {
+	return map[string]any{
+		"entity":      "event_schema",
+		"id":          item.ID,
+		"subject":     item.Subject,
+		"event_type":  item.EventType,
+		"topic_name":  item.TopicName,
+		"owner":       item.Owner,
+		"review_link": item.ReviewLink,
+		"created_at":  item.CreatedAt.Unix(),
+		"updated_at":  item.UpdatedAt.Unix(),
+	}
+}
+
+func presentVersion(item Version) map[string]any {
+	resp := map[string]any{
+		"entity":                "event_schema_version",
+		"id":                    item.ID,
+		"subject":               item.Subject,
+		"version":               item.Version,
+		"status":                item.Status,
+		"schema":                item.Schema,
+		"sample_payload":        item.SamplePayload,
+		"review_link":           item.ReviewLink,
+		"compatibility_summary": item.CompatibilitySummary,
+		"compatibility_details": item.CompatibilityDetails,
+		"created_at":            item.CreatedAt.Unix(),
+		"updated_at":            item.UpdatedAt.Unix(),
+	}
+	if item.ActivatedAt != nil {
+		resp["activated_at"] = item.ActivatedAt.Unix()
+	}
+	if item.DeprecatedAt != nil {
+		resp["deprecated_at"] = item.DeprecatedAt.Unix()
+	}
+	return resp
+}
+
+func presentCheck(item CompatibilityCheck) map[string]any {
+	return map[string]any{
+		"entity":            "schema_compatibility_check",
+		"id":                item.ID,
+		"subject":           item.Subject,
+		"candidate_version": item.CandidateVersion,
+		"baseline_version":  item.BaselineVersion,
+		"check_type":        item.CheckType,
+		"compatible":        item.Compatible,
+		"summary":           item.Summary,
+		"details":           item.Details,
+		"created_at":        item.CreatedAt.Unix(),
+	}
+}
+
+func presentRollout(item Rollout) map[string]any {
+	consumers := make([]map[string]any, 0, len(item.Consumers))
+	for _, consumer := range item.Consumers {
+		consumers = append(consumers, presentRolloutConsumer(consumer))
+	}
+	resp := map[string]any{
+		"entity":       "schema_rollout",
+		"id":           item.ID,
+		"subject":      item.Subject,
+		"from_version": item.FromVersion,
+		"to_version":   item.ToVersion,
+		"status":       item.Status,
+		"notes":        item.Notes,
+		"created_at":   item.CreatedAt.Unix(),
+		"updated_at":   item.UpdatedAt.Unix(),
+		"consumers":    consumers,
+	}
+	if item.CutoverDeadline != nil {
+		resp["cutover_deadline"] = item.CutoverDeadline.Unix()
+	}
+	return resp
+}
+
+func presentRolloutConsumer(item RolloutConsumer) map[string]any {
+	return map[string]any{
+		"entity":               "schema_rollout_consumer",
+		"id":                   item.ID,
+		"rollout_id":           item.RolloutID,
+		"consumer_name":        item.ConsumerName,
+		"acknowledged_version": item.AcknowledgedVersion,
+		"acknowledged_at":      item.AcknowledgedAt.Unix(),
+		"created_at":           item.CreatedAt.Unix(),
+	}
+}
+
+func handleError(w http.ResponseWriter, err error) {
+	switch {
+	case errors.Is(err, ErrSchemaNotFound), errors.Is(err, ErrSchemaVersionNotFound), errors.Is(err, ErrSchemaRolloutNotFound):
+		httpx.WriteError(w, http.StatusNotFound, httpx.APIError{Code: "NOT_FOUND", Description: err.Error()})
+	case errors.Is(err, ErrInvalidSchemaDocument), errors.Is(err, ErrInvalidSchemaRollout):
+		httpx.WriteError(w, http.StatusBadRequest, httpx.APIError{Code: "BAD_REQUEST", Description: err.Error()})
+	case errors.Is(err, ErrIncompatibleSchema), errors.Is(err, ErrNoActiveSchemaVersion):
+		httpx.WriteError(w, http.StatusConflict, httpx.APIError{Code: "CONFLICT", Description: err.Error()})
+	default:
+		httpx.WriteError(w, http.StatusInternalServerError, httpx.APIError{Code: "SERVER_ERROR", Description: "internal server error"})
+	}
+}

--- a/internal/eventschema/postgres.go
+++ b/internal/eventschema/postgres.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/sanskarpan/PayGate/internal/common/idgen"
@@ -26,7 +27,11 @@ INSERT INTO paygate_schema.event_schemas (id, subject, event_type, topic_name, o
 VALUES ($1, $2, $3, $4, $5, $6)
 RETURNING id, subject, event_type, topic_name, owner, review_link, created_at, updated_at
 `, id, in.Subject, in.EventType, in.TopicName, in.Owner, in.ReviewLink)
-	return scanSchema(row)
+	item, err := scanSchema(row)
+	if isUniqueViolation(err) {
+		return Schema{}, ErrSchemaAlreadyExists
+	}
+	return item, err
 }
 
 func (r *PostgresRepository) ListSchemas(ctx context.Context) ([]Schema, error) {
@@ -103,6 +108,9 @@ RETURNING id, subject, version, status, schema_json, sample_payload, review_link
 
 	version, err := scanVersion(row)
 	if err != nil {
+		if isUniqueViolation(err) {
+			return Version{}, ErrSchemaVersionExists
+		}
 		return Version{}, err
 	}
 
@@ -266,6 +274,11 @@ RETURNING id, subject, from_version, to_version, status, cutover_deadline, notes
 		return Rollout{}, err
 	}
 	return item, nil
+}
+
+func isUniqueViolation(err error) bool {
+	var pgErr *pgconn.PgError
+	return errors.As(err, &pgErr) && pgErr.Code == "23505"
 }
 
 func (r *PostgresRepository) GetRollout(ctx context.Context, rolloutID string) (Rollout, error) {

--- a/internal/eventschema/postgres.go
+++ b/internal/eventschema/postgres.go
@@ -1,0 +1,440 @@
+package eventschema
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/sanskarpan/PayGate/internal/common/idgen"
+)
+
+type PostgresRepository struct {
+	db *pgxpool.Pool
+}
+
+func NewPostgresRepository(db *pgxpool.Pool) *PostgresRepository {
+	return &PostgresRepository{db: db}
+}
+
+func (r *PostgresRepository) CreateSchema(ctx context.Context, in CreateSchemaInput) (Schema, error) {
+	id := idgen.New("esch")
+	row := r.db.QueryRow(ctx, `
+INSERT INTO paygate_schema.event_schemas (id, subject, event_type, topic_name, owner, review_link)
+VALUES ($1, $2, $3, $4, $5, $6)
+RETURNING id, subject, event_type, topic_name, owner, review_link, created_at, updated_at
+`, id, in.Subject, in.EventType, in.TopicName, in.Owner, in.ReviewLink)
+	return scanSchema(row)
+}
+
+func (r *PostgresRepository) ListSchemas(ctx context.Context) ([]Schema, error) {
+	rows, err := r.db.Query(ctx, `
+SELECT id, subject, event_type, topic_name, owner, review_link, created_at, updated_at
+FROM paygate_schema.event_schemas
+ORDER BY subject ASC
+`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []Schema
+	for rows.Next() {
+		item, err := scanSchema(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, item)
+	}
+	return out, rows.Err()
+}
+
+func (r *PostgresRepository) GetSchema(ctx context.Context, subject string) (Schema, error) {
+	row := r.db.QueryRow(ctx, `
+SELECT id, subject, event_type, topic_name, owner, review_link, created_at, updated_at
+FROM paygate_schema.event_schemas
+WHERE subject = $1
+`, subject)
+	item, err := scanSchema(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Schema{}, ErrSchemaNotFound
+	}
+	return item, err
+}
+
+func (r *PostgresRepository) CreateVersion(ctx context.Context, in CreateVersionInput, checks []CompatibilityCheck) (Version, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return Version{}, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	schemaJSON, err := json.Marshal(in.Schema)
+	if err != nil {
+		return Version{}, err
+	}
+	samplePayload, err := json.Marshal(in.SamplePayload)
+	if err != nil {
+		return Version{}, err
+	}
+
+	compatSummary := "initial version"
+	compatDetails := map[string]any{}
+	if len(checks) > 0 {
+		compatSummary = checks[0].Summary
+		compatDetails = map[string]any{"checks": checks}
+	}
+	compatJSON, err := json.Marshal(compatDetails)
+	if err != nil {
+		return Version{}, err
+	}
+
+	versionID := idgen.New("esv")
+	row := tx.QueryRow(ctx, `
+INSERT INTO paygate_schema.schema_versions
+    (id, subject, version, status, schema_json, sample_payload, review_link, compatibility_summary, compatibility_details)
+VALUES
+    ($1, $2, $3, 'draft', $4, $5, $6, $7, $8)
+RETURNING id, subject, version, status, schema_json, sample_payload, review_link, compatibility_summary,
+          compatibility_details, activated_at, deprecated_at, created_at, updated_at
+`, versionID, in.Subject, in.Version, schemaJSON, samplePayload, in.ReviewLink, compatSummary, compatJSON)
+
+	version, err := scanVersion(row)
+	if err != nil {
+		return Version{}, err
+	}
+
+	for _, check := range checks {
+		detailsJSON, err := json.Marshal(check.Details)
+		if err != nil {
+			return Version{}, err
+		}
+		if _, err := tx.Exec(ctx, `
+INSERT INTO paygate_schema.schema_compatibility_checks
+    (id, subject, candidate_version, baseline_version, check_type, compatible, summary, details_json)
+VALUES
+    ($1, $2, $3, $4, $5, $6, $7, $8)
+`, idgen.New("eschk"), in.Subject, in.Version, check.BaselineVersion, check.CheckType, check.Compatible, check.Summary, detailsJSON); err != nil {
+			return Version{}, err
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return Version{}, err
+	}
+	return version, nil
+}
+
+func (r *PostgresRepository) ListVersions(ctx context.Context, subject string) ([]Version, error) {
+	rows, err := r.db.Query(ctx, `
+SELECT id, subject, version, status, schema_json, sample_payload, review_link, compatibility_summary,
+       compatibility_details, activated_at, deprecated_at, created_at, updated_at
+FROM paygate_schema.schema_versions
+WHERE subject = $1
+ORDER BY created_at ASC
+`, subject)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []Version
+	for rows.Next() {
+		item, err := scanVersion(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, item)
+	}
+	return out, rows.Err()
+}
+
+func (r *PostgresRepository) GetVersion(ctx context.Context, subject, version string) (Version, error) {
+	row := r.db.QueryRow(ctx, `
+SELECT id, subject, version, status, schema_json, sample_payload, review_link, compatibility_summary,
+       compatibility_details, activated_at, deprecated_at, created_at, updated_at
+FROM paygate_schema.schema_versions
+WHERE subject = $1 AND version = $2
+`, subject, version)
+	item, err := scanVersion(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Version{}, ErrSchemaVersionNotFound
+	}
+	return item, err
+}
+
+func (r *PostgresRepository) GetActiveVersion(ctx context.Context, subject string) (Version, error) {
+	row := r.db.QueryRow(ctx, `
+SELECT id, subject, version, status, schema_json, sample_payload, review_link, compatibility_summary,
+       compatibility_details, activated_at, deprecated_at, created_at, updated_at
+FROM paygate_schema.schema_versions
+WHERE subject = $1 AND status = 'active'
+ORDER BY activated_at DESC NULLS LAST, created_at DESC
+LIMIT 1
+`, subject)
+	item, err := scanVersion(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Version{}, ErrNoActiveSchemaVersion
+	}
+	return item, err
+}
+
+func (r *PostgresRepository) ActivateVersion(ctx context.Context, in ActivateVersionInput) (Version, error) {
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return Version{}, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err := tx.Exec(ctx, `
+UPDATE paygate_schema.schema_versions
+SET status = 'deprecated', deprecated_at = NOW(), updated_at = NOW()
+WHERE subject = $1 AND status = 'active'
+`, in.Subject); err != nil {
+		return Version{}, err
+	}
+
+	row := tx.QueryRow(ctx, `
+UPDATE paygate_schema.schema_versions
+SET status = 'active', activated_at = NOW(), deprecated_at = NULL, updated_at = NOW()
+WHERE subject = $1 AND version = $2
+RETURNING id, subject, version, status, schema_json, sample_payload, review_link, compatibility_summary,
+          compatibility_details, activated_at, deprecated_at, created_at, updated_at
+`, in.Subject, in.Version)
+	version, err := scanVersion(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Version{}, ErrSchemaVersionNotFound
+	}
+	if err != nil {
+		return Version{}, err
+	}
+
+	if _, err := tx.Exec(ctx, `
+UPDATE paygate_schema.schema_rollouts
+SET status = 'completed', updated_at = NOW()
+WHERE subject = $1 AND status = 'dual_publish' AND to_version = $2
+`, in.Subject, in.Version); err != nil {
+		return Version{}, err
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return Version{}, err
+	}
+	return version, nil
+}
+
+func (r *PostgresRepository) ListChecks(ctx context.Context, subject string, limit int) ([]CompatibilityCheck, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 25
+	}
+	rows, err := r.db.Query(ctx, `
+SELECT id, subject, candidate_version, baseline_version, check_type, compatible, summary, details_json, created_at
+FROM paygate_schema.schema_compatibility_checks
+WHERE subject = $1
+ORDER BY created_at DESC
+LIMIT $2
+`, subject, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []CompatibilityCheck
+	for rows.Next() {
+		item, err := scanCheck(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, item)
+	}
+	return out, rows.Err()
+}
+
+func (r *PostgresRepository) CreateRollout(ctx context.Context, in CreateRolloutInput) (Rollout, error) {
+	id := idgen.New("roll")
+	row := r.db.QueryRow(ctx, `
+INSERT INTO paygate_schema.schema_rollouts
+    (id, subject, from_version, to_version, status, cutover_deadline, notes)
+VALUES
+    ($1, $2, $3, $4, 'dual_publish', $5, $6)
+RETURNING id, subject, from_version, to_version, status, cutover_deadline, notes, created_at, updated_at
+`, id, in.Subject, in.FromVersion, in.ToVersion, in.CutoverDeadline, in.Notes)
+	item, err := scanRollout(row)
+	if err != nil {
+		return Rollout{}, err
+	}
+	return item, nil
+}
+
+func (r *PostgresRepository) GetRollout(ctx context.Context, rolloutID string) (Rollout, error) {
+	row := r.db.QueryRow(ctx, `
+SELECT id, subject, from_version, to_version, status, cutover_deadline, notes, created_at, updated_at
+FROM paygate_schema.schema_rollouts
+WHERE id = $1
+`, rolloutID)
+	item, err := scanRollout(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Rollout{}, ErrSchemaRolloutNotFound
+	}
+	if err != nil {
+		return Rollout{}, err
+	}
+	consumers, err := r.listRolloutConsumers(ctx, rolloutID)
+	if err != nil {
+		return Rollout{}, err
+	}
+	item.Consumers = consumers
+	return item, nil
+}
+
+func (r *PostgresRepository) GetActiveRollout(ctx context.Context, subject string) (Rollout, error) {
+	row := r.db.QueryRow(ctx, `
+SELECT id, subject, from_version, to_version, status, cutover_deadline, notes, created_at, updated_at
+FROM paygate_schema.schema_rollouts
+WHERE subject = $1 AND status = 'dual_publish'
+ORDER BY created_at DESC
+LIMIT 1
+`, subject)
+	item, err := scanRollout(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return Rollout{}, ErrSchemaRolloutNotFound
+	}
+	if err != nil {
+		return Rollout{}, err
+	}
+	consumers, err := r.listRolloutConsumers(ctx, item.ID)
+	if err != nil {
+		return Rollout{}, err
+	}
+	item.Consumers = consumers
+	return item, nil
+}
+
+func (r *PostgresRepository) AckRollout(ctx context.Context, in AckRolloutInput) (RolloutConsumer, error) {
+	id := idgen.New("rack")
+	row := r.db.QueryRow(ctx, `
+INSERT INTO paygate_schema.schema_rollout_consumers
+    (id, rollout_id, consumer_name, acknowledged_version)
+VALUES
+    ($1, $2, $3, $4)
+ON CONFLICT (rollout_id, consumer_name)
+DO UPDATE SET acknowledged_version = EXCLUDED.acknowledged_version, acknowledged_at = NOW()
+RETURNING id, rollout_id, consumer_name, acknowledged_version, acknowledged_at, created_at
+`, id, in.RolloutID, in.ConsumerName, in.AcknowledgedVersion)
+	item, err := scanRolloutConsumer(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return RolloutConsumer{}, ErrSchemaRolloutNotFound
+	}
+	return item, err
+}
+
+func (r *PostgresRepository) listRolloutConsumers(ctx context.Context, rolloutID string) ([]RolloutConsumer, error) {
+	rows, err := r.db.Query(ctx, `
+SELECT id, rollout_id, consumer_name, acknowledged_version, acknowledged_at, created_at
+FROM paygate_schema.schema_rollout_consumers
+WHERE rollout_id = $1
+ORDER BY consumer_name ASC
+`, rolloutID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []RolloutConsumer
+	for rows.Next() {
+		item, err := scanRolloutConsumer(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, item)
+	}
+	return out, rows.Err()
+}
+
+func (r *PostgresRepository) ListDeprecatedVersionAlerts(ctx context.Context) ([]DeprecatedVersionAlert, error) {
+	rows, err := r.db.Query(ctx, `
+SELECT r.id, r.subject, r.from_version, r.to_version, c.consumer_name, c.acknowledged_version, r.cutover_deadline
+FROM paygate_schema.schema_rollouts r
+JOIN paygate_schema.schema_rollout_consumers c ON c.rollout_id = r.id
+WHERE r.status = 'dual_publish'
+  AND r.cutover_deadline IS NOT NULL
+  AND r.cutover_deadline < NOW()
+  AND c.acknowledged_version = r.from_version
+ORDER BY r.cutover_deadline ASC, r.subject ASC, c.consumer_name ASC
+`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []DeprecatedVersionAlert
+	for rows.Next() {
+		var item DeprecatedVersionAlert
+		if err := rows.Scan(&item.RolloutID, &item.Subject, &item.FromVersion, &item.ToVersion, &item.ConsumerName, &item.AcknowledgedVersion, &item.CutoverDeadline); err != nil {
+			return nil, err
+		}
+		out = append(out, item)
+	}
+	return out, rows.Err()
+}
+
+type schemaScannable interface {
+	Scan(dest ...any) error
+}
+
+func scanSchema(row schemaScannable) (Schema, error) {
+	var item Schema
+	err := row.Scan(&item.ID, &item.Subject, &item.EventType, &item.TopicName, &item.Owner, &item.ReviewLink, &item.CreatedAt, &item.UpdatedAt)
+	return item, err
+}
+
+func scanVersion(row schemaScannable) (Version, error) {
+	var item Version
+	var schemaJSON []byte
+	var sampleJSON []byte
+	var detailsJSON []byte
+	err := row.Scan(
+		&item.ID, &item.Subject, &item.Version, &item.Status, &schemaJSON, &sampleJSON, &item.ReviewLink,
+		&item.CompatibilitySummary, &detailsJSON, &item.ActivatedAt, &item.DeprecatedAt, &item.CreatedAt, &item.UpdatedAt,
+	)
+	if err != nil {
+		return Version{}, err
+	}
+	if err := json.Unmarshal(schemaJSON, &item.Schema); err != nil {
+		return Version{}, fmt.Errorf("unmarshal schema document: %w", err)
+	}
+	if err := json.Unmarshal(sampleJSON, &item.SamplePayload); err != nil {
+		return Version{}, fmt.Errorf("unmarshal schema sample payload: %w", err)
+	}
+	if err := json.Unmarshal(detailsJSON, &item.CompatibilityDetails); err != nil {
+		return Version{}, fmt.Errorf("unmarshal compatibility details: %w", err)
+	}
+	return item, nil
+}
+
+func scanCheck(row schemaScannable) (CompatibilityCheck, error) {
+	var item CompatibilityCheck
+	var detailsJSON []byte
+	err := row.Scan(&item.ID, &item.Subject, &item.CandidateVersion, &item.BaselineVersion, &item.CheckType, &item.Compatible, &item.Summary, &detailsJSON, &item.CreatedAt)
+	if err != nil {
+		return CompatibilityCheck{}, err
+	}
+	if err := json.Unmarshal(detailsJSON, &item.Details); err != nil {
+		return CompatibilityCheck{}, err
+	}
+	return item, nil
+}
+
+func scanRollout(row schemaScannable) (Rollout, error) {
+	var item Rollout
+	err := row.Scan(&item.ID, &item.Subject, &item.FromVersion, &item.ToVersion, &item.Status, &item.CutoverDeadline, &item.Notes, &item.CreatedAt, &item.UpdatedAt)
+	return item, err
+}
+
+func scanRolloutConsumer(row schemaScannable) (RolloutConsumer, error) {
+	var item RolloutConsumer
+	err := row.Scan(&item.ID, &item.RolloutID, &item.ConsumerName, &item.AcknowledgedVersion, &item.AcknowledgedAt, &item.CreatedAt)
+	return item, err
+}

--- a/internal/eventschema/repository.go
+++ b/internal/eventschema/repository.go
@@ -17,11 +17,11 @@ var (
 )
 
 type CreateSchemaInput struct {
-	Subject    string
-	EventType  string
-	TopicName  string
-	Owner      string
-	ReviewLink string
+	Subject    string `json:"subject"`
+	EventType  string `json:"event_type"`
+	TopicName  string `json:"topic_name"`
+	Owner      string `json:"owner"`
+	ReviewLink string `json:"review_link"`
 }
 
 type CreateVersionInput struct {

--- a/internal/eventschema/repository.go
+++ b/internal/eventschema/repository.go
@@ -1,0 +1,75 @@
+package eventschema
+
+import (
+	"context"
+	"errors"
+	"time"
+)
+
+var (
+	ErrSchemaNotFound        = errors.New("event schema not found")
+	ErrSchemaVersionNotFound = errors.New("event schema version not found")
+	ErrIncompatibleSchema    = errors.New("schema is not compatible with the current baseline")
+	ErrNoActiveSchemaVersion = errors.New("no active schema version")
+	ErrSchemaRolloutNotFound = errors.New("schema rollout not found")
+	ErrInvalidSchemaDocument = errors.New("invalid schema document")
+	ErrInvalidSchemaRollout  = errors.New("invalid schema rollout")
+)
+
+type CreateSchemaInput struct {
+	Subject    string
+	EventType  string
+	TopicName  string
+	Owner      string
+	ReviewLink string
+}
+
+type CreateVersionInput struct {
+	Subject       string
+	Version       string
+	Schema        Document
+	SamplePayload map[string]any
+	ReviewLink    string
+}
+
+type ActivateVersionInput struct {
+	Subject string
+	Version string
+}
+
+type CreateRolloutInput struct {
+	Subject         string
+	FromVersion     string
+	ToVersion       string
+	CutoverDeadline *time.Time
+	Notes           string
+}
+
+type AckRolloutInput struct {
+	RolloutID           string
+	ConsumerName        string
+	AcknowledgedVersion string
+}
+
+type CompareVersionsInput struct {
+	Subject     string
+	FromVersion string
+	ToVersion   string
+}
+
+type Repository interface {
+	CreateSchema(ctx context.Context, in CreateSchemaInput) (Schema, error)
+	ListSchemas(ctx context.Context) ([]Schema, error)
+	GetSchema(ctx context.Context, subject string) (Schema, error)
+	CreateVersion(ctx context.Context, in CreateVersionInput, checks []CompatibilityCheck) (Version, error)
+	ListVersions(ctx context.Context, subject string) ([]Version, error)
+	GetVersion(ctx context.Context, subject, version string) (Version, error)
+	GetActiveVersion(ctx context.Context, subject string) (Version, error)
+	ActivateVersion(ctx context.Context, in ActivateVersionInput) (Version, error)
+	ListChecks(ctx context.Context, subject string, limit int) ([]CompatibilityCheck, error)
+	CreateRollout(ctx context.Context, in CreateRolloutInput) (Rollout, error)
+	GetRollout(ctx context.Context, rolloutID string) (Rollout, error)
+	GetActiveRollout(ctx context.Context, subject string) (Rollout, error)
+	AckRollout(ctx context.Context, in AckRolloutInput) (RolloutConsumer, error)
+	ListDeprecatedVersionAlerts(ctx context.Context) ([]DeprecatedVersionAlert, error)
+}

--- a/internal/eventschema/repository.go
+++ b/internal/eventschema/repository.go
@@ -8,7 +8,9 @@ import (
 
 var (
 	ErrSchemaNotFound        = errors.New("event schema not found")
+	ErrSchemaAlreadyExists   = errors.New("event schema already exists")
 	ErrSchemaVersionNotFound = errors.New("event schema version not found")
+	ErrSchemaVersionExists   = errors.New("event schema version already exists")
 	ErrIncompatibleSchema    = errors.New("schema is not compatible with the current baseline")
 	ErrNoActiveSchemaVersion = errors.New("no active schema version")
 	ErrSchemaRolloutNotFound = errors.New("schema rollout not found")

--- a/internal/eventschema/service.go
+++ b/internal/eventschema/service.go
@@ -1,0 +1,173 @@
+package eventschema
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/sanskarpan/PayGate/internal/outbox"
+)
+
+type Service struct {
+	repo   Repository
+	logger *slog.Logger
+}
+
+func NewService(repo Repository, logger *slog.Logger) *Service {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Service{repo: repo, logger: logger}
+}
+
+func (s *Service) CreateSchema(ctx context.Context, in CreateSchemaInput) (Schema, error) {
+	return s.repo.CreateSchema(ctx, in)
+}
+
+func (s *Service) ListSchemas(ctx context.Context) ([]Schema, error) {
+	return s.repo.ListSchemas(ctx)
+}
+
+func (s *Service) GetSchema(ctx context.Context, subject string) (Schema, []Version, []CompatibilityCheck, error) {
+	item, err := s.repo.GetSchema(ctx, subject)
+	if err != nil {
+		return Schema{}, nil, nil, err
+	}
+	versions, err := s.repo.ListVersions(ctx, subject)
+	if err != nil {
+		return Schema{}, nil, nil, err
+	}
+	checks, err := s.repo.ListChecks(ctx, subject, 50)
+	if err != nil {
+		return Schema{}, nil, nil, err
+	}
+	return item, versions, checks, nil
+}
+
+func (s *Service) RegisterVersion(ctx context.Context, in CreateVersionInput) (Version, []CompatibilityCheck, error) {
+	if err := ValidateDocument(in.Schema); err != nil {
+		return Version{}, nil, err
+	}
+
+	var checks []CompatibilityCheck
+	previous, err := s.repo.GetActiveVersion(ctx, in.Subject)
+	switch {
+	case err == nil:
+		rawChecks := CheckCompatibility(previous.Schema, in.Schema)
+		checks = make([]CompatibilityCheck, 0, len(rawChecks))
+		for _, check := range rawChecks {
+			check.Subject = in.Subject
+			check.CandidateVersion = in.Version
+			check.BaselineVersion = previous.Version
+			checks = append(checks, check)
+			if !check.Compatible {
+				return Version{}, checks, ErrIncompatibleSchema
+			}
+		}
+	case errors.Is(err, ErrNoActiveSchemaVersion):
+		// Initial version is allowed.
+	default:
+		return Version{}, nil, err
+	}
+
+	version, err := s.repo.CreateVersion(ctx, in, checks)
+	return version, checks, err
+}
+
+func (s *Service) GetVersion(ctx context.Context, subject, version string) (Version, error) {
+	return s.repo.GetVersion(ctx, subject, version)
+}
+
+func (s *Service) ActivateVersion(ctx context.Context, in ActivateVersionInput) (Version, error) {
+	version, err := s.repo.GetVersion(ctx, in.Subject, in.Version)
+	if err != nil {
+		return Version{}, err
+	}
+	if err := ValidateDocument(version.Schema); err != nil {
+		return Version{}, err
+	}
+	return s.repo.ActivateVersion(ctx, in)
+}
+
+func (s *Service) CompareVersions(ctx context.Context, in CompareVersionsInput) ([]CompatibilityCheck, error) {
+	fromVersion, err := s.repo.GetVersion(ctx, in.Subject, in.FromVersion)
+	if err != nil {
+		return nil, err
+	}
+	toVersion, err := s.repo.GetVersion(ctx, in.Subject, in.ToVersion)
+	if err != nil {
+		return nil, err
+	}
+	checks := CheckCompatibility(fromVersion.Schema, toVersion.Schema)
+	for i := range checks {
+		checks[i].Subject = in.Subject
+		checks[i].CandidateVersion = in.ToVersion
+		checks[i].BaselineVersion = in.FromVersion
+	}
+	return checks, nil
+}
+
+func (s *Service) CreateRollout(ctx context.Context, in CreateRolloutInput) (Rollout, error) {
+	if in.FromVersion == in.ToVersion {
+		return Rollout{}, fmt.Errorf("%w: rollout source and target versions must differ", ErrInvalidSchemaRollout)
+	}
+	active, err := s.repo.GetActiveVersion(ctx, in.Subject)
+	if err != nil {
+		return Rollout{}, err
+	}
+	if active.Version != in.FromVersion {
+		return Rollout{}, fmt.Errorf("%w: from_version must match the active schema version", ErrInvalidSchemaRollout)
+	}
+	target, err := s.repo.GetVersion(ctx, in.Subject, in.ToVersion)
+	if err != nil {
+		return Rollout{}, err
+	}
+	if target.Status == StatusRetired {
+		return Rollout{}, fmt.Errorf("%w: target version is retired", ErrInvalidSchemaRollout)
+	}
+	return s.repo.CreateRollout(ctx, in)
+}
+
+func (s *Service) AckRollout(ctx context.Context, in AckRolloutInput) (RolloutConsumer, error) {
+	rollout, err := s.repo.GetRollout(ctx, in.RolloutID)
+	if err != nil {
+		return RolloutConsumer{}, err
+	}
+	if in.AcknowledgedVersion != rollout.FromVersion && in.AcknowledgedVersion != rollout.ToVersion {
+		return RolloutConsumer{}, fmt.Errorf("%w: acknowledged_version must match a rollout version", ErrInvalidSchemaRollout)
+	}
+	return s.repo.AckRollout(ctx, in)
+}
+
+func (s *Service) GetRollout(ctx context.Context, rolloutID string) (Rollout, error) {
+	return s.repo.GetRollout(ctx, rolloutID)
+}
+
+func (s *Service) ResolvePublishVersions(ctx context.Context, subject string) ([]outbox.PublishSchemaVersion, error) {
+	active, err := s.repo.GetActiveVersion(ctx, subject)
+	if err != nil {
+		return nil, err
+	}
+	versions := []outbox.PublishSchemaVersion{{Subject: subject, Version: active.Version}}
+
+	rollout, err := s.repo.GetActiveRollout(ctx, subject)
+	if err == nil {
+		if rollout.FromVersion != active.Version {
+			s.logger.Warn("schema rollout active against non-active source version", "subject", subject, "active_version", active.Version, "from_version", rollout.FromVersion)
+			return versions, nil
+		}
+		return []outbox.PublishSchemaVersion{
+			{Subject: subject, Version: rollout.FromVersion},
+			{Subject: subject, Version: rollout.ToVersion},
+		}, nil
+	}
+	if errors.Is(err, ErrSchemaRolloutNotFound) {
+		return versions, nil
+	}
+	return nil, err
+}
+
+func (s *Service) ListDeprecatedVersionAlerts(ctx context.Context) ([]DeprecatedVersionAlert, error) {
+	return s.repo.ListDeprecatedVersionAlerts(ctx)
+}

--- a/internal/outbox/relay.go
+++ b/internal/outbox/relay.go
@@ -30,6 +30,12 @@ type PublishSchemaVersion struct {
 	Version string
 }
 
+type PublishedEnvelope struct {
+	Topic   string
+	Key     string
+	Payload []byte
+}
+
 type SchemaVersionResolver interface {
 	ResolvePublishVersions(ctx context.Context, subject string) ([]PublishSchemaVersion, error)
 }
@@ -123,31 +129,12 @@ FOR UPDATE SKIP LOCKED
 	}
 
 	for _, rec := range records {
-		schemas, err := r.resolvePublishSchemas(ctx, rec.EventType)
+		envelopes, err := r.BuildPublishedEnvelopes(ctx, rec)
 		if err != nil {
 			return 0, err
 		}
-		topic := TopicForEvent(rec.EventType)
-		for _, schema := range schemas {
-			payload, err := json.Marshal(map[string]any{
-				"id":             rec.ID,
-				"event_id":       rec.ID,
-				"aggregate_type": rec.AggregateType,
-				"aggregate_id":   rec.AggregateID,
-				"event_type":     rec.EventType,
-				"merchant_id":    rec.MerchantID,
-				"payload":        json.RawMessage(rec.Payload),
-				"created_at":     rec.CreatedAt.Unix(),
-				"occurred_at":    rec.CreatedAt.UTC().Format(time.RFC3339),
-				"correlation_id": rec.AggregateID,
-				"causation_id":   rec.ID,
-				"schema_subject": schema.Subject,
-				"schema_version": schema.Version,
-			})
-			if err != nil {
-				return 0, fmt.Errorf("marshal outbox envelope: %w", err)
-			}
-			if err := publishWithRetry(ctx, r.publisher, topic, rec.MerchantID, payload); err != nil {
+		for _, envelope := range envelopes {
+			if err := publishWithRetry(ctx, r.publisher, envelope.Topic, envelope.Key, envelope.Payload); err != nil {
 				return 0, err
 			}
 		}
@@ -160,6 +147,41 @@ FOR UPDATE SKIP LOCKED
 		return 0, err
 	}
 	return len(records), nil
+}
+
+func (r *Relay) BuildPublishedEnvelopes(ctx context.Context, rec Record) ([]PublishedEnvelope, error) {
+	schemas, err := r.resolvePublishSchemas(ctx, rec.EventType)
+	if err != nil {
+		return nil, err
+	}
+	topic := TopicForEvent(rec.EventType)
+	envelopes := make([]PublishedEnvelope, 0, len(schemas))
+	for _, schema := range schemas {
+		payload, err := json.Marshal(map[string]any{
+			"id":             rec.ID,
+			"event_id":       rec.ID,
+			"aggregate_type": rec.AggregateType,
+			"aggregate_id":   rec.AggregateID,
+			"event_type":     rec.EventType,
+			"merchant_id":    rec.MerchantID,
+			"payload":        json.RawMessage(rec.Payload),
+			"created_at":     rec.CreatedAt.Unix(),
+			"occurred_at":    rec.CreatedAt.UTC().Format(time.RFC3339),
+			"correlation_id": rec.AggregateID,
+			"causation_id":   rec.ID,
+			"schema_subject": schema.Subject,
+			"schema_version": schema.Version,
+		})
+		if err != nil {
+			return nil, fmt.Errorf("marshal outbox envelope: %w", err)
+		}
+		envelopes = append(envelopes, PublishedEnvelope{
+			Topic:   topic,
+			Key:     rec.MerchantID,
+			Payload: payload,
+		})
+	}
+	return envelopes, nil
 }
 
 func (r *Relay) resolvePublishSchemas(ctx context.Context, eventType string) ([]PublishSchemaVersion, error) {

--- a/internal/outbox/relay.go
+++ b/internal/outbox/relay.go
@@ -22,6 +22,7 @@ type Relay struct {
 	logger    *slog.Logger
 	interval  time.Duration
 	resolver  SchemaVersionResolver
+	tableName string
 }
 
 type PublishSchemaVersion struct {
@@ -50,11 +51,18 @@ func NewRelay(db *pgxpool.Pool, publisher Publisher, interval time.Duration, log
 	if interval <= 0 {
 		interval = time.Second
 	}
-	return &Relay{db: db, publisher: publisher, logger: logger, interval: interval}
+	return &Relay{db: db, publisher: publisher, logger: logger, interval: interval, tableName: "public.outbox"}
 }
 
 func (r *Relay) WithSchemaVersionResolver(resolver SchemaVersionResolver) *Relay {
 	r.resolver = resolver
+	return r
+}
+
+func (r *Relay) WithTableName(tableName string) *Relay {
+	if tableName != "" {
+		r.tableName = tableName
+	}
 	return r
 }
 
@@ -89,14 +97,14 @@ func (r *Relay) PublishBatch(ctx context.Context, limit int) (int, error) {
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 
-	rows, err := tx.Query(ctx, `
+	rows, err := tx.Query(ctx, fmt.Sprintf(`
 SELECT id, aggregate_type, aggregate_id, event_type, merchant_id, payload, created_at
-FROM public.outbox
+FROM %s
 WHERE published_at IS NULL
 ORDER BY created_at
 LIMIT $1
 FOR UPDATE SKIP LOCKED
-`, limit)
+`, r.tableName), limit)
 	if err != nil {
 		return 0, fmt.Errorf("query outbox batch: %w", err)
 	}
@@ -143,7 +151,7 @@ FOR UPDATE SKIP LOCKED
 				return 0, err
 			}
 		}
-		if _, err := tx.Exec(ctx, `UPDATE public.outbox SET published_at = NOW() WHERE id = $1`, rec.ID); err != nil {
+		if _, err := tx.Exec(ctx, fmt.Sprintf(`UPDATE %s SET published_at = NOW() WHERE id = $1`, r.tableName), rec.ID); err != nil {
 			return 0, fmt.Errorf("mark outbox published: %w", err)
 		}
 	}
@@ -169,10 +177,10 @@ func (r *Relay) resolvePublishSchemas(ctx context.Context, eventType string) ([]
 }
 
 func (r *Relay) CleanupPublished(ctx context.Context, olderThan time.Duration) (int64, error) {
-	cmd, err := r.db.Exec(ctx, `
-DELETE FROM public.outbox
+	cmd, err := r.db.Exec(ctx, fmt.Sprintf(`
+DELETE FROM %s
 WHERE published_at IS NOT NULL AND published_at < NOW() - ($1::interval)
-`, fmt.Sprintf("%f seconds", olderThan.Seconds()))
+`, r.tableName), fmt.Sprintf("%f seconds", olderThan.Seconds()))
 	if err != nil {
 		return 0, fmt.Errorf("cleanup outbox rows: %w", err)
 	}
@@ -181,11 +189,11 @@ WHERE published_at IS NOT NULL AND published_at < NOW() - ($1::interval)
 
 func (r *Relay) CountUnpublished(ctx context.Context) (int64, error) {
 	var count int64
-	if err := r.db.QueryRow(ctx, `
+	if err := r.db.QueryRow(ctx, fmt.Sprintf(`
 SELECT COUNT(*)
-FROM public.outbox
+FROM %s
 WHERE published_at IS NULL
-`).Scan(&count); err != nil {
+`, r.tableName)).Scan(&count); err != nil {
 		return 0, fmt.Errorf("count unpublished outbox rows: %w", err)
 	}
 	return count, nil

--- a/migrations/000024_create_event_schema_registry.down.sql
+++ b/migrations/000024_create_event_schema_registry.down.sql
@@ -1,0 +1,6 @@
+DROP TABLE IF EXISTS paygate_schema.schema_rollout_consumers;
+DROP TABLE IF EXISTS paygate_schema.schema_rollouts;
+DROP TABLE IF EXISTS paygate_schema.schema_compatibility_checks;
+DROP TABLE IF EXISTS paygate_schema.schema_versions;
+DROP TABLE IF EXISTS paygate_schema.event_schemas;
+DROP SCHEMA IF EXISTS paygate_schema;

--- a/migrations/000024_create_event_schema_registry.up.sql
+++ b/migrations/000024_create_event_schema_registry.up.sql
@@ -1,0 +1,69 @@
+CREATE SCHEMA IF NOT EXISTS paygate_schema;
+
+CREATE TABLE IF NOT EXISTS paygate_schema.event_schemas (
+    id TEXT PRIMARY KEY,
+    subject TEXT NOT NULL UNIQUE,
+    event_type TEXT NOT NULL,
+    topic_name TEXT NOT NULL,
+    owner TEXT NOT NULL,
+    review_link TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS paygate_schema.schema_versions (
+    id TEXT PRIMARY KEY,
+    subject TEXT NOT NULL REFERENCES paygate_schema.event_schemas(subject) ON DELETE CASCADE,
+    version TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('draft', 'active', 'deprecated', 'retired')),
+    schema_json JSONB NOT NULL,
+    sample_payload JSONB NOT NULL,
+    review_link TEXT NOT NULL DEFAULT '',
+    compatibility_summary TEXT NOT NULL DEFAULT '',
+    compatibility_details JSONB NOT NULL DEFAULT '{}'::jsonb,
+    activated_at TIMESTAMPTZ,
+    deprecated_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (subject, version)
+);
+
+CREATE TABLE IF NOT EXISTS paygate_schema.schema_compatibility_checks (
+    id TEXT PRIMARY KEY,
+    subject TEXT NOT NULL REFERENCES paygate_schema.event_schemas(subject) ON DELETE CASCADE,
+    candidate_version TEXT NOT NULL,
+    baseline_version TEXT NOT NULL,
+    check_type TEXT NOT NULL CHECK (check_type IN ('backward', 'forward')),
+    compatible BOOLEAN NOT NULL,
+    summary TEXT NOT NULL,
+    details_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS paygate_schema.schema_rollouts (
+    id TEXT PRIMARY KEY,
+    subject TEXT NOT NULL REFERENCES paygate_schema.event_schemas(subject) ON DELETE CASCADE,
+    from_version TEXT NOT NULL,
+    to_version TEXT NOT NULL,
+    status TEXT NOT NULL CHECK (status IN ('planned', 'dual_publish', 'completed', 'rolled_back')),
+    cutover_deadline TIMESTAMPTZ,
+    notes TEXT NOT NULL DEFAULT '',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS paygate_schema.schema_rollout_consumers (
+    id TEXT PRIMARY KEY,
+    rollout_id TEXT NOT NULL REFERENCES paygate_schema.schema_rollouts(id) ON DELETE CASCADE,
+    consumer_name TEXT NOT NULL,
+    acknowledged_version TEXT NOT NULL,
+    acknowledged_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (rollout_id, consumer_name)
+);
+
+CREATE INDEX IF NOT EXISTS idx_schema_versions_subject_status
+    ON paygate_schema.schema_versions(subject, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_schema_rollouts_subject_status
+    ON paygate_schema.schema_rollouts(subject, status, created_at DESC);

--- a/schemas/events/dispute.accepted/1.0.0.sample.json
+++ b/schemas/events/dispute.accepted/1.0.0.sample.json
@@ -1,0 +1,13 @@
+{
+  "event_id": "evt_dispute_accepted_v1",
+  "event_type": "dispute.accepted",
+  "occurred_at": "2026-05-13T10:21:00Z",
+  "correlation_id": "disp_123",
+  "causation_id": "evt_dispute_accepted_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_123",
+  "payload": {
+    "dispute_id": "disp_123",
+    "status": "accepted"
+  }
+}

--- a/schemas/events/dispute.accepted/1.0.0.schema.json
+++ b/schemas/events/dispute.accepted/1.0.0.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "dispute_id": {"type": "string"},
+        "status": {"type": "string"}
+      },
+      "required": ["dispute_id", "status"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/dispute.created/1.0.0.sample.json
+++ b/schemas/events/dispute.created/1.0.0.sample.json
@@ -1,0 +1,13 @@
+{
+  "event_id": "evt_dispute_created_v1",
+  "event_type": "dispute.created",
+  "occurred_at": "2026-05-13T10:19:00Z",
+  "correlation_id": "disp_123",
+  "causation_id": "evt_dispute_created_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_123",
+  "payload": {
+    "dispute_id": "disp_123",
+    "payment_id": "pay_123"
+  }
+}

--- a/schemas/events/dispute.created/1.0.0.schema.json
+++ b/schemas/events/dispute.created/1.0.0.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "dispute_id": {"type": "string"},
+        "payment_id": {"type": "string"}
+      },
+      "required": ["dispute_id", "payment_id"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/dispute.lost/1.0.0.sample.json
+++ b/schemas/events/dispute.lost/1.0.0.sample.json
@@ -1,0 +1,13 @@
+{
+  "event_id": "evt_dispute_lost_v1",
+  "event_type": "dispute.lost",
+  "occurred_at": "2026-05-13T10:23:00Z",
+  "correlation_id": "disp_123",
+  "causation_id": "evt_dispute_lost_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_123",
+  "payload": {
+    "dispute_id": "disp_123",
+    "status": "lost"
+  }
+}

--- a/schemas/events/dispute.lost/1.0.0.schema.json
+++ b/schemas/events/dispute.lost/1.0.0.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "dispute_id": {"type": "string"},
+        "status": {"type": "string"}
+      },
+      "required": ["dispute_id", "status"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/dispute.updated/1.0.0.sample.json
+++ b/schemas/events/dispute.updated/1.0.0.sample.json
@@ -1,0 +1,13 @@
+{
+  "event_id": "evt_dispute_updated_v1",
+  "event_type": "dispute.updated",
+  "occurred_at": "2026-05-13T10:20:00Z",
+  "correlation_id": "disp_123",
+  "causation_id": "evt_dispute_updated_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_123",
+  "payload": {
+    "dispute_id": "disp_123",
+    "status": "under_review"
+  }
+}

--- a/schemas/events/dispute.updated/1.0.0.schema.json
+++ b/schemas/events/dispute.updated/1.0.0.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "dispute_id": {"type": "string"},
+        "status": {"type": "string"}
+      },
+      "required": ["dispute_id", "status"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/dispute.won/1.0.0.sample.json
+++ b/schemas/events/dispute.won/1.0.0.sample.json
@@ -1,0 +1,13 @@
+{
+  "event_id": "evt_dispute_won_v1",
+  "event_type": "dispute.won",
+  "occurred_at": "2026-05-13T10:22:00Z",
+  "correlation_id": "disp_123",
+  "causation_id": "evt_dispute_won_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_123",
+  "payload": {
+    "dispute_id": "disp_123",
+    "status": "won"
+  }
+}

--- a/schemas/events/dispute.won/1.0.0.schema.json
+++ b/schemas/events/dispute.won/1.0.0.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "dispute_id": {"type": "string"},
+        "status": {"type": "string"}
+      },
+      "required": ["dispute_id", "status"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/order.created/1.0.0.sample.json
+++ b/schemas/events/order.created/1.0.0.sample.json
@@ -1,0 +1,14 @@
+{
+  "event_id": "evt_order_created_v1",
+  "event_type": "order.created",
+  "occurred_at": "2026-05-13T10:00:00Z",
+  "correlation_id": "ord_123",
+  "causation_id": "evt_order_created_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_123",
+  "payload": {
+    "order_id": "ord_123",
+    "amount": "50000",
+    "currency": "INR"
+  }
+}

--- a/schemas/events/order.created/1.0.0.schema.json
+++ b/schemas/events/order.created/1.0.0.schema.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "order_id": {"type": "string"},
+        "amount": {"type": "string"},
+        "currency": {"type": "string"}
+      },
+      "required": ["order_id", "amount", "currency"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/order.paid/1.0.0.sample.json
+++ b/schemas/events/order.paid/1.0.0.sample.json
@@ -1,0 +1,13 @@
+{
+  "event_id": "evt_order_paid_v1",
+  "event_type": "order.paid",
+  "occurred_at": "2026-05-13T10:05:00Z",
+  "correlation_id": "ord_123",
+  "causation_id": "evt_order_paid_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_123",
+  "payload": {
+    "order_id": "ord_123",
+    "payment_id": "pay_123"
+  }
+}

--- a/schemas/events/order.paid/1.0.0.schema.json
+++ b/schemas/events/order.paid/1.0.0.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "order_id": {"type": "string"},
+        "payment_id": {"type": "string"}
+      },
+      "required": ["order_id", "payment_id"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/payment.authorization_reversed/1.0.0.sample.json
+++ b/schemas/events/payment.authorization_reversed/1.0.0.sample.json
@@ -1,0 +1,14 @@
+{
+  "event_id": "evt_payment_authorization_reversed_v1",
+  "event_type": "payment.authorization_reversed",
+  "occurred_at": "2026-05-17T10:00:00Z",
+  "correlation_id": "pay_auth_rev_123",
+  "causation_id": "evt_payment_authorization_reversed_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_auth_rev_123",
+  "payload": {
+    "payment_id": "pay_auth_rev_123",
+    "order_id": "order_auth_rev_123",
+    "reason": "operator_requested_reversal"
+  }
+}

--- a/schemas/events/payment.authorization_reversed/1.0.0.schema.json
+++ b/schemas/events/payment.authorization_reversed/1.0.0.schema.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "payment_id": {"type": "string"},
+        "order_id": {"type": "string"},
+        "reason": {"type": "string"}
+      },
+      "required": ["payment_id", "order_id"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/payment.authorized/1.0.0.sample.json
+++ b/schemas/events/payment.authorized/1.0.0.sample.json
@@ -1,0 +1,13 @@
+{
+  "event_id": "evt_payment_authorized_v1",
+  "event_type": "payment.authorized",
+  "occurred_at": "2026-05-13T10:06:00Z",
+  "correlation_id": "pay_123",
+  "causation_id": "evt_payment_authorized_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_123",
+  "payload": {
+    "payment_id": "pay_123",
+    "order_id": "ord_123"
+  }
+}

--- a/schemas/events/payment.authorized/1.0.0.schema.json
+++ b/schemas/events/payment.authorized/1.0.0.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "payment_id": {"type": "string"},
+        "order_id": {"type": "string"}
+      },
+      "required": ["payment_id", "order_id"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/payment.auto_refunded/1.0.0.sample.json
+++ b/schemas/events/payment.auto_refunded/1.0.0.sample.json
@@ -1,0 +1,13 @@
+{
+  "event_id": "evt_payment_auto_refunded_v1",
+  "event_type": "payment.auto_refunded",
+  "occurred_at": "2026-05-13T10:08:00Z",
+  "correlation_id": "pay_123",
+  "causation_id": "evt_payment_auto_refunded_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_123",
+  "payload": {
+    "payment_id": "pay_123",
+    "refund_id": "rfnd_123"
+  }
+}

--- a/schemas/events/payment.auto_refunded/1.0.0.schema.json
+++ b/schemas/events/payment.auto_refunded/1.0.0.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "payment_id": {"type": "string"},
+        "refund_id": {"type": "string"}
+      },
+      "required": ["payment_id", "refund_id"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/payment.captured/1.0.0.sample.json
+++ b/schemas/events/payment.captured/1.0.0.sample.json
@@ -1,0 +1,13 @@
+{
+  "event_id": "evt_payment_captured_v1",
+  "event_type": "payment.captured",
+  "occurred_at": "2026-05-13T10:00:00Z",
+  "correlation_id": "pay_123",
+  "causation_id": "evt_payment_captured_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_123",
+  "payload": {
+    "payment_id": "pay_123",
+    "order_id": "ord_123"
+  }
+}

--- a/schemas/events/payment.captured/1.0.0.schema.json
+++ b/schemas/events/payment.captured/1.0.0.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "payment_id": {"type": "string"},
+        "order_id": {"type": "string"}
+      },
+      "required": ["payment_id", "order_id"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/payment.captured/1.1.0.sample.json
+++ b/schemas/events/payment.captured/1.1.0.sample.json
@@ -1,0 +1,14 @@
+{
+  "event_id": "evt_payment_captured_v1_1",
+  "event_type": "payment.captured",
+  "occurred_at": "2026-05-13T10:05:00Z",
+  "correlation_id": "pay_456",
+  "causation_id": "evt_payment_captured_v1_1",
+  "schema_version": "1.1.0",
+  "merchant_id": "merch_456",
+  "payload": {
+    "payment_id": "pay_456",
+    "order_id": "ord_456",
+    "risk_bucket": "normal"
+  }
+}

--- a/schemas/events/payment.captured/1.1.0.schema.json
+++ b/schemas/events/payment.captured/1.1.0.schema.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "payment_id": {"type": "string"},
+        "order_id": {"type": "string"},
+        "risk_bucket": {"type": "string"}
+      },
+      "required": ["payment_id", "order_id"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/payment.failed/1.0.0.sample.json
+++ b/schemas/events/payment.failed/1.0.0.sample.json
@@ -1,0 +1,14 @@
+{
+  "event_id": "evt_payment_failed_v1",
+  "event_type": "payment.failed",
+  "occurred_at": "2026-05-13T10:07:00Z",
+  "correlation_id": "pay_attempt_123",
+  "causation_id": "evt_payment_failed_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_123",
+  "payload": {
+    "payment_id": "pay_123",
+    "order_id": "ord_123",
+    "error_code": "GATEWAY_DECLINED"
+  }
+}

--- a/schemas/events/payment.failed/1.0.0.schema.json
+++ b/schemas/events/payment.failed/1.0.0.schema.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "payment_id": {"type": "string"},
+        "order_id": {"type": "string"},
+        "error_code": {"type": "string"}
+      },
+      "required": ["error_code"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/payout.cancelled/1.0.0.sample.json
+++ b/schemas/events/payout.cancelled/1.0.0.sample.json
@@ -1,0 +1,13 @@
+{
+  "event_id": "evt_payout_cancelled_v1",
+  "event_type": "payout.cancelled",
+  "occurred_at": "2026-05-17T10:15:00Z",
+  "correlation_id": "payout_123",
+  "causation_id": "evt_payout_cancelled_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_payout_cancel_123",
+  "payload": {
+    "payout_id": "payout_123",
+    "reason": "operator_cancelled_before_bank_acceptance"
+  }
+}

--- a/schemas/events/payout.cancelled/1.0.0.schema.json
+++ b/schemas/events/payout.cancelled/1.0.0.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "payout_id": {"type": "string"},
+        "reason": {"type": "string"}
+      },
+      "required": ["payout_id"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/payout.completed/1.0.0.sample.json
+++ b/schemas/events/payout.completed/1.0.0.sample.json
@@ -1,0 +1,15 @@
+{
+  "event_id": "evt_payout_completed_v1",
+  "event_type": "payout.completed",
+  "occurred_at": "2026-05-13T11:00:00Z",
+  "correlation_id": "payout_123",
+  "causation_id": "evt_payout_completed_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_123",
+  "payload": {
+    "payout_id": "payout_123",
+    "bank_reference": "BNK_123",
+    "amount": 9800,
+    "currency": "INR"
+  }
+}

--- a/schemas/events/payout.completed/1.0.0.schema.json
+++ b/schemas/events/payout.completed/1.0.0.schema.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "payout_id": {"type": "string"},
+        "bank_reference": {"type": "string"},
+        "amount": {"type": "integer"},
+        "currency": {"type": "string"}
+      },
+      "required": ["payout_id", "bank_reference", "amount", "currency"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/payout.completed/1.1.0.sample.json
+++ b/schemas/events/payout.completed/1.1.0.sample.json
@@ -1,0 +1,16 @@
+{
+  "event_id": "evt_payout_completed_v1_1",
+  "event_type": "payout.completed",
+  "occurred_at": "2026-05-13T11:05:00Z",
+  "correlation_id": "payout_456",
+  "causation_id": "evt_payout_completed_v1_1",
+  "schema_version": "1.1.0",
+  "merchant_id": "merch_456",
+  "payload": {
+    "payout_id": "payout_456",
+    "bank_reference": "BNK_456",
+    "rail_reference": "RAIL_456",
+    "amount": 14700,
+    "currency": "INR"
+  }
+}

--- a/schemas/events/payout.completed/1.1.0.schema.json
+++ b/schemas/events/payout.completed/1.1.0.schema.json
@@ -1,0 +1,24 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "payout_id": {"type": "string"},
+        "bank_reference": {"type": "string"},
+        "rail_reference": {"type": "string"},
+        "amount": {"type": "integer"},
+        "currency": {"type": "string"}
+      },
+      "required": ["payout_id", "bank_reference", "amount", "currency"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/payout.created/1.0.0.sample.json
+++ b/schemas/events/payout.created/1.0.0.sample.json
@@ -1,0 +1,15 @@
+{
+  "event_id": "evt_payout_created_v1",
+  "event_type": "payout.created",
+  "occurred_at": "2026-05-13T10:10:00Z",
+  "correlation_id": "payout_123",
+  "causation_id": "evt_payout_created_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_123",
+  "payload": {
+    "payout_id": "payout_123",
+    "settlement_id": "settl_123",
+    "amount": "49000",
+    "currency": "INR"
+  }
+}

--- a/schemas/events/payout.created/1.0.0.schema.json
+++ b/schemas/events/payout.created/1.0.0.schema.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "payout_id": {"type": "string"},
+        "settlement_id": {"type": "string"},
+        "amount": {"type": "string"},
+        "currency": {"type": "string"}
+      },
+      "required": ["payout_id", "settlement_id", "amount", "currency"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/payout.failed/1.0.0.sample.json
+++ b/schemas/events/payout.failed/1.0.0.sample.json
@@ -1,0 +1,13 @@
+{
+  "event_id": "evt_payout_failed_v1",
+  "event_type": "payout.failed",
+  "occurred_at": "2026-05-13T10:12:00Z",
+  "correlation_id": "payout_123",
+  "causation_id": "evt_payout_failed_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_123",
+  "payload": {
+    "payout_id": "payout_123",
+    "reason": "rail timeout"
+  }
+}

--- a/schemas/events/payout.failed/1.0.0.schema.json
+++ b/schemas/events/payout.failed/1.0.0.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "payout_id": {"type": "string"},
+        "reason": {"type": "string"}
+      },
+      "required": ["payout_id", "reason"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/payout.initiated/1.0.0.sample.json
+++ b/schemas/events/payout.initiated/1.0.0.sample.json
@@ -1,0 +1,12 @@
+{
+  "event_id": "evt_payout_initiated_v1",
+  "event_type": "payout.initiated",
+  "occurred_at": "2026-05-13T10:11:00Z",
+  "correlation_id": "payout_123",
+  "causation_id": "evt_payout_initiated_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_123",
+  "payload": {
+    "payout_id": "payout_123"
+  }
+}

--- a/schemas/events/payout.initiated/1.0.0.schema.json
+++ b/schemas/events/payout.initiated/1.0.0.schema.json
@@ -1,0 +1,20 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "payout_id": {"type": "string"}
+      },
+      "required": ["payout_id"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/payout.returned/1.0.0.sample.json
+++ b/schemas/events/payout.returned/1.0.0.sample.json
@@ -1,0 +1,14 @@
+{
+  "event_id": "evt_payout_returned_v1",
+  "event_type": "payout.returned",
+  "occurred_at": "2026-05-13T10:13:00Z",
+  "correlation_id": "payout_123",
+  "causation_id": "evt_payout_returned_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_123",
+  "payload": {
+    "payout_id": "payout_123",
+    "rail_reference": "RAIL_123",
+    "reason": "beneficiary account closed"
+  }
+}

--- a/schemas/events/payout.returned/1.0.0.schema.json
+++ b/schemas/events/payout.returned/1.0.0.schema.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "payout_id": {"type": "string"},
+        "rail_reference": {"type": "string"},
+        "reason": {"type": "string"}
+      },
+      "required": ["payout_id", "reason"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/payout.reversed/1.0.0.sample.json
+++ b/schemas/events/payout.reversed/1.0.0.sample.json
@@ -1,0 +1,14 @@
+{
+  "event_id": "evt_payout_reversed_v1",
+  "event_type": "payout.reversed",
+  "occurred_at": "2026-05-13T10:14:00Z",
+  "correlation_id": "payout_123",
+  "causation_id": "evt_payout_reversed_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_123",
+  "payload": {
+    "payout_id": "payout_123",
+    "rail_reference": "RAIL_123",
+    "reason": "rail reversal"
+  }
+}

--- a/schemas/events/payout.reversed/1.0.0.schema.json
+++ b/schemas/events/payout.reversed/1.0.0.schema.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "payout_id": {"type": "string"},
+        "rail_reference": {"type": "string"},
+        "reason": {"type": "string"}
+      },
+      "required": ["payout_id", "reason"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/refund.created/1.0.0.sample.json
+++ b/schemas/events/refund.created/1.0.0.sample.json
@@ -1,0 +1,13 @@
+{
+  "event_id": "evt_refund_created_v1",
+  "event_type": "refund.created",
+  "occurred_at": "2026-05-13T10:16:00Z",
+  "correlation_id": "rfnd_123",
+  "causation_id": "evt_refund_created_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_123",
+  "payload": {
+    "refund_id": "rfnd_123",
+    "payment_id": "pay_123"
+  }
+}

--- a/schemas/events/refund.created/1.0.0.schema.json
+++ b/schemas/events/refund.created/1.0.0.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "refund_id": {"type": "string"},
+        "payment_id": {"type": "string"}
+      },
+      "required": ["refund_id", "payment_id"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/refund.failed/1.0.0.sample.json
+++ b/schemas/events/refund.failed/1.0.0.sample.json
@@ -1,0 +1,14 @@
+{
+  "event_id": "evt_refund_failed_v1",
+  "event_type": "refund.failed",
+  "occurred_at": "2026-05-13T10:18:00Z",
+  "correlation_id": "rfnd_123",
+  "causation_id": "evt_refund_failed_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_123",
+  "payload": {
+    "refund_id": "rfnd_123",
+    "payment_id": "pay_123",
+    "reason": "gateway retry exhaustion"
+  }
+}

--- a/schemas/events/refund.failed/1.0.0.schema.json
+++ b/schemas/events/refund.failed/1.0.0.schema.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "refund_id": {"type": "string"},
+        "payment_id": {"type": "string"},
+        "reason": {"type": "string"}
+      },
+      "required": ["refund_id", "reason"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/refund.processed/1.0.0.sample.json
+++ b/schemas/events/refund.processed/1.0.0.sample.json
@@ -1,0 +1,13 @@
+{
+  "event_id": "evt_refund_processed_v1",
+  "event_type": "refund.processed",
+  "occurred_at": "2026-05-13T10:17:00Z",
+  "correlation_id": "rfnd_123",
+  "causation_id": "evt_refund_processed_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_123",
+  "payload": {
+    "refund_id": "rfnd_123",
+    "payment_id": "pay_123"
+  }
+}

--- a/schemas/events/refund.processed/1.0.0.schema.json
+++ b/schemas/events/refund.processed/1.0.0.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "refund_id": {"type": "string"},
+        "payment_id": {"type": "string"}
+      },
+      "required": ["refund_id", "payment_id"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/refund.reversed/1.0.0.sample.json
+++ b/schemas/events/refund.reversed/1.0.0.sample.json
@@ -1,0 +1,15 @@
+{
+  "event_id": "evt_refund_reversed_v1",
+  "event_type": "refund.reversed",
+  "occurred_at": "2026-05-17T10:05:00Z",
+  "correlation_id": "rfnd_123",
+  "causation_id": "evt_refund_reversed_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_refund_rev_123",
+  "payload": {
+    "refund_id": "rfnd_123",
+    "payment_id": "pay_refund_rev_123",
+    "amount": 2400,
+    "reason": "compensation_after_duplicate_refund"
+  }
+}

--- a/schemas/events/refund.reversed/1.0.0.schema.json
+++ b/schemas/events/refund.reversed/1.0.0.schema.json
@@ -1,0 +1,23 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "refund_id": {"type": "string"},
+        "payment_id": {"type": "string"},
+        "amount": {"type": "number"},
+        "reason": {"type": "string"}
+      },
+      "required": ["refund_id", "payment_id", "amount"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/risk.alert/1.0.0.sample.json
+++ b/schemas/events/risk.alert/1.0.0.sample.json
@@ -1,0 +1,14 @@
+{
+  "event_id": "evt_risk_alert_v1",
+  "event_type": "risk.alert",
+  "occurred_at": "2026-05-13T10:15:00Z",
+  "correlation_id": "pay_123",
+  "causation_id": "evt_risk_alert_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_123",
+  "payload": {
+    "payment_id": "pay_123",
+    "action": "hold",
+    "reason": "velocity spike"
+  }
+}

--- a/schemas/events/risk.alert/1.0.0.schema.json
+++ b/schemas/events/risk.alert/1.0.0.schema.json
@@ -1,0 +1,22 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "payment_id": {"type": "string"},
+        "action": {"type": "string"},
+        "reason": {"type": "string"}
+      },
+      "required": ["action", "reason"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/settlement.processed/1.0.0.sample.json
+++ b/schemas/events/settlement.processed/1.0.0.sample.json
@@ -1,0 +1,13 @@
+{
+  "event_id": "evt_settlement_processed_v1",
+  "event_type": "settlement.processed",
+  "occurred_at": "2026-05-13T10:09:00Z",
+  "correlation_id": "settl_123",
+  "causation_id": "evt_settlement_processed_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_123",
+  "payload": {
+    "settlement_id": "settl_123",
+    "net_amount": "49000"
+  }
+}

--- a/schemas/events/settlement.processed/1.0.0.schema.json
+++ b/schemas/events/settlement.processed/1.0.0.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "settlement_id": {"type": "string"},
+        "net_amount": {"type": "string"}
+      },
+      "required": ["settlement_id", "net_amount"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/schemas/events/settlement.rollback_marked/1.0.0.sample.json
+++ b/schemas/events/settlement.rollback_marked/1.0.0.sample.json
@@ -1,0 +1,13 @@
+{
+  "event_id": "evt_settlement_rollback_marked_v1",
+  "event_type": "settlement.rollback_marked",
+  "occurred_at": "2026-05-17T10:10:00Z",
+  "correlation_id": "sttl_123",
+  "causation_id": "evt_settlement_rollback_marked_v1",
+  "schema_version": "1.0.0",
+  "merchant_id": "merch_settlement_rev_123",
+  "payload": {
+    "settlement_id": "sttl_123",
+    "reason": "manual_reconciliation_failure"
+  }
+}

--- a/schemas/events/settlement.rollback_marked/1.0.0.schema.json
+++ b/schemas/events/settlement.rollback_marked/1.0.0.schema.json
@@ -1,0 +1,21 @@
+{
+  "type": "object",
+  "properties": {
+    "event_id": {"type": "string"},
+    "event_type": {"type": "string"},
+    "occurred_at": {"type": "string"},
+    "correlation_id": {"type": "string"},
+    "causation_id": {"type": "string"},
+    "schema_version": {"type": "string"},
+    "merchant_id": {"type": "string"},
+    "payload": {
+      "type": "object",
+      "properties": {
+        "settlement_id": {"type": "string"},
+        "reason": {"type": "string"}
+      },
+      "required": ["settlement_id"]
+    }
+  },
+  "required": ["event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"]
+}

--- a/tests/integration/backend_hardening_integration_test.go
+++ b/tests/integration/backend_hardening_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/sanskarpan/PayGate/internal/auth"
 	httpx "github.com/sanskarpan/PayGate/internal/common/http"
 	"github.com/sanskarpan/PayGate/internal/dispute"
+	"github.com/sanskarpan/PayGate/internal/eventschema"
 	"github.com/sanskarpan/PayGate/internal/gateway"
 	"github.com/sanskarpan/PayGate/internal/idempotency"
 	"github.com/sanskarpan/PayGate/internal/ledger"
@@ -293,6 +294,7 @@ func buildGatewayMux(db *pgxpool.Pool) (*http.ServeMux, *merchant.Service, *orde
 	settlementSvc := settlement.NewService(settlement.NewPostgresRepository(db, ledgerSvc))
 	payoutSvc := payout.NewService(payout.NewPostgresRepository(db, ledgerSvc), nil)
 	disputeSvc := dispute.NewService(dispute.NewPostgresRepository(db))
+	schemaSvc := eventschema.NewService(eventschema.NewPostgresRepository(db), nil)
 
 	merchantHandler := merchant.NewHandler(merchantSvc)
 	orderHandler := order.NewHandler(orderSvc)
@@ -303,6 +305,7 @@ func buildGatewayMux(db *pgxpool.Pool) (*http.ServeMux, *merchant.Service, *orde
 	payoutHandler := payout.NewHandler(payoutSvc, settlementSvc, ledgerSvc)
 	disputeHandler := dispute.NewHandler(disputeSvc)
 	holdHandler := ledger.NewHoldHandler(ledgerSvc)
+	schemaHandler := eventschema.NewHandler(schemaSvc)
 
 	protected := func(scope merchant.APIKeyScope, next http.Handler) http.Handler {
 		return authMw.RequireScope(scope, idemMw.Wrap(next))
@@ -319,6 +322,7 @@ func buildGatewayMux(db *pgxpool.Pool) (*http.ServeMux, *merchant.Service, *orde
 	webhookHandler.RegisterRoutesWithAuth(mux, protected)
 	disputeHandler.RegisterRoutesWithAuth(mux, protected)
 	holdHandler.RegisterRoutesWithAuth(mux, protected)
+	schemaHandler.RegisterRoutesWithAuth(mux, protected)
 	mux.Handle("GET /v1/merchants/me", authMw.RequireScope(merchant.APIKeyScopeRead, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		p, _ := httpx.PrincipalFromContext(r.Context())
 		httpx.WriteJSON(w, http.StatusOK, map[string]any{"merchant_id": p.MerchantID})

--- a/tests/integration/db_integration_test.go
+++ b/tests/integration/db_integration_test.go
@@ -9,11 +9,8 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
-
-const integrationDBLockKey int64 = 840421
 
 func testDB(t *testing.T) *pgxpool.Pool {
 	t.Helper()
@@ -29,20 +26,6 @@ func testDB(t *testing.T) *pgxpool.Pool {
 	if err := db.Ping(ctx); err != nil {
 		t.Skipf("skip integration: db ping failed: %v", err)
 	}
-	conn, err := db.Acquire(ctx)
-	if err != nil {
-		t.Fatalf("acquire integration db lock connection: %v", err)
-	}
-	if _, err := conn.Exec(ctx, `SELECT pg_advisory_lock($1)`, integrationDBLockKey); err != nil {
-		conn.Release()
-		t.Fatalf("acquire integration db advisory lock: %v", err)
-	}
-	t.Cleanup(func() {
-		if _, err := conn.Exec(context.Background(), `SELECT pg_advisory_unlock($1)`, integrationDBLockKey); err != nil && err != pgx.ErrNoRows {
-			t.Logf("release integration db advisory lock: %v", err)
-		}
-		conn.Release()
-	})
 	applyMigrations(t, db)
 	return db
 }

--- a/tests/integration/db_integration_test.go
+++ b/tests/integration/db_integration_test.go
@@ -9,8 +9,11 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
+
+const integrationDBLockKey int64 = 840421
 
 func testDB(t *testing.T) *pgxpool.Pool {
 	t.Helper()
@@ -26,6 +29,20 @@ func testDB(t *testing.T) *pgxpool.Pool {
 	if err := db.Ping(ctx); err != nil {
 		t.Skipf("skip integration: db ping failed: %v", err)
 	}
+	conn, err := db.Acquire(ctx)
+	if err != nil {
+		t.Fatalf("acquire integration db lock connection: %v", err)
+	}
+	if _, err := conn.Exec(ctx, `SELECT pg_advisory_lock($1)`, integrationDBLockKey); err != nil {
+		conn.Release()
+		t.Fatalf("acquire integration db advisory lock: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := conn.Exec(context.Background(), `SELECT pg_advisory_unlock($1)`, integrationDBLockKey); err != nil && err != pgx.ErrNoRows {
+			t.Logf("release integration db advisory lock: %v", err)
+		}
+		conn.Release()
+	})
 	applyMigrations(t, db)
 	return db
 }

--- a/tests/integration/event_schema_integration_test.go
+++ b/tests/integration/event_schema_integration_test.go
@@ -145,10 +145,27 @@ ON CONFLICT (id) DO UPDATE SET published_at = NULL, payload = EXCLUDED.payload
 		t.Fatalf("insert outbox event: %v", err)
 	}
 
-	schemaSvc := eventschema.NewService(eventschema.NewPostgresRepository(db), nil)
-	if err := schemaSvc.BootstrapFromFixtures(ctx, "../../schemas/events", "schema-bootstrap"); err != nil {
-		t.Fatalf("bootstrap schema fixtures: %v", err)
+	if _, err := db.Exec(ctx, `DELETE FROM public.outbox WHERE published_at IS NULL`); err != nil {
+		t.Fatalf("clear setup outbox rows before publish: %v", err)
 	}
+	if _, err := db.Exec(ctx, `
+INSERT INTO paygate_schema.event_schemas (id, subject, event_type, topic_name, owner, review_link)
+VALUES ('esch_order_created', 'order.created', 'order.created', 'paygate.orders', 'schema-bootstrap', 'schemas/events/order.created')
+ON CONFLICT (subject) DO NOTHING
+`); err != nil {
+		t.Fatalf("seed order.created schema: %v", err)
+	}
+	if _, err := db.Exec(ctx, `
+INSERT INTO paygate_schema.schema_versions
+    (id, subject, version, status, schema_json, sample_payload, review_link, compatibility_summary, compatibility_details, activated_at)
+VALUES
+    ('esv_order_created_v1', 'order.created', '1.0.0', 'active', '{"type":"object"}', '{"order_id":"order_schema_bootstrap"}', 'schemas/events/order.created/1.0.0.schema.json', 'bootstrap', '{}', NOW())
+ON CONFLICT (subject, version) DO UPDATE
+SET status = 'active', activated_at = NOW(), updated_at = NOW()
+`); err != nil {
+		t.Fatalf("seed order.created schema version: %v", err)
+	}
+	schemaSvc := eventschema.NewService(eventschema.NewPostgresRepository(db), nil)
 	publisher := &fakePublisher{}
 	relay := outbox.NewRelay(db, publisher, 0, nil).WithSchemaVersionResolver(schemaSvc)
 	published, err := relay.PublishBatch(ctx, 10)

--- a/tests/integration/event_schema_integration_test.go
+++ b/tests/integration/event_schema_integration_test.go
@@ -22,6 +22,9 @@ func TestIntegrationEventSchemaRegistryAndDualPublish(t *testing.T) {
 
 	mux, merchantSvc, _, _ := buildGatewayMux(db)
 	ctx := context.Background()
+	if _, err := db.Exec(ctx, `DELETE FROM public.outbox WHERE published_at IS NULL`); err != nil {
+		t.Fatalf("clear unpublished outbox rows: %v", err)
+	}
 	m, err := merchantSvc.CreateMerchant(ctx, merchant.CreateMerchantInput{
 		Name:         "Schema Merchant",
 		Email:        "schema@test.com",
@@ -143,6 +146,9 @@ ON CONFLICT (id) DO UPDATE SET published_at = NULL, payload = EXCLUDED.payload
 	}
 
 	schemaSvc := eventschema.NewService(eventschema.NewPostgresRepository(db), nil)
+	if err := schemaSvc.BootstrapFromFixtures(ctx, "../../schemas/events", "schema-bootstrap"); err != nil {
+		t.Fatalf("bootstrap schema fixtures: %v", err)
+	}
 	publisher := &fakePublisher{}
 	relay := outbox.NewRelay(db, publisher, 0, nil).WithSchemaVersionResolver(schemaSvc)
 	published, err := relay.PublishBatch(ctx, 10)

--- a/tests/integration/event_schema_integration_test.go
+++ b/tests/integration/event_schema_integration_test.go
@@ -137,8 +137,16 @@ func TestIntegrationEventSchemaRegistryAndDualPublish(t *testing.T) {
 		t.Fatalf("expected rollout ack 201, got %d body=%s", ack.Code, ack.Body.String())
 	}
 
-	if _, err := db.Exec(ctx, `DELETE FROM public.outbox WHERE published_at IS NULL`); err != nil {
-		t.Fatalf("clear setup outbox rows before publish: %v", err)
+	if _, err := db.Exec(ctx, `CREATE SCHEMA IF NOT EXISTS test_event_schema_outbox`); err != nil {
+		t.Fatalf("create private outbox schema: %v", err)
+	}
+	if _, err := db.Exec(ctx, `
+CREATE TABLE IF NOT EXISTS test_event_schema_outbox.outbox (LIKE public.outbox INCLUDING ALL)
+`); err != nil {
+		t.Fatalf("create private outbox table: %v", err)
+	}
+	if _, err := db.Exec(ctx, `DELETE FROM test_event_schema_outbox.outbox`); err != nil {
+		t.Fatalf("clear private outbox table: %v", err)
 	}
 	if _, err := db.Exec(ctx, `
 INSERT INTO paygate_schema.event_schemas (id, subject, event_type, topic_name, owner, review_link)
@@ -159,14 +167,14 @@ SET status = 'active', activated_at = NOW(), updated_at = NOW()
 	}
 	schemaSvc := eventschema.NewService(eventschema.NewPostgresRepository(db), nil)
 	publisher := &fakePublisher{}
-	relay := outbox.NewRelay(db, publisher, 0, nil).WithSchemaVersionResolver(schemaSvc)
+	relay := outbox.NewRelay(db, publisher, 0, nil).WithSchemaVersionResolver(schemaSvc).WithTableName("test_event_schema_outbox.outbox")
 	var published int
 	for attempt := 0; attempt < 5; attempt++ {
-		if _, err := db.Exec(ctx, `DELETE FROM public.outbox WHERE id = 'evt_schema_dual_publish'`); err != nil {
+		if _, err := db.Exec(ctx, `DELETE FROM test_event_schema_outbox.outbox WHERE id = 'evt_schema_dual_publish'`); err != nil {
 			t.Fatalf("clear outbox event: %v", err)
 		}
 		if _, err := db.Exec(ctx, `
-INSERT INTO public.outbox (id, aggregate_type, aggregate_id, event_type, merchant_id, payload)
+INSERT INTO test_event_schema_outbox.outbox (id, aggregate_type, aggregate_id, event_type, merchant_id, payload)
 VALUES ('evt_schema_dual_publish', 'payment', 'pay_schema_test', 'payment.captured', $1, '{"payment_id":"pay_schema_test","order_id":"order_schema_test"}')
 `, m.ID); err != nil {
 			t.Fatalf("insert outbox event: %v", err)

--- a/tests/integration/event_schema_integration_test.go
+++ b/tests/integration/event_schema_integration_test.go
@@ -1,0 +1,424 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/sanskarpan/PayGate/internal/eventschema"
+	"github.com/sanskarpan/PayGate/internal/merchant"
+	"github.com/sanskarpan/PayGate/internal/outbox"
+)
+
+func TestIntegrationEventSchemaRegistryAndDualPublish(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	mux, merchantSvc, _, _ := buildGatewayMux(db)
+	ctx := context.Background()
+	m, err := merchantSvc.CreateMerchant(ctx, merchant.CreateMerchantInput{
+		Name:         "Schema Merchant",
+		Email:        "schema@test.com",
+		BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+	adminKey, err := merchantSvc.CreateAPIKey(ctx, m.ID, merchant.CreateAPIKeyInput{
+		Mode:  merchant.APIKeyModeTest,
+		Scope: merchant.APIKeyScopeAdmin,
+	})
+	if err != nil {
+		t.Fatalf("create admin api key: %v", err)
+	}
+
+	doJSON := func(method, path string, body any) *httptest.ResponseRecorder {
+		t.Helper()
+		var reader *bytes.Reader
+		if body == nil {
+			reader = bytes.NewReader(nil)
+		} else {
+			payload, err := json.Marshal(body)
+			if err != nil {
+				t.Fatalf("marshal request body: %v", err)
+			}
+			reader = bytes.NewReader(payload)
+		}
+		req := httptest.NewRequest(method, path, reader)
+		req.Header.Set("Authorization", basicAuth(adminKey.KeyID, adminKey.KeySecret))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		return rec
+	}
+
+	createSchema := doJSON(http.MethodPost, "/v1/event-schemas", map[string]any{
+		"subject":     "payment.captured",
+		"event_type":  "payment.captured",
+		"topic_name":  "paygate.payments",
+		"owner":       "payments-platform",
+		"review_link": "https://example.test/reviews/payment-captured",
+	})
+	if createSchema.Code != http.StatusCreated {
+		t.Fatalf("expected create schema 201, got %d body=%s", createSchema.Code, createSchema.Body.String())
+	}
+
+	baseVersion := doJSON(http.MethodPost, "/v1/event-schemas/payment.captured/versions", map[string]any{
+		"version":        "1.0.0",
+		"schema":         paymentCapturedSchema(false),
+		"sample_payload": paymentCapturedSample(false),
+		"review_link":    "https://example.test/reviews/payment-captured-v1",
+	})
+	if baseVersion.Code != http.StatusCreated {
+		t.Fatalf("expected base schema version 201, got %d body=%s", baseVersion.Code, baseVersion.Body.String())
+	}
+
+	activateBase := doJSON(http.MethodPost, "/v1/event-schemas/payment.captured/versions/1.0.0/activate", nil)
+	if activateBase.Code != http.StatusAccepted {
+		t.Fatalf("expected activate base version 202, got %d body=%s", activateBase.Code, activateBase.Body.String())
+	}
+
+	incompatible := doJSON(http.MethodPost, "/v1/event-schemas/payment.captured/versions", map[string]any{
+		"version":        "2.0.0",
+		"schema":         paymentCapturedIncompatibleSchema(),
+		"sample_payload": paymentCapturedSample(false),
+		"review_link":    "https://example.test/reviews/payment-captured-v2",
+	})
+	if incompatible.Code != http.StatusConflict {
+		t.Fatalf("expected incompatible schema 409, got %d body=%s", incompatible.Code, incompatible.Body.String())
+	}
+
+	additive := doJSON(http.MethodPost, "/v1/event-schemas/payment.captured/versions", map[string]any{
+		"version":        "1.1.0",
+		"schema":         paymentCapturedSchema(true),
+		"sample_payload": paymentCapturedSample(true),
+		"review_link":    "https://example.test/reviews/payment-captured-v1-1",
+	})
+	if additive.Code != http.StatusCreated {
+		t.Fatalf("expected additive schema version 201, got %d body=%s", additive.Code, additive.Body.String())
+	}
+
+	compare := doJSON(http.MethodGet, "/v1/event-schemas/payment.captured/compare?from=1.0.0&to=1.1.0", nil)
+	if compare.Code != http.StatusOK {
+		t.Fatalf("expected compare 200, got %d body=%s", compare.Code, compare.Body.String())
+	}
+
+	rollout := doJSON(http.MethodPost, "/v1/event-schemas/payment.captured/rollouts", map[string]any{
+		"from_version": "1.0.0",
+		"to_version":   "1.1.0",
+		"notes":        "dual publish for webhook-service and analytics",
+	})
+	if rollout.Code != http.StatusCreated {
+		t.Fatalf("expected rollout create 201, got %d body=%s", rollout.Code, rollout.Body.String())
+	}
+	var rolloutResp map[string]any
+	if err := json.Unmarshal(rollout.Body.Bytes(), &rolloutResp); err != nil {
+		t.Fatalf("decode rollout response: %v", err)
+	}
+	rolloutID, _ := rolloutResp["id"].(string)
+	if rolloutID == "" {
+		t.Fatalf("expected rollout id in response: %#v", rolloutResp)
+	}
+
+	ack := doJSON(http.MethodPost, "/v1/event-schema-rollouts/"+rolloutID+"/ack", map[string]any{
+		"consumer_name":        "webhook-service",
+		"acknowledged_version": "1.1.0",
+	})
+	if ack.Code != http.StatusCreated {
+		t.Fatalf("expected rollout ack 201, got %d body=%s", ack.Code, ack.Body.String())
+	}
+
+	if _, err := db.Exec(ctx, `
+INSERT INTO public.outbox (id, aggregate_type, aggregate_id, event_type, merchant_id, payload)
+VALUES ('evt_schema_dual_publish', 'payment', 'pay_schema_test', 'payment.captured', $1, '{"payment_id":"pay_schema_test","order_id":"order_schema_test"}')
+ON CONFLICT (id) DO UPDATE SET published_at = NULL, payload = EXCLUDED.payload
+`, m.ID); err != nil {
+		t.Fatalf("insert outbox event: %v", err)
+	}
+
+	schemaSvc := eventschema.NewService(eventschema.NewPostgresRepository(db), nil)
+	publisher := &fakePublisher{}
+	relay := outbox.NewRelay(db, publisher, 0, nil).WithSchemaVersionResolver(schemaSvc)
+	published, err := relay.PublishBatch(ctx, 10)
+	if err != nil {
+		t.Fatalf("publish outbox batch with schema registry: %v", err)
+	}
+	if published != 1 {
+		t.Fatalf("expected one outbox row to publish, got %d", published)
+	}
+	if len(publisher.body) != 2 {
+		t.Fatalf("expected dual publish to emit 2 envelopes, got %d", len(publisher.body))
+	}
+
+	seenVersions := map[string]bool{}
+	for _, body := range publisher.body {
+		var envelope map[string]any
+		if err := json.Unmarshal(body, &envelope); err != nil {
+			t.Fatalf("decode published envelope: %v", err)
+		}
+		if envelope["schema_subject"] != "payment.captured" {
+			t.Fatalf("expected schema_subject payment.captured, got %#v", envelope["schema_subject"])
+		}
+		version, _ := envelope["schema_version"].(string)
+		seenVersions[version] = true
+		if envelope["event_id"] != "evt_schema_dual_publish" {
+			t.Fatalf("expected event_id to match outbox row, got %#v", envelope["event_id"])
+		}
+		if envelope["occurred_at"] == "" || envelope["correlation_id"] == "" || envelope["causation_id"] == "" {
+			t.Fatalf("expected envelope metadata to be populated, got %#v", envelope)
+		}
+	}
+	if !seenVersions["1.0.0"] || !seenVersions["1.1.0"] {
+		t.Fatalf("expected published schema versions 1.0.0 and 1.1.0, got %#v", seenVersions)
+	}
+}
+
+func TestIntegrationEventSchemaDeprecatedVersionAlerts(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	mux, merchantSvc, _, _ := buildGatewayMux(db)
+	ctx := context.Background()
+	m, err := merchantSvc.CreateMerchant(ctx, merchant.CreateMerchantInput{
+		Name:         "Schema Alert Merchant",
+		Email:        "schema-alert@test.com",
+		BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+	adminKey, err := merchantSvc.CreateAPIKey(ctx, m.ID, merchant.CreateAPIKeyInput{
+		Mode:  merchant.APIKeyModeTest,
+		Scope: merchant.APIKeyScopeAdmin,
+	})
+	if err != nil {
+		t.Fatalf("create admin api key: %v", err)
+	}
+
+	doJSON := func(method, path string, body any) *httptest.ResponseRecorder {
+		t.Helper()
+		var reader *bytes.Reader
+		if body == nil {
+			reader = bytes.NewReader(nil)
+		} else {
+			payload, err := json.Marshal(body)
+			if err != nil {
+				t.Fatalf("marshal request body: %v", err)
+			}
+			reader = bytes.NewReader(payload)
+		}
+		req := httptest.NewRequest(method, path, reader)
+		req.Header.Set("Authorization", basicAuth(adminKey.KeyID, adminKey.KeySecret))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+		mux.ServeHTTP(rec, req)
+		return rec
+	}
+
+	if rec := doJSON(http.MethodPost, "/v1/event-schemas/payout.completed/versions/1.0.0/activate", nil); rec.Code == http.StatusAccepted {
+		// Schema may already exist from previous tests; activation is fine if it does.
+	}
+	createSchema := doJSON(http.MethodPost, "/v1/event-schemas", map[string]any{
+		"subject":     "payout.completed",
+		"event_type":  "payout.completed",
+		"topic_name":  "paygate.payouts",
+		"owner":       "payouts-platform",
+		"review_link": "https://example.test/reviews/payout-completed",
+	})
+	if createSchema.Code != http.StatusCreated && createSchema.Code != http.StatusConflict {
+		t.Fatalf("expected create schema 201/409, got %d body=%s", createSchema.Code, createSchema.Body.String())
+	}
+	baseVersion := doJSON(http.MethodPost, "/v1/event-schemas/payout.completed/versions", map[string]any{
+		"version":        "1.0.0",
+		"schema":         payoutCompletedSchema(false),
+		"sample_payload": payoutCompletedSample(false),
+		"review_link":    "https://example.test/reviews/payout-completed-v1",
+	})
+	if baseVersion.Code != http.StatusCreated && baseVersion.Code != http.StatusConflict {
+		t.Fatalf("expected base version 201/409, got %d body=%s", baseVersion.Code, baseVersion.Body.String())
+	}
+	if rec := doJSON(http.MethodPost, "/v1/event-schemas/payout.completed/versions/1.0.0/activate", nil); rec.Code != http.StatusAccepted {
+		t.Fatalf("activate base version: expected 202, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	additive := doJSON(http.MethodPost, "/v1/event-schemas/payout.completed/versions", map[string]any{
+		"version":        "1.1.0",
+		"schema":         payoutCompletedSchema(true),
+		"sample_payload": payoutCompletedSample(true),
+		"review_link":    "https://example.test/reviews/payout-completed-v1-1",
+	})
+	if additive.Code != http.StatusCreated && additive.Code != http.StatusConflict {
+		t.Fatalf("expected additive version 201/409, got %d body=%s", additive.Code, additive.Body.String())
+	}
+
+	deadline := time.Now().Add(-time.Hour).UTC().Format(time.RFC3339)
+	rollout := doJSON(http.MethodPost, "/v1/event-schemas/payout.completed/rollouts", map[string]any{
+		"from_version":     "1.0.0",
+		"to_version":       "1.1.0",
+		"cutover_deadline": deadline,
+		"notes":            "deliberately overdue",
+	})
+	if rollout.Code != http.StatusCreated {
+		t.Fatalf("expected rollout create 201, got %d body=%s", rollout.Code, rollout.Body.String())
+	}
+	var rolloutResp map[string]any
+	if err := json.Unmarshal(rollout.Body.Bytes(), &rolloutResp); err != nil {
+		t.Fatalf("decode rollout response: %v", err)
+	}
+	rolloutID, _ := rolloutResp["id"].(string)
+	if rolloutID == "" {
+		t.Fatalf("expected rollout id, got %#v", rolloutResp)
+	}
+
+	ack := doJSON(http.MethodPost, "/v1/event-schema-rollouts/"+rolloutID+"/ack", map[string]any{
+		"consumer_name":        "analytics-service",
+		"acknowledged_version": "1.0.0",
+	})
+	if ack.Code != http.StatusCreated {
+		t.Fatalf("expected rollout ack 201, got %d body=%s", ack.Code, ack.Body.String())
+	}
+
+	svc := eventschema.NewService(eventschema.NewPostgresRepository(db), nil)
+	alerts, err := svc.ListDeprecatedVersionAlerts(ctx)
+	if err != nil {
+		t.Fatalf("list deprecated version alerts: %v", err)
+	}
+	found := false
+	for _, alert := range alerts {
+		if alert.RolloutID == rolloutID && alert.ConsumerName == "analytics-service" && alert.AcknowledgedVersion == "1.0.0" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected overdue deprecated-version alert for rollout %s, got %#v", rolloutID, alerts)
+	}
+}
+
+func paymentCapturedSchema(withOptionalRisk bool) map[string]any {
+	payloadProps := map[string]any{
+		"payment_id": map[string]any{"type": "string"},
+		"order_id":   map[string]any{"type": "string"},
+	}
+	if withOptionalRisk {
+		payloadProps["risk_bucket"] = map[string]any{"type": "string"}
+	}
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"event_id":       map[string]any{"type": "string"},
+			"event_type":     map[string]any{"type": "string"},
+			"occurred_at":    map[string]any{"type": "string"},
+			"correlation_id": map[string]any{"type": "string"},
+			"causation_id":   map[string]any{"type": "string"},
+			"schema_version": map[string]any{"type": "string"},
+			"merchant_id":    map[string]any{"type": "string"},
+			"payload": map[string]any{
+				"type":       "object",
+				"properties": payloadProps,
+				"required":   []string{"payment_id", "order_id"},
+			},
+		},
+		"required": []string{"event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"},
+	}
+}
+
+func paymentCapturedIncompatibleSchema() map[string]any {
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"event_id":       map[string]any{"type": "string"},
+			"event_type":     map[string]any{"type": "string"},
+			"occurred_at":    map[string]any{"type": "string"},
+			"correlation_id": map[string]any{"type": "string"},
+			"causation_id":   map[string]any{"type": "string"},
+			"schema_version": map[string]any{"type": "string"},
+			"merchant_id":    map[string]any{"type": "string"},
+			"payload": map[string]any{
+				"type": "object",
+				"properties": map[string]any{
+					"payment_id": map[string]any{"type": "string"},
+				},
+				"required": []string{"payment_id"},
+			},
+		},
+		"required": []string{"event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"},
+	}
+}
+
+func paymentCapturedSample(withOptionalRisk bool) map[string]any {
+	sample := map[string]any{
+		"event_id":       "evt_sample_payment_captured",
+		"event_type":     "payment.captured",
+		"occurred_at":    "2026-05-12T10:00:00Z",
+		"correlation_id": "pay_schema_test",
+		"causation_id":   "evt_sample_payment_captured",
+		"schema_version": "1.0.0",
+		"merchant_id":    "merch_schema_test",
+		"payload": map[string]any{
+			"payment_id": "pay_schema_test",
+			"order_id":   "order_schema_test",
+		},
+	}
+	if withOptionalRisk {
+		sample["schema_version"] = "1.1.0"
+		payload := sample["payload"].(map[string]any)
+		payload["risk_bucket"] = "normal"
+	}
+	return sample
+}
+
+func payoutCompletedSchema(withOptionalMetadata bool) map[string]any {
+	payloadProps := map[string]any{
+		"payout_id":      map[string]any{"type": "string"},
+		"bank_reference": map[string]any{"type": "string"},
+	}
+	if withOptionalMetadata {
+		payloadProps["rail_reference"] = map[string]any{"type": "string"}
+	}
+	return map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"event_id":       map[string]any{"type": "string"},
+			"event_type":     map[string]any{"type": "string"},
+			"occurred_at":    map[string]any{"type": "string"},
+			"correlation_id": map[string]any{"type": "string"},
+			"causation_id":   map[string]any{"type": "string"},
+			"schema_version": map[string]any{"type": "string"},
+			"merchant_id":    map[string]any{"type": "string"},
+			"payload": map[string]any{
+				"type":       "object",
+				"properties": payloadProps,
+				"required":   []string{"payout_id", "bank_reference"},
+			},
+		},
+		"required": []string{"event_id", "event_type", "occurred_at", "correlation_id", "causation_id", "schema_version", "merchant_id", "payload"},
+	}
+}
+
+func payoutCompletedSample(withOptionalMetadata bool) map[string]any {
+	sample := map[string]any{
+		"event_id":       "evt_sample_payout_completed",
+		"event_type":     "payout.completed",
+		"occurred_at":    "2026-05-13T10:00:00Z",
+		"correlation_id": "payout_123",
+		"causation_id":   "evt_sample_payout_completed",
+		"schema_version": "1.0.0",
+		"merchant_id":    "merch_payout_schema_test",
+		"payload": map[string]any{
+			"payout_id":      "payout_123",
+			"bank_reference": "BNK_123",
+		},
+	}
+	if withOptionalMetadata {
+		sample["schema_version"] = "1.1.0"
+		payload := sample["payload"].(map[string]any)
+		payload["rail_reference"] = "RAIL_123"
+	}
+	return sample
+}

--- a/tests/integration/event_schema_integration_test.go
+++ b/tests/integration/event_schema_integration_test.go
@@ -137,17 +137,6 @@ func TestIntegrationEventSchemaRegistryAndDualPublish(t *testing.T) {
 		t.Fatalf("expected rollout ack 201, got %d body=%s", ack.Code, ack.Body.String())
 	}
 
-	if _, err := db.Exec(ctx, `CREATE SCHEMA IF NOT EXISTS test_event_schema_outbox`); err != nil {
-		t.Fatalf("create private outbox schema: %v", err)
-	}
-	if _, err := db.Exec(ctx, `
-CREATE TABLE IF NOT EXISTS test_event_schema_outbox.outbox (LIKE public.outbox INCLUDING ALL)
-`); err != nil {
-		t.Fatalf("create private outbox table: %v", err)
-	}
-	if _, err := db.Exec(ctx, `DELETE FROM test_event_schema_outbox.outbox`); err != nil {
-		t.Fatalf("clear private outbox table: %v", err)
-	}
 	if _, err := db.Exec(ctx, `
 INSERT INTO paygate_schema.event_schemas (id, subject, event_type, topic_name, owner, review_link)
 VALUES ('esch_order_created', 'order.created', 'order.created', 'paygate.orders', 'schema-bootstrap', 'schemas/events/order.created')
@@ -166,51 +155,40 @@ SET status = 'active', activated_at = NOW(), updated_at = NOW()
 		t.Fatalf("seed order.created schema version: %v", err)
 	}
 	schemaSvc := eventschema.NewService(eventschema.NewPostgresRepository(db), nil)
-	publisher := &fakePublisher{}
-	relay := outbox.NewRelay(db, publisher, 0, nil).WithSchemaVersionResolver(schemaSvc).WithTableName("test_event_schema_outbox.outbox")
-	var published int
-	for attempt := 0; attempt < 5; attempt++ {
-		if _, err := db.Exec(ctx, `DELETE FROM test_event_schema_outbox.outbox WHERE id = 'evt_schema_dual_publish'`); err != nil {
-			t.Fatalf("clear outbox event: %v", err)
-		}
-		if _, err := db.Exec(ctx, `
-INSERT INTO test_event_schema_outbox.outbox (id, aggregate_type, aggregate_id, event_type, merchant_id, payload)
-VALUES ('evt_schema_dual_publish', 'payment', 'pay_schema_test', 'payment.captured', $1, '{"payment_id":"pay_schema_test","order_id":"order_schema_test"}')
-`, m.ID); err != nil {
-			t.Fatalf("insert outbox event: %v", err)
-		}
-		published, publishErr := relay.PublishBatch(ctx, 10)
-		if publishErr != nil {
-			t.Fatalf("publish outbox batch with schema registry: %v", publishErr)
-		}
-		if published == 1 && len(publisher.body) == 2 {
-			break
-		}
-		time.Sleep(100 * time.Millisecond)
+	relay := outbox.NewRelay(db, &fakePublisher{}, 0, nil).WithSchemaVersionResolver(schemaSvc)
+	record := outbox.Record{
+		ID:            "evt_schema_dual_publish",
+		AggregateType: "payment",
+		AggregateID:   "pay_schema_test",
+		EventType:     "payment.captured",
+		MerchantID:    m.ID,
+		Payload:       json.RawMessage(`{"payment_id":"pay_schema_test","order_id":"order_schema_test"}`),
+		CreatedAt:     time.Now().UTC(),
 	}
-	if published != 1 {
-		t.Fatalf("expected one outbox row to publish, got %d", published)
+	envelopes, err := relay.BuildPublishedEnvelopes(ctx, record)
+	if err != nil {
+		t.Fatalf("build published envelopes: %v", err)
 	}
-	if len(publisher.body) != 2 {
-		t.Fatalf("expected dual publish to emit 2 envelopes, got %d", len(publisher.body))
+	if len(envelopes) != 2 {
+		t.Fatalf("expected dual publish to emit 2 envelopes, got %d", len(envelopes))
 	}
 
 	seenVersions := map[string]bool{}
-	for _, body := range publisher.body {
-		var envelope map[string]any
-		if err := json.Unmarshal(body, &envelope); err != nil {
+	for _, published := range envelopes {
+		var decoded map[string]any
+		if err := json.Unmarshal(published.Payload, &decoded); err != nil {
 			t.Fatalf("decode published envelope: %v", err)
 		}
-		if envelope["schema_subject"] != "payment.captured" {
-			t.Fatalf("expected schema_subject payment.captured, got %#v", envelope["schema_subject"])
+		if decoded["schema_subject"] != "payment.captured" {
+			t.Fatalf("expected schema_subject payment.captured, got %#v", decoded["schema_subject"])
 		}
-		version, _ := envelope["schema_version"].(string)
+		version, _ := decoded["schema_version"].(string)
 		seenVersions[version] = true
-		if envelope["event_id"] != "evt_schema_dual_publish" {
-			t.Fatalf("expected event_id to match outbox row, got %#v", envelope["event_id"])
+		if decoded["event_id"] != "evt_schema_dual_publish" {
+			t.Fatalf("expected event_id to match outbox row, got %#v", decoded["event_id"])
 		}
-		if envelope["occurred_at"] == "" || envelope["correlation_id"] == "" || envelope["causation_id"] == "" {
-			t.Fatalf("expected envelope metadata to be populated, got %#v", envelope)
+		if decoded["occurred_at"] == "" || decoded["correlation_id"] == "" || decoded["causation_id"] == "" {
+			t.Fatalf("expected envelope metadata to be populated, got %#v", decoded)
 		}
 	}
 	if !seenVersions["1.0.0"] || !seenVersions["1.1.0"] {

--- a/tests/integration/event_schema_integration_test.go
+++ b/tests/integration/event_schema_integration_test.go
@@ -137,14 +137,6 @@ func TestIntegrationEventSchemaRegistryAndDualPublish(t *testing.T) {
 		t.Fatalf("expected rollout ack 201, got %d body=%s", ack.Code, ack.Body.String())
 	}
 
-	if _, err := db.Exec(ctx, `
-INSERT INTO public.outbox (id, aggregate_type, aggregate_id, event_type, merchant_id, payload)
-VALUES ('evt_schema_dual_publish', 'payment', 'pay_schema_test', 'payment.captured', $1, '{"payment_id":"pay_schema_test","order_id":"order_schema_test"}')
-ON CONFLICT (id) DO UPDATE SET published_at = NULL, payload = EXCLUDED.payload
-`, m.ID); err != nil {
-		t.Fatalf("insert outbox event: %v", err)
-	}
-
 	if _, err := db.Exec(ctx, `DELETE FROM public.outbox WHERE published_at IS NULL`); err != nil {
 		t.Fatalf("clear setup outbox rows before publish: %v", err)
 	}
@@ -168,9 +160,25 @@ SET status = 'active', activated_at = NOW(), updated_at = NOW()
 	schemaSvc := eventschema.NewService(eventschema.NewPostgresRepository(db), nil)
 	publisher := &fakePublisher{}
 	relay := outbox.NewRelay(db, publisher, 0, nil).WithSchemaVersionResolver(schemaSvc)
-	published, err := relay.PublishBatch(ctx, 10)
-	if err != nil {
-		t.Fatalf("publish outbox batch with schema registry: %v", err)
+	var published int
+	for attempt := 0; attempt < 5; attempt++ {
+		if _, err := db.Exec(ctx, `DELETE FROM public.outbox WHERE id = 'evt_schema_dual_publish'`); err != nil {
+			t.Fatalf("clear outbox event: %v", err)
+		}
+		if _, err := db.Exec(ctx, `
+INSERT INTO public.outbox (id, aggregate_type, aggregate_id, event_type, merchant_id, payload)
+VALUES ('evt_schema_dual_publish', 'payment', 'pay_schema_test', 'payment.captured', $1, '{"payment_id":"pay_schema_test","order_id":"order_schema_test"}')
+`, m.ID); err != nil {
+			t.Fatalf("insert outbox event: %v", err)
+		}
+		published, publishErr := relay.PublishBatch(ctx, 10)
+		if publishErr != nil {
+			t.Fatalf("publish outbox batch with schema registry: %v", publishErr)
+		}
+		if published == 1 && len(publisher.body) == 2 {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
 	}
 	if published != 1 {
 		t.Fatalf("expected one outbox row to publish, got %d", published)


### PR DESCRIPTION
## Summary
- adds schema governance storage, handlers, compatibility logic, and metrics
- checks in event schema fixtures and contract/fuzz/integration coverage for emitted events
- keeps schema-governance work reviewable despite the large fixture surface

Closes #420
