### PR TITLE
[#550] Wire final routes and add integration regression coverage

### DIFF
--- a/cmd/api-gateway/main.go
+++ b/cmd/api-gateway/main.go
@@ -102,9 +102,12 @@ func run() error {
 
 	scenarioStore := gateway.NewScenarioStore(db)
 	methodStore := gateway.NewMethodConfigStore(db)
-	gatewayClient := gateway.NewSimulatorWithStores(scenarioStore, methodStore)
+	routingStore := gateway.NewRoutingPolicyStore(db)
+	simulatorGateway := gateway.NewSimulatorWithStores(scenarioStore, methodStore)
+	gatewayClient := gateway.NewRouter(routingStore, simulatorGateway)
 	gatewayAdminHandler := gateway.NewAdminHandler(scenarioStore)
 	methodHandler := gateway.NewMethodHandler(methodStore)
+	routingHandler := gateway.NewRoutingHandler(routingStore)
 	cardTokenRepo := tokenization.NewPostgresRepository(db)
 	cardTokenSvc := tokenization.NewService(cardTokenRepo)
 	vpaVerifySvc := upiverify.NewService(upiverify.NewPostgresRepository(db), upiverify.NewSimulatorProvider())
@@ -262,6 +265,7 @@ func run() error {
 	orderHandler.RegisterRoutesWithAuth(mux, protected)
 	cardTokenHandler.RegisterRoutesWithAuth(mux, protected)
 	billingHandler.RegisterRoutesWithAuth(mux, protected)
+	billingHandler.RegisterPublicRoutes(mux)
 	paymentHandler.RegisterRoutesWithAuth(mux, protected)
 	refundHandler.RegisterRoutesWithAuth(mux, protected)
 	ledgerHoldHandler.RegisterRoutesWithAuth(mux, protected)
@@ -296,6 +300,9 @@ func run() error {
 		return authMw.RequireScope(merchant.APIKeyScopeAdmin, next)
 	})
 	methodHandler.RegisterRoutesWithAuth(mux, func(next http.Handler) http.Handler {
+		return authMw.RequireScope(merchant.APIKeyScopeAdmin, next)
+	})
+	routingHandler.RegisterRoutesWithAuth(mux, func(next http.Handler) http.Handler {
 		return authMw.RequireScope(merchant.APIKeyScopeAdmin, next)
 	})
 

--- a/tests/integration/backend_hardening_integration_test.go
+++ b/tests/integration/backend_hardening_integration_test.go
@@ -309,7 +309,8 @@ func buildGatewayMux(db *pgxpool.Pool) (*http.ServeMux, *merchant.Service, *orde
 	vpaVerifySvc := upiverify.NewService(upiverify.NewPostgresRepository(db), upiverify.NewSimulatorProvider())
 	scenarioStore := gateway.NewScenarioStore(db)
 	methodStore := gateway.NewMethodConfigStore(db)
-	paymentSvc := payment.NewService(payment.NewPostgresRepository(db, ledgerSvc, orderSvc), gateway.NewSimulatorWithStores(scenarioStore, methodStore), payment.WithCardTokenAuthorizer(cardTokenSvc))
+	routingStore := gateway.NewRoutingPolicyStore(db)
+	paymentSvc := payment.NewService(payment.NewPostgresRepository(db, ledgerSvc, orderSvc), gateway.NewRouter(routingStore, gateway.NewSimulatorWithStores(scenarioStore, methodStore)), payment.WithCardTokenAuthorizer(cardTokenSvc))
 	billingSvc := billing.NewService(billing.NewPostgresRepository(db), orderSvc, paymentSvc, cardTokenSvc, billing.WithVPAVerifier(vpaVerifySvc))
 	refundSvc := refund.NewService(refund.NewPostgresRepository(db, ledgerSvc))
 	webhookSvc := webhook.NewService(webhook.NewPostgresRepository(db))
@@ -346,6 +347,7 @@ func buildGatewayMux(db *pgxpool.Pool) (*http.ServeMux, *merchant.Service, *orde
 	reportingHandler := reporting.NewHandler(reportingSvc)
 	retentionHandler := retention.NewHandler(retentionSvc)
 	gatewayAdminHandler := gateway.NewAdminHandler(scenarioStore)
+	routingHandler := gateway.NewRoutingHandler(routingStore)
 
 	protected := func(scope merchant.APIKeyScope, next http.Handler) http.Handler {
 		return authMw.RequireScope(scope, idemMw.Wrap(next))
@@ -369,6 +371,7 @@ func buildGatewayMux(db *pgxpool.Pool) (*http.ServeMux, *merchant.Service, *orde
 	orderHandler.RegisterRoutesWithAuth(mux, protected)
 	cardTokenHandler.RegisterRoutesWithAuth(mux, protected)
 	billingHandler.RegisterRoutesWithAuth(mux, protected)
+	billingHandler.RegisterPublicRoutes(mux)
 	paymentHandler.RegisterRoutesWithAuth(mux, protected)
 	refundHandler.RegisterRoutesWithAuth(mux, protected)
 	settlementHandler.RegisterRoutesWithAuth(mux, protected)
@@ -385,6 +388,9 @@ func buildGatewayMux(db *pgxpool.Pool) (*http.ServeMux, *merchant.Service, *orde
 	reportingHandler.RegisterRoutesWithAuth(mux, protected)
 	retentionHandler.RegisterRoutesWithAuth(mux, protected)
 	gatewayAdminHandler.RegisterRoutesWithAuth(mux, func(next http.Handler) http.Handler {
+		return authMw.RequireScope(merchant.APIKeyScopeAdmin, next)
+	})
+	routingHandler.RegisterRoutesWithAuth(mux, func(next http.Handler) http.Handler {
 		return authMw.RequireScope(merchant.APIKeyScopeAdmin, next)
 	})
 	mux.Handle("GET /v1/merchants/me", authMw.RequireScope(merchant.APIKeyScopeRead, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/tests/integration/manual_invoice_integration_test.go
+++ b/tests/integration/manual_invoice_integration_test.go
@@ -1,0 +1,96 @@
+//go:build integration
+
+package integration
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/sanskarpan/PayGate/internal/merchant"
+)
+
+func TestIntegrationManualInvoiceSurfaceAndStatusDerivation(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	mux, merchantSvc, _, _ := buildGatewayMux(db)
+	createdMerchant, err := merchantSvc.CreateMerchant(t.Context(), merchant.CreateMerchantInput{
+		Name:         "Manual Invoice Merchant",
+		Email:        uniqueTestEmail(t, "manual-invoice"),
+		BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+	key, err := merchantSvc.CreateAPIKey(t.Context(), createdMerchant.ID, merchant.CreateAPIKeyInput{
+		Mode:  merchant.APIKeyModeTest,
+		Scope: merchant.APIKeyScopeAdmin,
+	})
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+	authHeader := basicAuth(key.KeyID, key.KeySecret)
+
+	customerResp := sendJSON(t, mux, http.MethodPost, "/v1/customers", authHeader, map[string]any{
+		"name":  "Invoice Customer",
+		"email": "invoice.customer@test.local",
+	}, http.StatusCreated)
+	customerID := mustString(t, customerResp, "id")
+
+	invoiceResp := sendJSON(t, mux, http.MethodPost, "/v1/invoices", authHeader, map[string]any{
+		"customer_id":        customerID,
+		"amount":             5100,
+		"currency":           "INR",
+		"description":        "April consulting invoice",
+		"external_reference": "inv-apr-001",
+		"collection_surface": "payment_link",
+		"due_at":             time.Now().UTC().Add(24 * time.Hour).Unix(),
+	}, http.StatusCreated)
+	invoiceID := mustString(t, invoiceResp, "id")
+	orderID := mustString(t, invoiceResp, "order_id")
+	if mustString(t, invoiceResp, "payment_link_id") == "" {
+		t.Fatalf("expected payment_link_id on invoice, got %#v", invoiceResp)
+	}
+
+	remindedResp := sendJSON(t, mux, http.MethodPost, "/v1/invoices/"+invoiceID+"/send-reminder", authHeader, map[string]any{}, http.StatusOK)
+	if got := remindedResp["reminder_count"].(float64); got != 1 {
+		t.Fatalf("expected reminder_count 1, got %#v", remindedResp["reminder_count"])
+	}
+
+	cardTokenID := createCardTokenViaMux(t, mux, authHeader, false)
+	paymentResp := sendJSON(t, mux, http.MethodPost, "/v1/payments/authorize", authHeader, map[string]any{
+		"order_id":                orderID,
+		"amount":                  5100,
+		"currency":                "INR",
+		"method":                  "card",
+		"payment_method_token_id": cardTokenID,
+	}, http.StatusCreated)
+	captureResp := sendJSON(t, mux, http.MethodPost, "/v1/payments/"+mustString(t, paymentResp, "id")+"/capture", authHeader, map[string]any{
+		"amount": 5100,
+	}, http.StatusOK)
+
+	paidInvoice := sendJSON(t, mux, http.MethodGet, "/v1/invoices/"+invoiceID, authHeader, nil, http.StatusOK)
+	if got := mustString(t, paidInvoice, "status"); got != "paid" {
+		t.Fatalf("expected paid invoice status, got %s", got)
+	}
+	if got := mustString(t, paidInvoice, "payment_id"); got != mustString(t, captureResp, "id") {
+		t.Fatalf("expected derived payment_id %s, got %s", mustString(t, captureResp, "id"), got)
+	}
+
+	overdueResp := sendJSON(t, mux, http.MethodPost, "/v1/invoices", authHeader, map[string]any{
+		"customer_id":        customerID,
+		"amount":             2200,
+		"currency":           "INR",
+		"description":        "Overdue bank collect invoice",
+		"external_reference": "inv-od-001",
+		"collection_surface": "virtual_account",
+		"due_at":             time.Now().UTC().Add(-24 * time.Hour).Unix(),
+	}, http.StatusCreated)
+	if mustString(t, overdueResp, "virtual_account_id") == "" {
+		t.Fatalf("expected virtual_account_id on overdue invoice, got %#v", overdueResp)
+	}
+	if overdue, ok := overdueResp["overdue"].(bool); !ok || !overdue {
+		t.Fatalf("expected overdue invoice, got %#v", overdueResp["overdue"])
+	}
+}

--- a/tests/integration/open_issue_batch_one_integration_test.go
+++ b/tests/integration/open_issue_batch_one_integration_test.go
@@ -1,0 +1,160 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/sanskarpan/PayGate/internal/merchant"
+	"github.com/sanskarpan/PayGate/internal/order"
+	"github.com/sanskarpan/PayGate/internal/payment"
+)
+
+func TestIntegrationSavedCardsMetadataAndCustomerDefault(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	mux, merchantSvc, orderSvc, paymentSvc := buildGatewayMux(db)
+	ctx := context.Background()
+
+	m, err := merchantSvc.CreateMerchant(ctx, merchant.CreateMerchantInput{
+		Name: "Saved Card Merchant", Email: uniqueTestEmail(t, "saved-card"), BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+	key, err := merchantSvc.CreateAPIKey(ctx, m.ID, merchant.CreateAPIKeyInput{
+		Mode: merchant.APIKeyModeTest, Scope: merchant.APIKeyScopeAdmin,
+	})
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+	authHeader := basicAuth(key.KeyID, key.KeySecret)
+
+	customer := sendJSON(t, mux, http.MethodPost, "/v1/customers", authHeader, map[string]any{
+		"name": "Card Owner",
+	}, http.StatusCreated)
+	customerID := mustString(t, customer, "id")
+
+	expires := time.Now().UTC().AddDate(3, 0, 0)
+	token := sendJSON(t, mux, http.MethodPost, "/v1/card-tokens", authHeader, map[string]any{
+		"card_number":       "5555555555554444",
+		"exp_month":         int(expires.Month()),
+		"exp_year":          expires.Year(),
+		"reusable":          true,
+		"customer_ref":      customerID,
+		"network_reference": "ntok_live_12345",
+	}, http.StatusCreated)
+	tokenID := mustString(t, token, "id")
+	if got := token["issuer_name"]; got == "" {
+		t.Fatalf("expected issuer_name in token response, got %#v", token)
+	}
+	if got := token["network_token_type"]; got != "network_token" {
+		t.Fatalf("expected network_token_type=network_token, got %v", got)
+	}
+
+	list := sendJSON(t, mux, http.MethodGet, "/v1/card-tokens?customer_ref="+customerID, authHeader, nil, http.StatusOK)
+	if int(list["count"].(float64)) != 1 {
+		t.Fatalf("expected one saved card, got %#v", list)
+	}
+
+	updatedCustomer := sendJSON(t, mux, http.MethodPatch, "/v1/customers/"+customerID, authHeader, map[string]any{
+		"name":                     "Card Owner",
+		"default_payment_token_id": tokenID,
+	}, http.StatusOK)
+	if got := updatedCustomer["default_payment_token_id"]; got != tokenID {
+		t.Fatalf("expected default token id %s, got %v", tokenID, got)
+	}
+
+	orderOut, err := orderSvc.Create(ctx, order.CreateInput{
+		MerchantID: m.ID, Amount: 5400, Currency: "INR", Receipt: "saved-card-pay",
+	})
+	if err != nil {
+		t.Fatalf("create order: %v", err)
+	}
+	authResult, err := paymentSvc.Authorize(ctx, payment.AuthorizeInput{
+		MerchantID:           m.ID,
+		OrderID:              orderOut.ID,
+		Amount:               orderOut.Amount,
+		Currency:             orderOut.Currency,
+		Method:               "card",
+		PaymentMethodTokenID: tokenID,
+	})
+	if err != nil {
+		t.Fatalf("authorize card: %v", err)
+	}
+	paymentResp := sendJSON(t, mux, http.MethodGet, "/v1/payments/"+authResult.PaymentID, authHeader, nil, http.StatusOK)
+	card := paymentResp["card"].(map[string]any)
+	if got := card["issuer_country"]; got != "IN" {
+		t.Fatalf("expected issuer_country=IN, got %v", got)
+	}
+	if got := card["funding_type"]; got == "" {
+		t.Fatalf("expected funding_type in payment response, got %#v", card)
+	}
+
+	disabled := sendJSON(t, mux, http.MethodDelete, "/v1/card-tokens/"+tokenID, authHeader, map[string]any{
+		"reason": "customer removed card",
+	}, http.StatusOK)
+	if got := disabled["status"]; got != "disabled" {
+		t.Fatalf("expected disabled token, got %#v", disabled)
+	}
+}
+
+func TestIntegrationBeneficiaryPennyDropAndPayoutBatchReadback(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+	ctx := context.Background()
+
+	mux, merchantSvc, orderSvc, paymentSvc := buildGatewayMux(db)
+	_, authHeader, settlementOut, _ := createSettledMerchantFlow(t, ctx, db, merchantSvc, orderSvc, paymentSvc)
+
+	beneficiary := sendJSON(t, mux, http.MethodPost, "/v1/beneficiaries", authHeader, map[string]any{
+		"destination_type":    "bank_account",
+		"account_holder_name": "Batch Owner",
+		"bank_account_number": "123456789012",
+		"bank_ifsc":           "HDFC0001234",
+	}, http.StatusCreated)
+	beneficiaryID := mustString(t, beneficiary, "id")
+
+	verify := sendJSON(t, mux, http.MethodPost, "/v1/beneficiaries/"+beneficiaryID+"/verify", authHeader, map[string]any{}, http.StatusOK)
+	verification := verify["verification"].(map[string]any)
+	if got := verification["provider"]; got != "penny_drop" {
+		t.Fatalf("expected penny_drop provider, got %v", got)
+	}
+	evidence := verification["evidence"].(map[string]any)
+	if got := evidence["method"]; got != "penny_drop" {
+		t.Fatalf("expected penny_drop evidence method, got %v", got)
+	}
+
+	sendJSON(t, mux, http.MethodPost, "/v1/beneficiaries/"+beneficiaryID+"/approve", authHeader, map[string]any{
+		"notes": "approved for batch payouts",
+	}, http.StatusOK)
+
+	batch := sendJSON(t, mux, http.MethodPost, "/v1/payout-batches", authHeader, map[string]any{
+		"dry_run": true,
+		"items": []map[string]any{
+			{
+				"settlement_id":  settlementOut.ID,
+				"beneficiary_id": beneficiaryID,
+			},
+		},
+	}, http.StatusCreated)
+	batchID := mustString(t, batch, "id")
+
+	batches := sendJSON(t, mux, http.MethodGet, "/v1/payout-batches", authHeader, nil, http.StatusOK)
+	if int(batches["count"].(float64)) < 1 {
+		t.Fatalf("expected payout batch list to include created batch, got %#v", batches)
+	}
+
+	batchGet := sendJSON(t, mux, http.MethodGet, "/v1/payout-batches/"+batchID, authHeader, nil, http.StatusOK)
+	if got := batchGet["id"]; got != batchID {
+		t.Fatalf("expected batch id %s, got %v", batchID, got)
+	}
+	items := batchGet["items"].([]any)
+	if len(items) != 1 {
+		t.Fatalf("expected one batch item, got %#v", batchGet)
+	}
+}

--- a/tests/integration/open_issue_batch_two_integration_test.go
+++ b/tests/integration/open_issue_batch_two_integration_test.go
@@ -1,0 +1,226 @@
+//go:build integration
+
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/sanskarpan/PayGate/internal/merchant"
+	"github.com/sanskarpan/PayGate/internal/order"
+)
+
+func TestIntegrationGatewayRoutingFailoverPersistsDecision(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	mux, merchantSvc, _, _ := buildGatewayMux(db)
+	createdMerchant, err := merchantSvc.CreateMerchant(t.Context(), merchant.CreateMerchantInput{
+		Name:         "Routing Merchant",
+		Email:        uniqueTestEmail(t, "routing"),
+		BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+	key, err := merchantSvc.CreateAPIKey(t.Context(), createdMerchant.ID, merchant.CreateAPIKeyInput{
+		Mode:  merchant.APIKeyModeTest,
+		Scope: merchant.APIKeyScopeAdmin,
+	})
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+	authHeader := basicAuth(key.KeyID, key.KeySecret)
+
+	sendJSON(t, mux, http.MethodPost, "/v1/gateway/scenarios", authHeader, map[string]any{
+		"merchant_id":  createdMerchant.ID,
+		"mode":         "decline",
+		"decline_code": "CARD_DECLINED",
+	}, http.StatusCreated)
+	sendJSON(t, mux, http.MethodPost, "/v1/gateway/routing-policies", authHeader, map[string]any{
+		"merchant_id":         createdMerchant.ID,
+		"method":              "card",
+		"primary_provider":    "simulator_primary",
+		"fallback_provider":   "simulator_failover",
+		"failover_on_decline": true,
+		"failover_on_error":   true,
+		"cost_weight":         20,
+		"success_weight":      80,
+	}, http.StatusCreated)
+
+	orderResp := sendJSON(t, mux, http.MethodPost, "/v1/orders", authHeader, map[string]any{
+		"amount":   7300,
+		"currency": "INR",
+		"receipt":  "routing-failover-order",
+	}, http.StatusCreated)
+	cardTokenID := createCardTokenViaMux(t, mux, authHeader, false)
+	paymentResp := sendJSON(t, mux, http.MethodPost, "/v1/payments/authorize", authHeader, map[string]any{
+		"order_id":                mustString(t, orderResp, "id"),
+		"amount":                  7300,
+		"currency":                "INR",
+		"method":                  "card",
+		"payment_method_token_id": cardTokenID,
+	}, http.StatusCreated)
+
+	if got := mustString(t, paymentResp, "provider"); got != "simulator_failover" {
+		t.Fatalf("expected failover provider, got %s", got)
+	}
+	if got := mustString(t, paymentResp, "routing_reason"); !strings.Contains(got, "failover") {
+		t.Fatalf("expected failover routing reason, got %s", got)
+	}
+	attempted, ok := paymentResp["attempted_providers"].([]any)
+	if !ok || len(attempted) != 2 {
+		t.Fatalf("expected two attempted providers, got %#v", paymentResp["attempted_providers"])
+	}
+	if attempted[0] != "simulator_primary" || attempted[1] != "simulator_failover" {
+		t.Fatalf("unexpected attempted providers %#v", attempted)
+	}
+}
+
+func TestIntegrationNetbankingRedirectLifecycle(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	mux, merchantSvc, orderSvc, _ := buildGatewayMux(db)
+	createdMerchant, err := merchantSvc.CreateMerchant(t.Context(), merchant.CreateMerchantInput{
+		Name:         "Netbanking Merchant",
+		Email:        uniqueTestEmail(t, "netbanking"),
+		BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+	key, err := merchantSvc.CreateAPIKey(t.Context(), createdMerchant.ID, merchant.CreateAPIKeyInput{
+		Mode:  merchant.APIKeyModeTest,
+		Scope: merchant.APIKeyScopeAdmin,
+	})
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+	authHeader := basicAuth(key.KeyID, key.KeySecret)
+
+	orderModel, err := orderSvc.Create(t.Context(), order.CreateInput{
+		MerchantID: createdMerchant.ID,
+		Amount:     8400,
+		Currency:   "INR",
+		Receipt:    "netbanking-order",
+	})
+	if err != nil {
+		t.Fatalf("create order: %v", err)
+	}
+	redirectResp := sendJSON(t, mux, http.MethodPost, "/v1/payments/netbanking/redirects", authHeader, map[string]any{
+		"order_id":  orderModel.ID,
+		"amount":    orderModel.Amount,
+		"currency":  orderModel.Currency,
+		"bank_code": "HDFC",
+	}, http.StatusCreated)
+	if got := mustString(t, redirectResp, "method"); got != "netbanking" {
+		t.Fatalf("expected netbanking method, got %s", got)
+	}
+	if got := mustString(t, redirectResp, "status"); got != "pending_customer_action" {
+		t.Fatalf("expected pending_customer_action, got %s", got)
+	}
+	nextAction := mustMap(t, redirectResp, "next_action")
+	if mustString(t, nextAction, "type") != "netbanking_redirect" {
+		t.Fatalf("unexpected next action %#v", nextAction)
+	}
+	sandbox := mustMap(t, redirectResp, "sandbox")
+	callbackURL := mustString(t, sandbox, "callback_url")
+
+	callbackPayload := map[string]any{
+		"merchant_id":       createdMerchant.ID,
+		"event_id":          "nbk_evt_1",
+		"status":            "succeeded",
+		"gateway_reference": "nbk_success_1",
+	}
+	callbackResp := sendJSON(t, mux, http.MethodPost, strings.TrimPrefix(callbackURL, "http://example.com"), "", callbackPayload, http.StatusAccepted)
+	if processed, ok := callbackResp["processed"].(bool); !ok || !processed {
+		t.Fatalf("expected callback processed=true, got %#v", callbackResp)
+	}
+	duplicateResp := sendJSON(t, mux, http.MethodPost, strings.TrimPrefix(callbackURL, "http://example.com"), "", callbackPayload, http.StatusAccepted)
+	if processed, ok := duplicateResp["processed"].(bool); !ok || processed {
+		t.Fatalf("expected duplicate callback processed=false, got %#v", duplicateResp)
+	}
+
+	getResp := sendJSON(t, mux, http.MethodGet, fmt.Sprintf("/v1/payments/%s/redirect-session", mustString(t, redirectResp, "id")), authHeader, nil, http.StatusOK)
+	if got := mustString(t, getResp, "status"); got != "captured" {
+		t.Fatalf("expected captured redirect payment, got %s", got)
+	}
+	if got := mustString(t, getResp, "provider_status"); got != "succeeded" {
+		t.Fatalf("expected succeeded provider status, got %s", got)
+	}
+}
+
+func TestIntegrationWalletRedirectTimeoutAndFailure(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	mux, merchantSvc, orderSvc, _ := buildGatewayMux(db)
+	createdMerchant, err := merchantSvc.CreateMerchant(t.Context(), merchant.CreateMerchantInput{
+		Name:         "Wallet Merchant",
+		Email:        uniqueTestEmail(t, "wallet"),
+		BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+	key, err := merchantSvc.CreateAPIKey(t.Context(), createdMerchant.ID, merchant.CreateAPIKeyInput{
+		Mode:  merchant.APIKeyModeTest,
+		Scope: merchant.APIKeyScopeAdmin,
+	})
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+	authHeader := basicAuth(key.KeyID, key.KeySecret)
+
+	sendJSON(t, mux, http.MethodPost, "/v1/gateway/scenarios", authHeader, map[string]any{
+		"merchant_id": createdMerchant.ID,
+		"mode":        "timeout",
+	}, http.StatusCreated)
+	orderModel, err := orderSvc.Create(t.Context(), order.CreateInput{
+		MerchantID: createdMerchant.ID,
+		Amount:     3900,
+		Currency:   "INR",
+		Receipt:    "wallet-order",
+	})
+	if err != nil {
+		t.Fatalf("create order: %v", err)
+	}
+	redirectResp := sendJSON(t, mux, http.MethodPost, "/v1/payments/wallet/redirects", authHeader, map[string]any{
+		"order_id":           orderModel.ID,
+		"amount":             orderModel.Amount,
+		"currency":           orderModel.Currency,
+		"wallet_code":        "paytm",
+		"expires_in_seconds": 1,
+	}, http.StatusCreated)
+	paymentID := mustString(t, redirectResp, "id")
+	pollResp := sendJSON(t, mux, http.MethodPost, fmt.Sprintf("/v1/payments/%s/redirect-session/poll", paymentID), authHeader, map[string]any{}, http.StatusOK)
+	if got := mustString(t, pollResp, "status"); got != "processing" && got != "pending_customer_action" {
+		t.Fatalf("expected processing or pending state, got %s", got)
+	}
+	if _, err := db.Exec(t.Context(), `UPDATE paygate_payments.redirect_payment_details SET expires_at = NOW() - INTERVAL '1 second' WHERE payment_id = $1`, paymentID); err != nil {
+		t.Fatalf("expire redirect session: %v", err)
+	}
+	expiredResp := sendJSON(t, mux, http.MethodPost, fmt.Sprintf("/v1/payments/%s/redirect-session/poll", paymentID), authHeader, map[string]any{}, http.StatusOK)
+	if got := mustString(t, expiredResp, "provider_status"); got != "expired" {
+		t.Fatalf("expected expired provider status, got %s", got)
+	}
+	if got := mustString(t, expiredResp, "status"); got != "failed" {
+		t.Fatalf("expected failed payment state after expiry, got %s", got)
+	}
+}
+
+func mustMap(t *testing.T, payload map[string]any, key string) map[string]any {
+	t.Helper()
+	raw, ok := payload[key]
+	if !ok {
+		t.Fatalf("missing key %q in %#v", key, payload)
+	}
+	out, ok := raw.(map[string]any)
+	if !ok {
+		t.Fatalf("expected object at key %q, got %#v", key, raw)
+	}
+	return out
+}

--- a/tests/integration/payment_link_integration_test.go
+++ b/tests/integration/payment_link_integration_test.go
@@ -1,0 +1,93 @@
+//go:build integration
+
+package integration
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sanskarpan/PayGate/internal/merchant"
+)
+
+func TestIntegrationPaymentLinkLifecycleAndPublicResolve(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	mux, merchantSvc, _, _ := buildGatewayMux(db)
+	createdMerchant, err := merchantSvc.CreateMerchant(t.Context(), merchant.CreateMerchantInput{
+		Name:         "Payment Link Merchant",
+		Email:        uniqueTestEmail(t, "payment-link"),
+		BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+	key, err := merchantSvc.CreateAPIKey(t.Context(), createdMerchant.ID, merchant.CreateAPIKeyInput{
+		Mode:  merchant.APIKeyModeTest,
+		Scope: merchant.APIKeyScopeAdmin,
+	})
+	if err != nil {
+		t.Fatalf("create api key: %v", err)
+	}
+	authHeader := basicAuth(key.KeyID, key.KeySecret)
+
+	linkResp := sendJSON(t, mux, http.MethodPost, "/v1/payment-links", authHeader, map[string]any{
+		"title":              "June Collection",
+		"description":        "June invoice payment",
+		"external_reference": "plink-june",
+		"amount":             6600,
+		"currency":           "INR",
+		"callback_url":       "/checkout/callback",
+		"notes": map[string]any{
+			"source": "integration",
+		},
+	}, http.StatusCreated)
+	linkID := mustString(t, linkResp, "id")
+	if got := mustString(t, linkResp, "status"); got != "active" {
+		t.Fatalf("expected active payment link, got %s", got)
+	}
+	if got := mustString(t, linkResp, "public_url"); !strings.Contains(got, "/pay/") {
+		t.Fatalf("expected public url, got %s", got)
+	}
+
+	getResp := sendJSON(t, mux, http.MethodGet, "/v1/payment-links/"+linkID, authHeader, nil, http.StatusOK)
+	if mustString(t, getResp, "order_id") == "" {
+		t.Fatalf("expected order_id on payment link, got %#v", getResp)
+	}
+
+	publicReq := httptest.NewRequest(http.MethodGet, "/pay/"+linkID+"?merchant_id="+createdMerchant.ID, nil)
+	publicRecorder := httptest.NewRecorder()
+	mux.ServeHTTP(publicRecorder, publicReq)
+	if publicRecorder.Code != http.StatusFound {
+		t.Fatalf("expected public resolve redirect, got %d body=%s", publicRecorder.Code, publicRecorder.Body.String())
+	}
+	location := publicRecorder.Header().Get("Location")
+	if !strings.Contains(location, "/checkout?") || !strings.Contains(location, "order_id="+mustString(t, linkResp, "order_id")) {
+		t.Fatalf("unexpected payment link redirect location %s", location)
+	}
+
+	if _, err := db.Exec(t.Context(), `UPDATE paygate_orders.orders SET status = 'paid', amount_due = 0, amount_paid = amount WHERE id = $1`, mustString(t, linkResp, "order_id")); err != nil {
+		t.Fatalf("mark order paid: %v", err)
+	}
+	paidResp := sendJSON(t, mux, http.MethodGet, "/v1/payment-links/"+linkID, authHeader, nil, http.StatusOK)
+	if got := mustString(t, paidResp, "status"); got != "paid" {
+		t.Fatalf("expected paid payment link, got %s", got)
+	}
+
+	secondLink := sendJSON(t, mux, http.MethodPost, "/v1/payment-links", authHeader, map[string]any{
+		"title":        "Disable Me",
+		"amount":       1200,
+		"currency":     "INR",
+		"callback_url": "/checkout/callback",
+	}, http.StatusCreated)
+	secondID := mustString(t, secondLink, "id")
+	sendJSON(t, mux, http.MethodPost, "/v1/payment-links/"+secondID+"/disable", authHeader, map[string]any{}, http.StatusOK)
+	disabledReq := httptest.NewRequest(http.MethodGet, "/pay/"+secondID+"?merchant_id="+createdMerchant.ID, nil)
+	disabledRecorder := httptest.NewRecorder()
+	mux.ServeHTTP(disabledRecorder, disabledReq)
+	if disabledRecorder.Code != http.StatusBadRequest {
+		t.Fatalf("expected disabled payment link resolve failure, got %d body=%s", disabledRecorder.Code, disabledRecorder.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary
- wire the final payment, billing, and payout routes into the API gateway
- expand integration bootstrap for the new surfaces
- add focused integration coverage for vault, routing, redirect, payment-link, and manual-invoice flows

## Local Validation
- `go test -count=1 ./...`
- `go vet ./...`
- `go test -count=1 -tags=integration ./tests/integration/...`

Closes #550
