### PR TITLE
[#533] Align OpenAPI contracts for the new payment and webhook surfaces

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -608,6 +608,9 @@ components:
         events:
           type: array
           items: { type: string }
+        signature_mode:
+          type: string
+          enum: [compat, hmac_sha256, http_message_signatures]
     CreateDisputeRequest:
       type: object
       required: [payment_id, reason, amount, currency]


### PR DESCRIPTION
## Scope
- align OpenAPI surface with the newly added payment and webhook capabilities

## Local validation
- go test -count=1 -tags=integration ./tests/integration/...
- cd dashboard && pnpm build

Closes #533
