### PR TITLE
[#528] Expand SDK contracts and harden integration artifact verification

### DIFF
--- a/postman/PayGate.postman_collection.json
+++ b/postman/PayGate.postman_collection.json
@@ -98,6 +98,21 @@
       }
     },
     {
+      "name": "Create Webhook Subscription",
+      "request": {
+        "method": "POST",
+        "header": [
+          { "key": "Authorization", "value": "{{auth_header}}" },
+          { "key": "Content-Type", "value": "application/json" }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"merchant_id\": \"{{merchant_id}}\",\n  \"url\": \"https://example.com/paygate/webhooks\",\n  \"event_types\": [\"payment.captured\", \"refund.succeeded\"],\n  \"signature_mode\": \"compat\"\n}"
+        },
+        "url": { "raw": "{{api_base_url}}/v1/webhooks", "host": ["{{api_base_url}}"], "path": ["v1", "webhooks"] }
+      }
+    },
+    {
       "name": "Request Reporting Export",
       "request": {
         "method": "POST",

--- a/scripts/test/verify_integrations_artifacts.sh
+++ b/scripts/test/verify_integrations_artifacts.sh
@@ -7,15 +7,21 @@ cd "${ROOT_DIR}"
 
 go test ./sdk/go/paygate
 node --test sdk/js/paygate.test.mjs
+go test -count=1 -tags=integration ./tests/integration/... -run 'TestIntegrationSDKClientsAgainstLiveMux'
 
 (
   cd examples/server-only-go
   go build ./...
 )
 
+go run ./cmd/sandbox-bootstrap -h >/dev/null 2>&1 || true
 node --check examples/hosted-checkout-node/index.mjs
 node --check examples/webhook-consumer/server.mjs
 
 jq empty postman/PayGate.postman_collection.json
 jq empty insomnia/PayGate.json
 jq empty bruno/paygate/bruno.json
+
+jq -e '.item[] | .. | objects | select(.request? and (.request.url.raw // "" | contains("/v1/orders")))' postman/PayGate.postman_collection.json >/dev/null
+jq -e '.item[] | .. | objects | select(.request? and (.request.url.raw // "" | contains("/v1/payments/authorize")))' postman/PayGate.postman_collection.json >/dev/null
+jq -e '.item[] | .. | objects | select(.request? and (.request.url.raw // "" | contains("/v1/webhooks")))' postman/PayGate.postman_collection.json >/dev/null

--- a/sdk/go/paygate/client.go
+++ b/sdk/go/paygate/client.go
@@ -55,6 +55,23 @@ type Refund struct {
 	Reason    string `json:"reason"`
 }
 
+type CardToken struct {
+	ID               string `json:"id"`
+	Brand            string `json:"brand"`
+	Last4            string `json:"last4"`
+	PaymentTokenType string `json:"token_type"`
+	Reusable         bool   `json:"reusable"`
+}
+
+type WebhookSubscription struct {
+	ID            string   `json:"id"`
+	URL           string   `json:"url"`
+	Events        []string `json:"events"`
+	Status        string   `json:"status"`
+	SignatureMode string   `json:"signature_mode"`
+	Secret        string   `json:"secret"`
+}
+
 func (c *Client) CreateOrder(ctx context.Context, payload map[string]any, idempotencyKey string) (Order, error) {
 	var out Order
 	if err := c.doJSON(ctx, http.MethodPost, "/v1/orders", payload, idempotencyKey, &out); err != nil {
@@ -67,6 +84,22 @@ func (c *Client) CreatePayment(ctx context.Context, payload map[string]any, idem
 	var out Payment
 	if err := c.doJSON(ctx, http.MethodPost, "/v1/payments/authorize", payload, idempotencyKey, &out); err != nil {
 		return Payment{}, err
+	}
+	return out, nil
+}
+
+func (c *Client) CreateCardToken(ctx context.Context, payload map[string]any) (CardToken, error) {
+	var out CardToken
+	if err := c.doJSON(ctx, http.MethodPost, "/v1/card-tokens", payload, "", &out); err != nil {
+		return CardToken{}, err
+	}
+	return out, nil
+}
+
+func (c *Client) CreateWebhookSubscription(ctx context.Context, payload map[string]any) (WebhookSubscription, error) {
+	var out WebhookSubscription
+	if err := c.doJSON(ctx, http.MethodPost, "/v1/webhooks", payload, "", &out); err != nil {
+		return WebhookSubscription{}, err
 	}
 	return out, nil
 }

--- a/sdk/go/paygate/client_test.go
+++ b/sdk/go/paygate/client_test.go
@@ -48,3 +48,48 @@ func TestVerifyWebhookSignature(t *testing.T) {
 		t.Fatal("expected body hex for sanity check")
 	}
 }
+
+func TestCreateCardTokenAndWebhookSubscription(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/v1/card-tokens":
+			if r.Method != http.MethodPost {
+				t.Fatalf("unexpected method %s", r.Method)
+			}
+			_ = json.NewEncoder(w).Encode(CardToken{ID: "ctok_123", Brand: "visa", Last4: "1111", PaymentTokenType: "single_use", Reusable: false})
+		case "/v1/webhooks":
+			if r.Method != http.MethodPost {
+				t.Fatalf("unexpected method %s", r.Method)
+			}
+			_ = json.NewEncoder(w).Encode(WebhookSubscription{ID: "wh_123", URL: "https://example.com/hook", Status: "active", SignatureMode: "compat"})
+		default:
+			t.Fatalf("unexpected path %s", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := New(server.URL, "key", "secret")
+	cardToken, err := client.CreateCardToken(context.Background(), map[string]any{
+		"card_number": "4111111111111111",
+		"exp_month":   12,
+		"exp_year":    2030,
+	})
+	if err != nil {
+		t.Fatalf("create card token: %v", err)
+	}
+	if cardToken.ID == "" {
+		t.Fatal("expected card token id")
+	}
+
+	sub, err := client.CreateWebhookSubscription(context.Background(), map[string]any{
+		"url":            "https://example.com/hook",
+		"events":         []string{"payment.captured"},
+		"signature_mode": "compat",
+	})
+	if err != nil {
+		t.Fatalf("create webhook subscription: %v", err)
+	}
+	if sub.ID == "" {
+		t.Fatal("expected webhook subscription id")
+	}
+}

--- a/sdk/js/paygate.js
+++ b/sdk/js/paygate.js
@@ -64,6 +64,18 @@ export function createClient({ baseUrl, keyId, keySecret, fetchImpl = fetch }) {
         body: JSON.stringify(payload),
       });
     },
+    createCardToken(payload) {
+      return request("/v1/card-tokens", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+    },
+    createWebhookSubscription(payload) {
+      return request("/v1/webhooks", {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+    },
     capturePayment(paymentId, payload = {}, idempotencyKey) {
       return request(`/v1/payments/${paymentId}/capture`, {
         method: "POST",

--- a/sdk/js/paygate.test.mjs
+++ b/sdk/js/paygate.test.mjs
@@ -29,3 +29,28 @@ test("verifyWebhookSignature verifies hmac", async () => {
     signature: "16abb10adb33ff9cff34f6a57fc2c0b902c11ea19fe73dae86f2940c235e7ed5",
   }), true);
 });
+
+test("client can create card tokens and webhook subscriptions", async () => {
+  const paths = [];
+  const client = createClient({
+    baseUrl: "http://example.test",
+    keyId: "key",
+    keySecret: "secret",
+    fetchImpl: async (url, init) => {
+      paths.push(new URL(url).pathname);
+      if (url.endsWith("/v1/card-tokens")) {
+        return new Response(JSON.stringify({ id: "ctok_1", brand: "visa", last4: "1111", token_type: "single_use", reusable: false }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      if (url.endsWith("/v1/webhooks")) {
+        return new Response(JSON.stringify({ id: "wh_1", url: "https://example.test/hook", status: "active", signature_mode: "compat" }), { status: 200, headers: { "Content-Type": "application/json" } });
+      }
+      throw new Error(`unexpected request ${url}`);
+    },
+  });
+
+  const token = await client.createCardToken({ card_number: "4111111111111111", exp_month: 12, exp_year: 2030 });
+  assert.equal(token.id, "ctok_1");
+  const webhook = await client.createWebhookSubscription({ url: "https://example.test/hook", events: ["payment.captured"] });
+  assert.equal(webhook.id, "wh_1");
+  assert.deepEqual(paths, ["/v1/card-tokens", "/v1/webhooks"]);
+});

--- a/tests/integration/sdk_contract_integration_test.go
+++ b/tests/integration/sdk_contract_integration_test.go
@@ -1,0 +1,100 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"encoding/base64"
+	"net/http/httptest"
+	"os/exec"
+	"testing"
+
+	"github.com/sanskarpan/PayGate/internal/merchant"
+	sdk "github.com/sanskarpan/PayGate/sdk/go/paygate"
+)
+
+func TestIntegrationSDKClientsAgainstLiveMux(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	mux, merchantSvc, _, _ := buildGatewayMux(db)
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	ctx := context.Background()
+	createdMerchant, err := merchantSvc.CreateMerchant(ctx, merchant.CreateMerchantInput{
+		Name: "SDK Merchant", Email: uniqueTestEmail(t, "sdk"), BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+	key, err := merchantSvc.CreateAPIKey(ctx, createdMerchant.ID, merchant.CreateAPIKeyInput{
+		Mode: merchant.APIKeyModeTest, Scope: merchant.APIKeyScopeWrite,
+	})
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+
+	client := sdk.New(server.URL, key.KeyID, key.KeySecret)
+	order, err := client.CreateOrder(ctx, map[string]any{
+		"amount":   4200,
+		"currency": "INR",
+		"receipt":  "sdk-go-live",
+	}, "sdk-go-order")
+	if err != nil {
+		t.Fatalf("go sdk create order: %v", err)
+	}
+	if order.ID == "" {
+		t.Fatal("expected order id from go sdk")
+	}
+
+	cardToken, err := client.CreateCardToken(ctx, map[string]any{
+		"card_number":     "4111111111111111",
+		"exp_month":       12,
+		"exp_year":        2030,
+		"cardholder_name": "SDK Go",
+		"reusable":        false,
+	})
+	if err != nil {
+		t.Fatalf("go sdk create card token: %v", err)
+	}
+	if cardToken.ID == "" {
+		t.Fatal("expected card token id from go sdk")
+	}
+
+	sub, err := client.CreateWebhookSubscription(ctx, map[string]any{
+		"url":            "https://example.test/sdk-hook",
+		"events":         []string{"payment.captured"},
+		"signature_mode": "compat",
+	})
+	if err != nil {
+		t.Fatalf("go sdk create webhook: %v", err)
+	}
+	if sub.ID == "" {
+		t.Fatal("expected webhook subscription id from go sdk")
+	}
+
+	auth := base64.StdEncoding.EncodeToString([]byte(key.KeyID + ":" + key.KeySecret))
+	js := `
+import { createClient } from './sdk/js/paygate.js';
+const client = createClient({ baseUrl: process.env.SDK_BASE_URL, keyId: process.env.SDK_KEY_ID, keySecret: process.env.SDK_KEY_SECRET });
+const order = await client.createOrder({ amount: 4300, currency: 'INR', receipt: 'sdk-js-live' }, 'sdk-js-order');
+if (!order.id) throw new Error('missing order id');
+const token = await client.createCardToken({ card_number: '4111111111111111', exp_month: 12, exp_year: 2030, cardholder_name: 'SDK JS', reusable: false });
+if (!token.id) throw new Error('missing card token id');
+const webhook = await client.createWebhookSubscription({ url: 'https://example.test/sdk-js-hook', events: ['payment.captured'], signature_mode: 'compat' });
+if (!webhook.id) throw new Error('missing webhook id');
+`
+	cmd := exec.Command("node", "--input-type=module", "-e", js)
+	cmd.Dir = "../.."
+	cmd.Env = append(cmd.Environ(),
+		"SDK_BASE_URL="+server.URL,
+		"SDK_KEY_ID="+key.KeyID,
+		"SDK_KEY_SECRET="+key.KeySecret,
+		"SDK_AUTH=Basic "+auth,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("js sdk live contract test failed: %v\n%s", err, out)
+	}
+}


### PR DESCRIPTION
## Scope
- expand Go and JS SDK contracts
- add live SDK contract integration coverage
- harden Postman and artifact verification coverage

## Local validation
- ./scripts/test/verify_integrations_artifacts.sh
- go test -count=1 -tags=integration ./tests/integration/...

Closes #528
