### PR TITLE
[#530] Expand operator dashboard for mandate, compliance, risk, and payout flows

### DIFF
--- a/dashboard/app/compliance/page.tsx
+++ b/dashboard/app/compliance/page.tsx
@@ -9,6 +9,7 @@ import {
   requireViewer,
 } from "../../lib/api";
 import { formatMoney, formatTime } from "../../lib/types";
+import ComplianceOpsConsole from "../../components/compliance-ops-console";
 
 function stateTone(state: string) {
   switch (state) {
@@ -117,6 +118,8 @@ export default async function CompliancePage() {
           <div className="stat-label">current reserve escalation trigger</div>
         </div>
       </div>
+
+      <ComplianceOpsConsole merchantID={viewer.merchant_id} onboarding={onboarding} capabilities={capabilities.items} />
 
       <div className="detail-grid">
         <div className="list-card">

--- a/dashboard/app/mandates/[id]/page.tsx
+++ b/dashboard/app/mandates/[id]/page.tsx
@@ -1,0 +1,50 @@
+import { getUPIMandate, getUPIMandateEvents } from "../../../lib/api";
+import { formatMoney, formatTime, truncateMiddle } from "../../../lib/types";
+
+export default async function MandateDetailPage({ params }: { params: { id: string } }) {
+  const [mandate, events] = await Promise.all([getUPIMandate(params.id), getUPIMandateEvents(params.id)]);
+
+  return (
+    <section className="stack fade-up">
+      <div className="hero-card">
+        <div className="eyebrow">Mandate Detail</div>
+        <h1>{mandate.display_name}</h1>
+        <p className="mono" style={{ margin: "0 0 8px" }}>{mandate.id}</p>
+        <p className="lede">
+          {mandate.status} · {formatMoney(mandate.amount_limit, mandate.currency)} ceiling · {mandate.vpa}
+        </p>
+      </div>
+
+      <div className="detail-grid">
+        <div className="detail-card">
+          <h2>Attributes</h2>
+          <dl className="detail-list">
+            <div><dt>Reference</dt><dd>{truncateMiddle(mandate.reference)}</dd></div>
+            <div><dt>Customer ID</dt><dd>{truncateMiddle(mandate.customer_id)}</dd></div>
+            <div><dt>Interval</dt><dd>{mandate.interval_count} {mandate.interval_unit}</dd></div>
+            <div><dt>Retry Window</dt><dd>{mandate.retry_window_hours}h</dd></div>
+            <div><dt>Approved At</dt><dd>{mandate.approved_at ? formatTime(mandate.approved_at) : "Not approved"}</dd></div>
+            <div><dt>Expires At</dt><dd>{mandate.expires_at ? formatTime(mandate.expires_at) : "No hard expiry"}</dd></div>
+          </dl>
+        </div>
+
+        <div className="detail-card">
+          <h2>History</h2>
+          <div className="timeline">
+            {events.items.map((event) => (
+              <div className="timeline-item active" key={event.id}>
+                <div className="timeline-dot" />
+                <div>
+                  <div className="row-title">{event.event_type}</div>
+                  <div className="muted">{formatTime(event.created_at)} · {event.actor_type} · {event.actor_id || "system"}</div>
+                  {event.reason ? <div className="muted">{event.reason}</div> : null}
+                  {event.payment_id ? <div className="muted">payment {truncateMiddle(event.payment_id)}</div> : null}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/dashboard/app/mandates/page.tsx
+++ b/dashboard/app/mandates/page.tsx
@@ -1,0 +1,67 @@
+import Link from "next/link";
+
+import { getUPIMandates, requireViewer } from "../../lib/api";
+import { formatMoney, formatTime, truncateMiddle } from "../../lib/types";
+
+export default async function MandatesPage() {
+  await requireViewer();
+  const mandates = await getUPIMandates();
+
+  return (
+    <section className="stack fade-up">
+      <div className="hero-card">
+        <div className="eyebrow">UPI AutoPay</div>
+        <h1>Mandates and recurring approvals.</h1>
+        <p className="lede">Inspect mandate state, customer linkage, expiry windows, and recurring collection readiness.</p>
+        <div className="metric-strip">
+          <div className="metric-chip">
+            <span className="metric-chip-label">Mandates</span>
+            <strong>{mandates.count}</strong>
+          </div>
+          <div className="metric-chip">
+            <span className="metric-chip-label">Active</span>
+            <strong>{mandates.items.filter((item) => item.status === "active").length}</strong>
+          </div>
+          <div className="metric-chip">
+            <span className="metric-chip-label">Pending approval</span>
+            <strong>{mandates.items.filter((item) => item.status === "pending_approval").length}</strong>
+          </div>
+        </div>
+      </div>
+
+      <div className="list-card">
+        <div className="section-head">
+          <div>
+            <h2>Mandate registry</h2>
+            <div className="section-kicker">Customer approvals, amount ceilings, and lifecycle state</div>
+          </div>
+        </div>
+        {mandates.items.length === 0 ? (
+          <div className="empty-state">
+            <strong>No mandates created</strong>
+            <span className="muted">Create a UPI AutoPay mandate to enable recurring collections for subscriptions.</span>
+          </div>
+        ) : (
+          mandates.items.map((mandate) => (
+            <article className="list-row" key={mandate.id}>
+              <div className="entity-primary">
+                <div className="row-title">
+                  <Link href={`/mandates/${mandate.id}`}>{mandate.display_name}</Link>
+                </div>
+                <div className="row-meta">
+                  <span className={mandate.status === "active" ? "badge-success" : mandate.status === "pending_approval" ? "badge-warning" : "badge-neutral"}>
+                    {mandate.status}
+                  </span>
+                  <span>{truncateMiddle(mandate.reference, 12, 6)}</span>
+                  <span>{mandate.vpa}</span>
+                  <span>{formatMoney(mandate.amount_limit, mandate.currency)}</span>
+                </div>
+                <div className="muted">Created {formatTime(mandate.created_at)} · interval {mandate.interval_count} {mandate.interval_unit}</div>
+              </div>
+            </article>
+          ))
+        )}
+      </div>
+    </section>
+  );
+}

--- a/dashboard/app/payments/[id]/page.tsx
+++ b/dashboard/app/payments/[id]/page.tsx
@@ -6,9 +6,19 @@ import { formatMoney, formatTime, truncateMiddle } from "../../../lib/types";
 export default async function PaymentDetailPage({ params }: { params: { id: string } }) {
   const payment = await getPayment(params.id);
   const upiIntent = payment.method === "upi" ? await getUPIIntent(params.id) : null;
+  const isUPIQR = upiIntent?.flow_type === "qr";
+  const isCardChallenge = payment.method === "card" && payment.status === "requires_action";
   const timeline = [
     { label: "Created", at: payment.created_at, active: true },
-    { label: "Customer Action", at: upiIntent ? payment.created_at : 0, active: payment.status === "pending_customer_action" || payment.method === "upi" },
+    {
+      label: "Customer Action",
+      at: isCardChallenge
+        ? payment.card_challenge?.expires_at || payment.created_at
+        : upiIntent
+          ? payment.created_at
+          : 0,
+      active: payment.status === "pending_customer_action" || payment.method === "upi" || isCardChallenge,
+    },
     { label: "Processing", at: upiIntent?.last_polled_at || upiIntent?.completed_at || 0, active: payment.status === "processing" },
     { label: "Authorized", at: payment.authorized_at, active: Boolean(payment.authorized_at) },
     { label: "Captured", at: payment.captured_at, active: Boolean(payment.captured_at) },
@@ -21,7 +31,7 @@ export default async function PaymentDetailPage({ params }: { params: { id: stri
         <h1>{truncateMiddle(payment.id, 14, 8)}</h1>
         <p className="mono" style={{ margin: "0 0 8px" }}>{payment.id}</p>
         <p className="lede">
-          {payment.status} · {formatMoney(payment.amount, payment.currency)} via {payment.method}.
+          {payment.status} · {formatMoney(payment.amount, payment.currency)} via {payment.method}{isUPIQR ? " QR" : isCardChallenge ? " with 3DS" : ""}.
         </p>
         <div className="hero-actions">
           <Link className="ghost-button" href={`/orders/${payment.order_id}`}>
@@ -45,6 +55,12 @@ export default async function PaymentDetailPage({ params }: { params: { id: stri
           <span className="eyebrow">Method</span>
           <strong>{payment.method}</strong>
         </div>
+        {isCardChallenge ? (
+          <div className="key-fact">
+            <span className="eyebrow">Challenge</span>
+            <strong>{payment.card_challenge?.status || payment.next_action?.challenge_status || "pending"}</strong>
+          </div>
+        ) : null}
         {upiIntent ? (
           <div className="key-fact">
             <span className="eyebrow">UPI Status</span>
@@ -86,16 +102,54 @@ export default async function PaymentDetailPage({ params }: { params: { id: stri
               <dt>Captured At</dt>
               <dd>{payment.captured_at ? formatTime(payment.captured_at) : "Not available"}</dd>
             </div>
+            {isCardChallenge ? (
+              <>
+                <div>
+                  <dt>Challenge Status</dt>
+                  <dd>{payment.card_challenge?.status || payment.next_action?.challenge_status || "pending"}</dd>
+                </div>
+                <div>
+                  <dt>Challenge Session</dt>
+                  <dd>{payment.card_challenge?.session_id || payment.next_action?.challenge_session_id || "Not available"}</dd>
+                </div>
+                <div>
+                  <dt>Redirect URL</dt>
+                  <dd>
+                    {payment.next_action?.redirect_url ? (
+                      <a href={payment.next_action.redirect_url} target="_blank" rel="noreferrer">
+                        Open 3DS Challenge
+                      </a>
+                    ) : (
+                      "Not available"
+                    )}
+                  </dd>
+                </div>
+                <div>
+                  <dt>Challenge Expires</dt>
+                  <dd>{payment.next_action?.expires_at ? formatTime(payment.next_action.expires_at) : "Not available"}</dd>
+                </div>
+                <div>
+                  <dt>Sandbox Callback</dt>
+                  <dd>{payment.sandbox?.callback_url || payment.card_challenge?.sandbox_callback_url || "Not available"}</dd>
+                </div>
+              </>
+            ) : null}
             {upiIntent ? (
               <>
                 <div>
-                  <dt>VPA</dt>
-                  <dd>{upiIntent.vpa || "Not available"}</dd>
+                  <dt>{isUPIQR ? "Display Name" : "VPA"}</dt>
+                  <dd>{isUPIQR ? upiIntent.display_name || "PayGate" : upiIntent.vpa || "Not available"}</dd>
                 </div>
                 <div>
                   <dt>Provider Status</dt>
                   <dd>{upiIntent.provider_status}</dd>
                 </div>
+                {isUPIQR ? (
+                  <div>
+                    <dt>QR Mode</dt>
+                    <dd>{upiIntent.qr_mode || "dynamic"}</dd>
+                  </div>
+                ) : null}
                 <div>
                   <dt>Expires At</dt>
                   <dd>{formatTime(upiIntent.expires_at)}</dd>
@@ -105,17 +159,25 @@ export default async function PaymentDetailPage({ params }: { params: { id: stri
                   <dd>{upiIntent.gateway_reference || "Pending"}</dd>
                 </div>
                 <div>
-                  <dt>Intent Link</dt>
+                  <dt>{isUPIQR ? "Scan Payload" : "Intent Link"}</dt>
                   <dd>
-                    {upiIntent.next_action?.deep_link ? (
-                      <a href={upiIntent.next_action.deep_link} target="_blank" rel="noreferrer">
-                        Open UPI App
-                      </a>
-                    ) : (
-                      "Not available"
-                    )}
+                    {isUPIQR
+                      ? upiIntent.next_action?.qr_payload || upiIntent.qr_payload || "Not available"
+                      : upiIntent.next_action?.deep_link ? (
+                          <a href={upiIntent.next_action.deep_link} target="_blank" rel="noreferrer">
+                            Open UPI App
+                          </a>
+                        ) : (
+                          "Not available"
+                        )}
                   </dd>
                 </div>
+                {isUPIQR ? (
+                  <div>
+                    <dt>Reusable</dt>
+                    <dd>{upiIntent.is_reusable ? "Yes" : "No"}</dd>
+                  </div>
+                ) : null}
                 <div>
                   <dt>Failure</dt>
                   <dd>{upiIntent.failure_code || upiIntent.failure_description || "Not available"}</dd>

--- a/dashboard/app/payouts/page.tsx
+++ b/dashboard/app/payouts/page.tsx
@@ -1,5 +1,6 @@
 import { getBeneficiaries, getPayouts, requireViewer } from "../../lib/api";
 import { formatMoney, formatTime } from "../../lib/types";
+import PayoutApprovalManager from "../../components/payout-approval-manager";
 
 function statusBadge(status: string) {
   switch (status) {
@@ -123,51 +124,7 @@ export default async function PayoutsPage() {
           )}
         </div>
       </div>
-      <div className="list-card">
-        {payouts.items.length === 0 ? (
-          <div className="empty-state">
-            <strong>No payouts initiated</strong>
-            <span className="muted">
-              Run a settlement batch and then initiate a payout through the settlement payout endpoint.
-            </span>
-            <code>POST /v1/settlements/{"{id}"}/payout</code>
-          </div>
-        ) : (
-          payouts.items.map((p) => (
-            <article className="list-row" key={p.id}>
-              <div>
-                <div className="row-title">{p.id}</div>
-                <div className="row-meta">
-                  <span className={statusBadge(p.status)}>{p.status}</span>
-                  {p.approval_status ? <span>{p.approval_status}</span> : null}
-                  <span>Settlement: {p.settlement_id}</span>
-                  {p.beneficiary_id ? <span>Beneficiary: {p.beneficiary_id}</span> : null}
-                  {p.bank_reference && <span>Ref: {p.bank_reference}</span>}
-                  {p.failure_reason && (
-                    <span className="badge-error">{p.failure_reason}</span>
-                  )}
-                  <span>{formatTime(p.created_at)}</span>
-                </div>
-              </div>
-              <div className="row-actions">
-                <div className="amount-pill">{formatMoney(p.amount, p.currency)}</div>
-                {p.approval_status === "pending" ? (
-                  <>
-                    <form action={`/api/proxy/v1/payouts/${p.id}/approve`} method="POST">
-                      <input type="hidden" name="_redirect" value="/payouts" />
-                      <button className="ghost-button" type="submit">Approve</button>
-                    </form>
-                    <form action={`/api/proxy/v1/payouts/${p.id}/reject`} method="POST">
-                      <input type="hidden" name="_redirect" value="/payouts" />
-                      <button className="ghost-button" type="submit">Reject</button>
-                    </form>
-                  </>
-                ) : null}
-              </div>
-            </article>
-          ))
-        )}
-      </div>
+      <PayoutApprovalManager items={payouts.items} />
     </section>
   );
 }

--- a/dashboard/app/risk/page.tsx
+++ b/dashboard/app/risk/page.tsx
@@ -1,11 +1,5 @@
 import { getRiskEvents, requireViewer } from "../../lib/api";
-import { formatTime } from "../../lib/types";
-
-function actionBadge(action: string) {
-  if (action === "block") return "badge-error";
-  if (action === "hold") return "badge-warning";
-  return "badge-success";
-}
+import RiskQueueManager from "../../components/risk-queue-manager";
 
 export default async function RiskEventsPage() {
   const viewer = await requireViewer();
@@ -36,70 +30,7 @@ export default async function RiskEventsPage() {
           </div>
         </div>
       </div>
-      <div className="list-card">
-        <div className="section-head">
-          <div>
-            <h2>Event queue</h2>
-            <div className="section-kicker">Action, score, triggered rules, and resolution state</div>
-          </div>
-        </div>
-        {events.items.length === 0 ? (
-          <div className="empty-state">
-            <strong>No risk events recorded</strong>
-            <span className="muted">The fraud and policy engine has not raised any merchant events yet.</span>
-          </div>
-        ) : (
-          events.items.map((ev) => (
-            <article className="list-row" key={ev.id}>
-              <div>
-                <div className="row-title">{ev.payment_id}</div>
-                <div className="row-meta">
-                  <span className={actionBadge(ev.action)}>{ev.action}</span>
-                  <span>score: {ev.score}</span>
-                  {ev.review_status ? <span>{ev.review_status}</span> : null}
-                  {ev.assigned_to ? <span>assigned to {ev.assigned_to}</span> : null}
-                  {ev.manual_decision ? <span>decision: {ev.manual_decision}</span> : null}
-                  {ev.triggered_rules?.length > 0 && (
-                    <span>{ev.triggered_rules.join(", ")}</span>
-                  )}
-                  {ev.resolved && (
-                    <span className="badge-success">resolved</span>
-                  )}
-                  <span>{formatTime(ev.created_at)}</span>
-                </div>
-                {ev.review_notes ? <div className="muted">{ev.review_notes}</div> : null}
-              </div>
-              <div className="row-actions">
-                <div className="amount-pill">Score: {ev.score}</div>
-                {!ev.assigned_to ? (
-                  <form action={`/api/proxy/v1/risk/events/${ev.id}/assign`} method="POST">
-                    <input type="hidden" name="_redirect" value="/risk" />
-                    <button className="ghost-button" type="submit">Assign</button>
-                  </form>
-                ) : null}
-                {!ev.resolved ? (
-                  <>
-                    <form action={`/api/proxy/v1/risk/events/${ev.id}/review`} method="POST">
-                      <input type="hidden" name="_redirect" value="/risk" />
-                      <input type="hidden" name="decision" value="approve" />
-                      <button className="ghost-button" type="submit">Approve</button>
-                    </form>
-                    <form action={`/api/proxy/v1/risk/events/${ev.id}/review`} method="POST">
-                      <input type="hidden" name="_redirect" value="/risk" />
-                      <input type="hidden" name="decision" value="block" />
-                      <button className="ghost-button" type="submit">Block</button>
-                    </form>
-                    <form action={`/api/proxy/v1/risk/events/${ev.id}/resolve`} method="POST">
-                      <input type="hidden" name="_redirect" value="/risk" />
-                      <button className="ghost-button" type="submit">Resolve</button>
-                    </form>
-                  </>
-                ) : null}
-              </div>
-            </article>
-          ))
-        )}
-      </div>
+      <RiskQueueManager initialItems={events.items} />
     </section>
   );
 }

--- a/dashboard/components/compliance-ops-console.tsx
+++ b/dashboard/components/compliance-ops-console.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+import type {
+  CapabilityItem,
+  OnboardingApplicationItem,
+} from "../lib/types";
+
+type Props = {
+  merchantID: string;
+  onboarding: OnboardingApplicationItem;
+  capabilities: CapabilityItem[];
+};
+
+type CapabilityStatus = "enabled" | "restricted" | "disabled";
+type OnboardingDecision = "in_review" | "needs_information" | "approved" | "rejected";
+
+export default function ComplianceOpsConsole({ merchantID, onboarding, capabilities }: Props) {
+  const router = useRouter();
+  const [pending, setPending] = useState(false);
+  const [message, setMessage] = useState("");
+  const [reviewState, setReviewState] = useState<OnboardingDecision>("in_review");
+  const [reviewNotes, setReviewNotes] = useState("");
+
+  async function run(path: string, body: unknown, success: string) {
+    setPending(true);
+    setMessage("");
+    try {
+      const response = await fetch(`/api/proxy${path}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        setMessage((data as { error?: { description?: string } }).error?.description ?? "Action failed");
+        return false;
+      }
+      setMessage(success);
+      router.refresh();
+      return true;
+    } catch {
+      setMessage("Network error while updating compliance state.");
+      return false;
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function reviewOnboarding() {
+    await run(
+      "/v1/merchants/me/onboarding/review",
+      {
+        merchant_id: merchantID,
+        state: reviewState,
+        reviewer_notes: reviewNotes,
+      },
+      "Onboarding review updated.",
+    );
+  }
+
+  async function setCapability(item: CapabilityItem, nextStatus: CapabilityStatus) {
+    const reason =
+      nextStatus === "enabled"
+        ? "operator enabled capability from dashboard"
+        : "operator restricted capability from dashboard";
+    await run(
+      "/v1/merchants/me/capabilities",
+      {
+        items: [
+          {
+            capability_code: item.capability_code,
+            status: nextStatus,
+            reason,
+          },
+        ],
+      },
+      `Capability ${item.capability_code} updated.`,
+    );
+  }
+
+  return (
+    <div className="detail-grid">
+      <div className="detail-card">
+        <div className="section-head">
+          <div>
+            <h2>Review decision</h2>
+            <div className="section-kicker">Move the merchant into review, request more information, approve, or reject.</div>
+          </div>
+        </div>
+        <div className="stack" style={{ marginTop: "16px" }}>
+          <div className="inline-form">
+            <label>
+              Decision
+              <select value={reviewState} onChange={(event) => setReviewState(event.target.value as OnboardingDecision)}>
+                <option value="in_review">in_review</option>
+                <option value="needs_information">needs_information</option>
+                <option value="approved">approved</option>
+                <option value="rejected">rejected</option>
+              </select>
+            </label>
+            <label style={{ minWidth: "320px" }}>
+              Reviewer notes
+              <input
+                type="text"
+                value={reviewNotes}
+                onChange={(event) => setReviewNotes(event.target.value)}
+                placeholder="Explain the operator decision"
+              />
+            </label>
+          </div>
+          <div className="hero-actions">
+            <button className="primary-button" type="button" disabled={pending} onClick={reviewOnboarding}>
+              {pending ? "Updating..." : "Apply review decision"}
+            </button>
+          </div>
+        </div>
+      </div>
+
+      <div className="detail-card">
+        <div className="section-head">
+          <div>
+            <h2>Capability controls</h2>
+            <div className="section-kicker">Enable or restrict merchant live capabilities from the same review surface.</div>
+          </div>
+        </div>
+        <div className="stack" style={{ marginTop: "16px" }}>
+          {capabilities.map((item) => (
+            <div className="list-row" key={item.id}>
+              <div>
+                <div className="row-title">{item.capability_code}</div>
+                <div className="row-meta">
+                  <span className={item.status === "enabled" ? "badge-success" : "badge-warning"}>{item.status}</span>
+                  {item.reason ? <span>{item.reason}</span> : null}
+                </div>
+              </div>
+              <div className="row-actions">
+                <button
+                  className="ghost-button"
+                  type="button"
+                  disabled={pending || item.status === "enabled"}
+                  onClick={() => setCapability(item, "enabled")}
+                >
+                  Enable
+                </button>
+                <button
+                  className="ghost-button"
+                  type="button"
+                  disabled={pending || item.status === "restricted"}
+                  onClick={() => setCapability(item, "restricted")}
+                >
+                  Restrict
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {message ? <p className={`notice ${message.includes("failed") || message.includes("error") ? "error" : "success"}`}>{message}</p> : null}
+    </div>
+  );
+}

--- a/dashboard/components/nav.tsx
+++ b/dashboard/components/nav.tsx
@@ -9,6 +9,7 @@ const links = [
   ["/overview", "Overview"],
   ["/orders", "Orders"],
   ["/compliance", "Compliance"],
+  ["/mandates", "Mandates"],
   ["/webhooks", "Webhooks"],
   ["/settlements", "Settlements"],
   ["/payouts", "Payouts"],

--- a/dashboard/components/payout-approval-manager.tsx
+++ b/dashboard/components/payout-approval-manager.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { formatMoney, formatTime, type PayoutItem } from "../lib/types";
+
+type SavedView = {
+  name: string;
+  query: string;
+  approval: string;
+  status: string;
+};
+
+const storageKey = "paygate:payout-saved-views";
+
+function statusBadge(status: string) {
+  switch (status) {
+    case "completed":
+      return "badge-success";
+    case "failed":
+    case "reversed":
+      return "badge-error";
+    case "processing":
+    case "returned":
+      return "badge-warning";
+    default:
+      return "badge-neutral";
+  }
+}
+
+export default function PayoutApprovalManager({ items }: { items: PayoutItem[] }) {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [approval, setApproval] = useState("pending");
+  const [status, setStatus] = useState("all");
+  const [selected, setSelected] = useState<string[]>([]);
+  const [savedViews, setSavedViews] = useState<SavedView[]>([]);
+  const [pending, setPending] = useState(false);
+  const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(storageKey);
+      if (!raw) return;
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        setSavedViews(parsed);
+      }
+    } catch {
+      return;
+    }
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem(storageKey, JSON.stringify(savedViews));
+  }, [savedViews]);
+
+  const visibleItems = useMemo(() => {
+    const lowered = query.trim().toLowerCase();
+    return items.filter((item) => {
+      if (approval !== "all" && (item.approval_status || "none") !== approval) return false;
+      if (status !== "all" && item.status !== status) return false;
+      if (!lowered) return true;
+      return [item.id, item.settlement_id, item.beneficiary_id, item.bank_reference, item.failure_reason]
+        .filter(Boolean)
+        .some((value) => String(value).toLowerCase().includes(lowered));
+    });
+  }, [approval, items, query, status]);
+
+  async function run(path: string) {
+    const response = await fetch(`/api/proxy${path}`, { method: "POST" });
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      throw new Error((data as { error?: { description?: string } }).error?.description ?? "Payout action failed");
+    }
+  }
+
+  async function bulk(decision: "approve" | "reject") {
+    setPending(true);
+    setMessage("");
+    try {
+      for (const id of selected) {
+        await run(`/v1/payouts/${id}/${decision}`);
+      }
+      setSelected([]);
+      setMessage(`${decision === "approve" ? "Approved" : "Rejected"} ${selected.length} payout(s).`);
+      router.refresh();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Bulk payout action failed");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  function saveView() {
+    const name = window.prompt("Saved view name");
+    if (!name) return;
+    setSavedViews((current) => [...current, { name, query, approval, status }]);
+  }
+
+  function applyView(view: SavedView) {
+    setQuery(view.query);
+    setApproval(view.approval);
+    setStatus(view.status);
+  }
+
+  function toggle(id: string) {
+    setSelected((current) => (current.includes(id) ? current.filter((item) => item !== id) : [...current, id]));
+  }
+
+  return (
+    <div className="stack">
+      <div className="detail-card">
+        <div className="section-head">
+          <div>
+            <h2>Approval workbench</h2>
+            <div className="section-kicker">Filter the queue, save repeated views, and approve or reject pending payouts in bulk.</div>
+          </div>
+        </div>
+        <div className="stack" style={{ marginTop: "16px" }}>
+          <div className="inline-form">
+            <label style={{ minWidth: "220px" }}>
+              Search
+              <input value={query} onChange={(event) => setQuery(event.target.value)} type="text" placeholder="payout, settlement, beneficiary" />
+            </label>
+            <label>
+              Approval
+              <select value={approval} onChange={(event) => setApproval(event.target.value)}>
+                <option value="pending">pending</option>
+                <option value="approved">approved</option>
+                <option value="rejected">rejected</option>
+                <option value="all">all</option>
+              </select>
+            </label>
+            <label>
+              Status
+              <select value={status} onChange={(event) => setStatus(event.target.value)}>
+                <option value="all">all</option>
+                <option value="pending">pending</option>
+                <option value="processing">processing</option>
+                <option value="completed">completed</option>
+                <option value="failed">failed</option>
+                <option value="returned">returned</option>
+              </select>
+            </label>
+          </div>
+          <div className="hero-actions">
+            <button className="ghost-button" type="button" onClick={saveView}>Save current view</button>
+            {savedViews.map((view) => (
+              <button key={view.name} className="filter-pill" type="button" onClick={() => applyView(view)}>
+                {view.name}
+              </button>
+            ))}
+          </div>
+          <div className="hero-actions">
+            <span className="micro-copy">{selected.length} selected</span>
+            <button className="ghost-button" type="button" disabled={pending || selected.length === 0} onClick={() => bulk("approve")}>Approve selected</button>
+            <button className="ghost-button" type="button" disabled={pending || selected.length === 0} onClick={() => bulk("reject")}>Reject selected</button>
+          </div>
+          {message ? <p className={`notice ${message.includes("failed") || message.includes("error") ? "error" : "success"}`}>{message}</p> : null}
+        </div>
+      </div>
+
+      <div className="list-card">
+        {visibleItems.length === 0 ? (
+          <div className="empty-state">
+            <strong>No payouts match this view</strong>
+            <span className="muted">Adjust approval or status filters to expand the queue.</span>
+          </div>
+        ) : (
+          visibleItems.map((payout) => (
+            <article className="list-row" key={payout.id}>
+              <div className="row-actions">
+                <input
+                  type="checkbox"
+                  checked={selected.includes(payout.id)}
+                  onChange={() => toggle(payout.id)}
+                  aria-label={`Select ${payout.id}`}
+                  disabled={payout.approval_status !== "pending"}
+                />
+              </div>
+              <div style={{ flex: 1 }}>
+                <div className="row-title">{payout.id}</div>
+                <div className="row-meta">
+                  <span className={statusBadge(payout.status)}>{payout.status}</span>
+                  {payout.approval_status ? <span>{payout.approval_status}</span> : null}
+                  <span>Settlement: {payout.settlement_id}</span>
+                  {payout.beneficiary_id ? <span>Beneficiary: {payout.beneficiary_id}</span> : null}
+                  {payout.bank_reference ? <span>Ref: {payout.bank_reference}</span> : null}
+                  <span>{formatTime(payout.created_at)}</span>
+                </div>
+                {payout.failure_reason ? <div className="muted">{payout.failure_reason}</div> : null}
+              </div>
+              <div className="amount-pill">{formatMoney(payout.amount, payout.currency)}</div>
+            </article>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/components/risk-queue-manager.tsx
+++ b/dashboard/components/risk-queue-manager.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+
+import { formatTime, type RiskEventItem } from "../lib/types";
+
+type SavedView = {
+  name: string;
+  query: string;
+  status: string;
+  action: string;
+  assigned: string;
+};
+
+const storageKey = "paygate:risk-saved-views";
+
+function actionBadge(action: string) {
+  if (action === "block") return "badge-error";
+  if (action === "hold") return "badge-warning";
+  return "badge-success";
+}
+
+export default function RiskQueueManager({ initialItems }: { initialItems: RiskEventItem[] }) {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [status, setStatus] = useState("open");
+  const [action, setAction] = useState("all");
+  const [assigned, setAssigned] = useState("all");
+  const [selected, setSelected] = useState<string[]>([]);
+  const [savedViews, setSavedViews] = useState<SavedView[]>([]);
+  const [pending, setPending] = useState(false);
+  const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(storageKey);
+      if (!raw) return;
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        setSavedViews(parsed);
+      }
+    } catch {
+      return;
+    }
+  }, []);
+
+  useEffect(() => {
+    window.localStorage.setItem(storageKey, JSON.stringify(savedViews));
+  }, [savedViews]);
+
+  const visibleItems = useMemo(() => {
+    const lowered = query.trim().toLowerCase();
+    return initialItems.filter((item) => {
+      if (status === "open" && item.resolved) return false;
+      if (status === "resolved" && !item.resolved) return false;
+      if (action !== "all" && item.action !== action) return false;
+      if (assigned === "assigned" && !item.assigned_to) return false;
+      if (assigned === "unassigned" && item.assigned_to) return false;
+      if (!lowered) return true;
+      return [
+        item.id,
+        item.payment_id,
+        item.review_status,
+        item.manual_decision,
+        item.assigned_to,
+        item.triggered_rules.join(" "),
+      ]
+        .filter(Boolean)
+        .some((value) => String(value).toLowerCase().includes(lowered));
+    });
+  }, [action, assigned, initialItems, query, status]);
+
+  async function run(path: string, body?: unknown) {
+    const response = await fetch(`/api/proxy${path}`, {
+      method: "POST",
+      headers: body ? { "Content-Type": "application/json" } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({}));
+      throw new Error((data as { error?: { description?: string } }).error?.description ?? "Queue action failed");
+    }
+  }
+
+  async function bulkReview(decision: "approve" | "block") {
+    setPending(true);
+    setMessage("");
+    try {
+      for (const id of selected) {
+        await run(`/v1/risk/events/${id}/review`, { decision, notes: `bulk ${decision} from dashboard` });
+      }
+      setSelected([]);
+      setMessage(`Applied ${decision} to ${selected.length} risk event(s).`);
+      router.refresh();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Bulk review failed");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function bulkResolve() {
+    setPending(true);
+    setMessage("");
+    try {
+      for (const id of selected) {
+        await run(`/v1/risk/events/${id}/resolve`);
+      }
+      setSelected([]);
+      setMessage(`Resolved ${selected.length} risk event(s).`);
+      router.refresh();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Bulk resolve failed");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  async function bulkAssign() {
+    setPending(true);
+    setMessage("");
+    try {
+      for (const id of selected) {
+        await run(`/v1/risk/events/${id}/assign`, { assigned_to: "dashboard-operator" });
+      }
+      setSelected([]);
+      setMessage(`Assigned ${selected.length} risk event(s).`);
+      router.refresh();
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Bulk assign failed");
+    } finally {
+      setPending(false);
+    }
+  }
+
+  function toggle(id: string) {
+    setSelected((current) => (current.includes(id) ? current.filter((item) => item !== id) : [...current, id]));
+  }
+
+  function saveView() {
+    const name = window.prompt("Saved view name");
+    if (!name) return;
+    setSavedViews((current) => [...current, { name, query, status, action, assigned }]);
+  }
+
+  function applyView(view: SavedView) {
+    setQuery(view.query);
+    setStatus(view.status);
+    setAction(view.action);
+    setAssigned(view.assigned);
+  }
+
+  return (
+    <div className="stack">
+      <div className="detail-card">
+        <div className="section-head">
+          <div>
+            <h2>Queue workbench</h2>
+            <div className="section-kicker">Filter high-volume risk queues, save views, and act on selections in bulk.</div>
+          </div>
+        </div>
+        <div className="stack" style={{ marginTop: "16px" }}>
+          <div className="inline-form">
+            <label style={{ minWidth: "220px" }}>
+              Search
+              <input value={query} onChange={(event) => setQuery(event.target.value)} type="text" placeholder="payment, rule, assignee" />
+            </label>
+            <label>
+              Resolution
+              <select value={status} onChange={(event) => setStatus(event.target.value)}>
+                <option value="open">open</option>
+                <option value="resolved">resolved</option>
+                <option value="all">all</option>
+              </select>
+            </label>
+            <label>
+              Action
+              <select value={action} onChange={(event) => setAction(event.target.value)}>
+                <option value="all">all</option>
+                <option value="allow">allow</option>
+                <option value="hold">hold</option>
+                <option value="block">block</option>
+              </select>
+            </label>
+            <label>
+              Assignment
+              <select value={assigned} onChange={(event) => setAssigned(event.target.value)}>
+                <option value="all">all</option>
+                <option value="assigned">assigned</option>
+                <option value="unassigned">unassigned</option>
+              </select>
+            </label>
+          </div>
+          <div className="hero-actions">
+            <button className="ghost-button" type="button" onClick={saveView}>Save current view</button>
+            {savedViews.map((view) => (
+              <button key={view.name} className="filter-pill" type="button" onClick={() => applyView(view)}>
+                {view.name}
+              </button>
+            ))}
+          </div>
+          <div className="hero-actions">
+            <span className="micro-copy">{selected.length} selected</span>
+            <button className="ghost-button" type="button" disabled={pending || selected.length === 0} onClick={bulkAssign}>Assign</button>
+            <button className="ghost-button" type="button" disabled={pending || selected.length === 0} onClick={() => bulkReview("approve")}>Approve</button>
+            <button className="ghost-button" type="button" disabled={pending || selected.length === 0} onClick={() => bulkReview("block")}>Block</button>
+            <button className="ghost-button" type="button" disabled={pending || selected.length === 0} onClick={bulkResolve}>Resolve</button>
+          </div>
+          {message ? <p className={`notice ${message.includes("failed") || message.includes("error") ? "error" : "success"}`}>{message}</p> : null}
+        </div>
+      </div>
+
+      <div className="list-card">
+        {visibleItems.length === 0 ? (
+          <div className="empty-state">
+            <strong>No risk events match this view</strong>
+            <span className="muted">Broaden the filters or use a different saved view.</span>
+          </div>
+        ) : (
+          visibleItems.map((ev) => (
+            <article className="list-row" key={ev.id}>
+              <div className="row-actions">
+                <input type="checkbox" checked={selected.includes(ev.id)} onChange={() => toggle(ev.id)} aria-label={`Select ${ev.id}`} />
+              </div>
+              <div style={{ flex: 1 }}>
+                <div className="row-title">{ev.payment_id}</div>
+                <div className="row-meta">
+                  <span className={actionBadge(ev.action)}>{ev.action}</span>
+                  <span>score: {ev.score}</span>
+                  {ev.review_status ? <span>{ev.review_status}</span> : null}
+                  {ev.assigned_to ? <span>assigned to {ev.assigned_to}</span> : <span>unassigned</span>}
+                  {ev.manual_decision ? <span>decision: {ev.manual_decision}</span> : null}
+                  {ev.resolved ? <span className="badge-success">resolved</span> : <span className="badge-warning">open</span>}
+                  <span>{formatTime(ev.created_at)}</span>
+                </div>
+                {ev.triggered_rules?.length > 0 ? <div className="muted">{ev.triggered_rules.join(", ")}</div> : null}
+                {ev.review_notes ? <div className="muted">{ev.review_notes}</div> : null}
+              </div>
+              <div className="amount-pill">Score {ev.score}</div>
+            </article>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -31,8 +31,11 @@ import type {
   SettlementItem,
   SettlementLineItem,
   TaxProfileItem,
+  UPIMandateEventItem,
+  UPIMandateItem,
   UPIIntentItem,
   WebhookItem,
+  PrometheusSeriesPoint,
 } from "./types";
 
 type CollectionResponse<T> = {
@@ -146,6 +149,36 @@ export async function getUPIIntent(paymentID: string) {
     throw new Error(`upi intent fetch failed: ${response.status}`);
   }
   return (await response.json()) as UPIIntentItem;
+}
+
+export async function getUPIMandates() {
+  await requireViewer();
+  const response = await apiFetch("/v1/upi-mandates");
+  if (!response.ok) {
+    throw new Error(`upi mandates fetch failed: ${response.status}`);
+  }
+  return (await response.json()) as CollectionResponse<UPIMandateItem>;
+}
+
+export async function getUPIMandate(id: string) {
+  await requireViewer();
+  const response = await apiFetch(`/v1/upi-mandates/${id}`);
+  if (response.status === 404) {
+    notFound();
+  }
+  if (!response.ok) {
+    throw new Error(`upi mandate fetch failed: ${response.status}`);
+  }
+  return (await response.json()) as UPIMandateItem;
+}
+
+export async function getUPIMandateEvents(id: string) {
+  await requireViewer();
+  const response = await apiFetch(`/v1/upi-mandates/${id}/events`);
+  if (!response.ok) {
+    throw new Error(`upi mandate events fetch failed: ${response.status}`);
+  }
+  return (await response.json()) as CollectionResponse<UPIMandateEventItem>;
 }
 
 export async function getAPIKeys() {
@@ -506,5 +539,42 @@ export async function getPrometheusMetricSum(metricName: string): Promise<number
     return found ? sum : null;
   } catch {
     return null;
+  }
+}
+
+export async function getPrometheusMetricSeries(metricName: string): Promise<PrometheusSeriesPoint[]> {
+  try {
+    const res = await fetch(`${getApiBaseUrl()}/metrics`, { cache: "no-store" });
+    if (!res.ok) return [];
+    const text = await res.text();
+    const lines = text.split("\n");
+    const points: PrometheusSeriesPoint[] = [];
+    for (const line of lines) {
+      if (line.startsWith("#") || line.trim() === "") continue;
+      const parts = line.trim().split(/\s+/);
+      if (parts.length < 2) continue;
+      const metric = parts[0];
+      const value = Number(parts[1]);
+      if (Number.isNaN(value)) continue;
+      const braceIdx = metric.indexOf("{");
+      const name = braceIdx === -1 ? metric : metric.slice(0, braceIdx);
+      if (name !== metricName) continue;
+      const labels: Record<string, string> = {};
+      if (braceIdx !== -1 && metric.endsWith("}")) {
+        const body = metric.slice(braceIdx + 1, -1);
+        for (const pair of body.split(",")) {
+          if (!pair) continue;
+          const eqIdx = pair.indexOf("=");
+          if (eqIdx === -1) continue;
+          const key = pair.slice(0, eqIdx);
+          const raw = pair.slice(eqIdx + 1).trim();
+          labels[key] = raw.startsWith("\"") && raw.endsWith("\"") ? raw.slice(1, -1) : raw;
+        }
+      }
+      points.push({ labels, value });
+    }
+    return points;
+  } catch {
+    return [];
   }
 }

--- a/dashboard/lib/types.ts
+++ b/dashboard/lib/types.ts
@@ -33,9 +33,35 @@ export type PaymentItem = {
   captured_at: number;
   authorized_at: number;
   created_at: number;
+  card_challenge?: {
+    entity: string;
+    payment_id: string;
+    session_id: string;
+    status: string;
+    redirect_url: string;
+    expires_at?: number;
+    sandbox_callback_url?: string;
+  };
+  next_action?: {
+    type: string;
+    redirect_url?: string;
+    challenge_session_id?: string;
+    challenge_status?: string;
+    expires_at?: number;
+  };
+  sandbox?: {
+    callback_url?: string;
+  };
 };
 
 export type UPIIntentItem = PaymentItem & {
+  flow_type?: string;
+  mandate_id?: string;
+  qr_mode?: string;
+  qr_payload?: string;
+  qr_image_url?: string;
+  display_name?: string;
+  is_reusable?: boolean;
   vpa: string;
   provider_status: string;
   gateway_reference: string;
@@ -46,10 +72,46 @@ export type UPIIntentItem = PaymentItem & {
   failure_description?: string;
   next_action?: {
     type: string;
-    deep_link: string;
-    intent_uri: string;
+    deep_link?: string;
+    intent_uri?: string;
+    qr_payload?: string;
+    qr_image_url?: string;
+    qr_mode?: string;
     expires_at: number;
   };
+};
+
+export type UPIMandateItem = {
+  id: string;
+  merchant_id: string;
+  customer_id: string;
+  reference: string;
+  display_name: string;
+  vpa: string;
+  amount_limit: number;
+  currency: string;
+  interval_unit: string;
+  interval_count: number;
+  retry_window_hours: number;
+  status: string;
+  approved_at?: number;
+  paused_at?: number;
+  revoked_at?: number;
+  expires_at?: number;
+  created_at: number;
+  updated_at: number;
+};
+
+export type UPIMandateEventItem = {
+  id: string;
+  mandate_id: string;
+  event_type: string;
+  actor_type: string;
+  actor_id: string;
+  reason: string;
+  payment_id: string;
+  metadata?: Record<string, unknown>;
+  created_at: number;
 };
 
 export type APIKeyItem = {
@@ -252,12 +314,12 @@ export type BeneficiaryItem = {
 export type OnboardingApplicationItem = {
   id: string;
   merchant_id: string;
+  state: string;
   legal_name: string;
   business_classification: string;
   registration_number: string;
   tax_identifier: string;
   country_code: string;
-  state: string;
   reviewer_notes: string;
   submitted_at?: number | null;
   reviewed_at?: number | null;
@@ -449,6 +511,11 @@ export type GatewayScenario = {
   decline_code: string;
   active: boolean;
   created_at: number;
+};
+
+export type PrometheusSeriesPoint = {
+  labels: Record<string, string>;
+  value: number;
 };
 
 export function formatMoney(amount: number, currency: string) {

--- a/dashboard/tests/e2e/dashboard-smoke.spec.ts
+++ b/dashboard/tests/e2e/dashboard-smoke.spec.ts
@@ -5,10 +5,12 @@ import { loadSeedData } from "./helpers/seed";
 const pageChecks = [
   { path: "/overview", heading: "Merchant command center." },
   { path: "/orders", heading: "Orders" },
-  { path: "/api-keys", heading: "API Keys" },
+  { path: "/compliance", heading: "Onboarding and controls." },
+  { path: "/api-keys", text: "Create Key" },
   { path: "/webhooks", heading: "Webhooks" },
   { path: "/settlements", heading: "Settlement Reports" },
   { path: "/payouts", heading: "Payouts" },
+  { path: "/reports", heading: "Download center." },
   { path: "/recon", heading: "Reconciliation Control" },
   { path: "/risk", heading: "Risk Events" },
   { path: "/gateway", heading: "Payment Gateway Control Panel" },
@@ -16,7 +18,7 @@ const pageChecks = [
   { path: "/audit", heading: "Audit Log" },
   { path: "/team", heading: "Team" },
   { path: "/disputes", heading: "Disputes" },
-];
+] as const;
 
 const ignoredConsoleErrorPatterns = [
   "Failed to fetch RSC payload",
@@ -47,7 +49,11 @@ test("operator dashboard pages render correctly with seeded data", async ({ page
 
   for (const check of pageChecks) {
     await navigate(check.path);
-    await expect(page.getByRole("heading", { name: check.heading })).toBeVisible();
+    if ("heading" in check) {
+      await expect(page.getByRole("heading", { name: check.heading })).toBeVisible();
+      continue;
+    }
+    await expect(page.getByText(check.text)).toBeVisible();
   }
 
   await navigate(`/orders/${seed.orderID}`);
@@ -74,6 +80,16 @@ test("operator dashboard pages render correctly with seeded data", async ({ page
   await expect(page.getByText("Dispute Detail")).toBeVisible();
   await expect(page.getByText("Case summary")).toBeVisible();
   await expect(page.getByText("Submitted evidence payload")).toBeVisible();
+
+  await navigate("/compliance");
+  await expect(page.getByRole("heading", { name: "Review decision" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Capability controls" })).toBeVisible();
+
+  await navigate("/risk");
+  await expect(page.getByRole("heading", { name: "Queue workbench" })).toBeVisible();
+
+  await navigate("/payouts");
+  await expect(page.getByRole("heading", { name: "Approval workbench" })).toBeVisible();
 
   expect(consoleErrors).toEqual([]);
   expect(pageErrors).toEqual([]);


### PR DESCRIPTION
## Scope
- add operator mandate surfaces
- add compliance reviewer, payout approval, and risk queue workbenches
- align dashboard smoke coverage with the expanded operator surface

## Local validation
- cd dashboard && pnpm build
- cd dashboard && pnpm test:e2e

Closes #530
Closes #498
