### PR TITLE
Stabilize payment persistence and verification harnesses

### DIFF
--- a/dashboard/playwright.config.ts
+++ b/dashboard/playwright.config.ts
@@ -5,11 +5,11 @@ import { defineConfig, devices } from "@playwright/test";
 const rootDir = path.resolve(__dirname, "..");
 const apiBaseUrl = process.env.API_BASE_URL || "http://127.0.0.1:38090";
 const appBaseUrl = process.env.APP_BASE_URL || "http://127.0.0.1:33001";
-const localDatabaseUrl =
+const isolatedDatabaseUrl =
   `postgres://${["pay", "gate"].join("")}:${["pay", "gate"].join("")}` +
-  "@localhost:5435/paygate?sslmode=disable";
-const databaseUrl = process.env.DATABASE_URL || localDatabaseUrl;
-const redisAddr = process.env.REDIS_ADDR || "localhost:6380";
+  "@localhost:5433/paygate_test?sslmode=disable";
+const databaseUrl = process.env.DATABASE_URL || isolatedDatabaseUrl;
+const redisAddr = process.env.REDIS_ADDR || "localhost:6381";
 const kafkaBrokers = process.env.KAFKA_BROKERS || "localhost:19092";
 const authDir = path.join(__dirname, "playwright", ".auth");
 
@@ -57,9 +57,9 @@ export default defineConfig({
         `REDIS_ADDR=${redisAddr}`,
         `KAFKA_BROKERS=${kafkaBrokers}`,
         "DASHBOARD_ORIGIN=http://127.0.0.1:33001",
-        "go",
-        "run",
-        "./cmd/api-gateway",
+        "bash",
+        "-lc",
+        `'scripts/test/prepare_playwright_stack.sh && go run ./cmd/api-gateway'`,
       ].join(" "),
       cwd: rootDir,
       url: `${apiBaseUrl}/readyz`,

--- a/dashboard/tests/e2e/global-setup.ts
+++ b/dashboard/tests/e2e/global-setup.ts
@@ -1,6 +1,5 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { execFileSync } from "node:child_process";
 
 async function ensureDir(dir: string) {
   await fs.mkdir(dir, { recursive: true });
@@ -8,7 +7,6 @@ async function ensureDir(dir: string) {
 
 async function main() {
   const dashboardDir = path.resolve(__dirname, "../..");
-  const repoRoot = path.resolve(dashboardDir, "..");
   const authDir = path.join(dashboardDir, "playwright", ".auth");
 
   await ensureDir(authDir);
@@ -18,15 +16,6 @@ async function main() {
   if (process.env.PLAYWRIGHT_SKIP_BOOTSTRAP === "true") {
     return;
   }
-
-  execFileSync("bash", ["scripts/test/prepare_local_stack.sh"], {
-    cwd: repoRoot,
-    stdio: "inherit",
-    env: {
-      ...process.env,
-      DATABASE_URL: process.env.DATABASE_URL || "postgres://paygate:paygate@localhost:5435/paygate?sslmode=disable",
-    },
-  });
 }
 
 export default main;

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   postgres-test:
     image: postgres:16-alpine
@@ -20,4 +18,4 @@ services:
     image: redis:7-alpine
     container_name: paygate-redis-test
     ports:
-      - "6380:6379"
+      - "6381:6379"

--- a/internal/payment/postgres.go
+++ b/internal/payment/postgres.go
@@ -100,7 +100,7 @@ func (r *PostgresRepository) CreateFailedAttempt(ctx context.Context, in CreateA
 INSERT INTO paygate_payments.payment_attempts
 (id, order_id, merchant_id, payment_id, amount, currency, method, provider, routing_reason, attempted_providers, status, error_code, error_description, idempotency_key)
 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,'failed',$11,$12,$13)
-`, attemptID, in.OrderID, in.MerchantID, nullableText(in.PaymentID), in.Amount, in.Currency, in.Method, nullableText(in.Provider), nullableText(in.RoutingReason), in.AttemptedProviders, errorCode, errorDescription, in.IdempotencyKey)
+`, attemptID, in.OrderID, in.MerchantID, nullableText(in.PaymentID), in.Amount, in.Currency, in.Method, nonEmptyText(in.Provider), nonEmptyText(in.RoutingReason), normalizeAttemptedProviders(in.AttemptedProviders), errorCode, errorDescription, in.IdempotencyKey)
 	if err != nil {
 		return err
 	}
@@ -175,7 +175,7 @@ FOR UPDATE
 INSERT INTO paygate_payments.payment_attempts
 (id, order_id, merchant_id, payment_id, amount, currency, method, provider, routing_reason, attempted_providers, status, idempotency_key)
 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,'processing',$11)
-`, attemptID, in.OrderID, in.MerchantID, paymentID, in.Amount, in.Currency, in.Method, nullableText(in.Provider), nullableText(in.RoutingReason), in.AttemptedProviders, in.IdempotencyKey)
+`, attemptID, in.OrderID, in.MerchantID, paymentID, in.Amount, in.Currency, in.Method, nonEmptyText(in.Provider), nonEmptyText(in.RoutingReason), normalizeAttemptedProviders(in.AttemptedProviders), in.IdempotencyKey)
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if in.IdempotencyKey != "" && errors.As(err, &pgErr) && pgErr.Code == "23505" {
@@ -188,7 +188,7 @@ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,'processing',$11)
 INSERT INTO paygate_payments.payments
 (id, attempt_id, order_id, merchant_id, amount, currency, method, provider, routing_reason, attempted_providers, method_state, status, captured)
 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,'created',false)
-`, paymentID, attemptID, in.OrderID, in.MerchantID, in.Amount, in.Currency, in.Method, nullableText(in.Provider), nullableText(in.RoutingReason), in.AttemptedProviders, initialMethodState(in.Method))
+`, paymentID, attemptID, in.OrderID, in.MerchantID, in.Amount, in.Currency, in.Method, nonEmptyText(in.Provider), nonEmptyText(in.RoutingReason), normalizeAttemptedProviders(in.AttemptedProviders), initialMethodState(in.Method))
 	if err != nil {
 		return CaptureResult{}, fmt.Errorf("insert payment: %w", err)
 	}
@@ -221,7 +221,7 @@ SET provider = NULLIF($3, ''),
     attempted_providers = $5,
     updated_at = NOW()
 WHERE id = $1 AND merchant_id = $2
-`, paymentID, merchantID, decision.Provider, decision.RoutingReason, decision.AttemptedProviders)
+`, paymentID, merchantID, decision.Provider, decision.RoutingReason, normalizeAttemptedProviders(decision.AttemptedProviders))
 	if err != nil {
 		return fmt.Errorf("update payment routing: %w", err)
 	}
@@ -232,7 +232,7 @@ SET provider = NULLIF($3, ''),
     attempted_providers = $5,
     updated_at = NOW()
 WHERE payment_id = $1 AND merchant_id = $2
-`, paymentID, merchantID, decision.Provider, decision.RoutingReason, decision.AttemptedProviders)
+`, paymentID, merchantID, decision.Provider, decision.RoutingReason, normalizeAttemptedProviders(decision.AttemptedProviders))
 	if err != nil {
 		return fmt.Errorf("update attempt routing: %w", err)
 	}
@@ -1099,4 +1099,15 @@ func nullableText(v string) *string {
 		return nil
 	}
 	return &v
+}
+
+func nonEmptyText(v string) string {
+	return v
+}
+
+func normalizeAttemptedProviders(values []string) []string {
+	if values == nil {
+		return []string{}
+	}
+	return values
 }

--- a/internal/payment/redirect_postgres.go
+++ b/internal/payment/redirect_postgres.go
@@ -60,7 +60,7 @@ FOR UPDATE
 INSERT INTO paygate_payments.payment_attempts
 (id, order_id, merchant_id, payment_id, amount, currency, method, provider, routing_reason, attempted_providers, status, idempotency_key)
 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,'processing',$11)
-`, attemptID, in.OrderID, in.MerchantID, in.PaymentID, in.Amount, in.Currency, in.Method, nullableText(in.Provider), nullableText(in.RoutingReason), in.Attempted, in.IdempotencyKey)
+`, attemptID, in.OrderID, in.MerchantID, in.PaymentID, in.Amount, in.Currency, in.Method, nonEmptyText(in.Provider), nonEmptyText(in.RoutingReason), normalizeAttemptedProviders(in.Attempted), in.IdempotencyKey)
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if in.IdempotencyKey != "" && errors.As(err, &pgErr) && pgErr.Code == "23505" {
@@ -72,7 +72,7 @@ VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,'processing',$11)
 INSERT INTO paygate_payments.payments
 (id, attempt_id, order_id, merchant_id, amount, currency, method, provider, routing_reason, attempted_providers, method_state, status, captured)
 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,'pending_customer_action',false)
-`, in.PaymentID, attemptID, in.OrderID, in.MerchantID, in.Amount, in.Currency, in.Method, nullableText(in.Provider), nullableText(in.RoutingReason), in.Attempted, initialMethodState(in.Method))
+`, in.PaymentID, attemptID, in.OrderID, in.MerchantID, in.Amount, in.Currency, in.Method, nonEmptyText(in.Provider), nonEmptyText(in.RoutingReason), normalizeAttemptedProviders(in.Attempted), initialMethodState(in.Method))
 	if err != nil {
 		return RedirectSessionResult{}, fmt.Errorf("insert redirect payment: %w", err)
 	}

--- a/scripts/test/prepare_local_stack.sh
+++ b/scripts/test/prepare_local_stack.sh
@@ -5,6 +5,11 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 DEFAULT_DATABASE_URL="postgres://pay""gate:pay""gate@localhost:5435/paygate?sslmode=disable"
 DATABASE_URL="${DATABASE_URL:-${DEFAULT_DATABASE_URL}}"
 RESET_DATABASE="${RESET_DATABASE:-true}"
+POSTGRES_CONTAINER="${POSTGRES_CONTAINER:-paygate-postgres}"
+REDIS_CONTAINER="${REDIS_CONTAINER:-paygate-redis}"
+KAFKA_CONTAINER="${KAFKA_CONTAINER:-paygate-kafka}"
+DATABASE_NAME="${DATABASE_NAME:-${DATABASE_URL##*/}}"
+DATABASE_NAME="${DATABASE_NAME%%\?*}"
 
 if ! command -v docker >/dev/null 2>&1; then
   echo "docker is required" >&2
@@ -20,25 +25,25 @@ cd "${ROOT_DIR}"
 
 docker compose up -d postgres redis kafka >/dev/null
 
-until docker exec paygate-postgres pg_isready -U paygate -d paygate >/dev/null 2>&1; do
+until docker exec "${POSTGRES_CONTAINER}" pg_isready -U paygate -d postgres >/dev/null 2>&1; do
   sleep 2
 done
 
-until docker exec paygate-redis redis-cli ping >/dev/null 2>&1; do
+until docker exec "${REDIS_CONTAINER}" redis-cli ping >/dev/null 2>&1; do
   sleep 2
 done
 
-until docker exec paygate-kafka /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list >/dev/null 2>&1; do
+until docker exec "${KAFKA_CONTAINER}" /opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list >/dev/null 2>&1; do
   sleep 2
 done
 
 if [[ "${RESET_DATABASE}" == "true" ]]; then
-  docker exec paygate-postgres psql -U paygate -d postgres -v ON_ERROR_STOP=1 \
-    -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = 'paygate' AND pid <> pg_backend_pid();" >/dev/null
-  docker exec paygate-postgres psql -U paygate -d postgres -v ON_ERROR_STOP=1 \
-    -c "DROP DATABASE IF EXISTS paygate;" >/dev/null
-  docker exec paygate-postgres psql -U paygate -d postgres -v ON_ERROR_STOP=1 \
-    -c "CREATE DATABASE paygate OWNER paygate;" >/dev/null
+  docker exec "${POSTGRES_CONTAINER}" psql -U paygate -d postgres -v ON_ERROR_STOP=1 \
+    -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${DATABASE_NAME}' AND pid <> pg_backend_pid();" >/dev/null
+  docker exec "${POSTGRES_CONTAINER}" psql -U paygate -d postgres -v ON_ERROR_STOP=1 \
+    -c "DROP DATABASE IF EXISTS ${DATABASE_NAME};" >/dev/null
+  docker exec "${POSTGRES_CONTAINER}" psql -U paygate -d postgres -v ON_ERROR_STOP=1 \
+    -c "CREATE DATABASE ${DATABASE_NAME} OWNER paygate;" >/dev/null
 fi
 
 MIGRATE_BIN="$(command -v migrate || true)"

--- a/scripts/test/prepare_playwright_stack.sh
+++ b/scripts/test/prepare_playwright_stack.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DATABASE_URL="${DATABASE_URL:-postgres://paygate:paygate@localhost:5433/paygate_test?sslmode=disable}"
+
+cd "${ROOT_DIR}"
+
+docker compose -f docker-compose.test.yml up -d postgres-test redis-test >/dev/null
+
+until docker exec paygate-postgres-test pg_isready -U paygate -d postgres >/dev/null 2>&1; do
+  sleep 1
+done
+
+until docker exec paygate-redis-test redis-cli ping >/dev/null 2>&1; do
+  sleep 1
+done
+
+DATABASE_NAME="${DATABASE_URL##*/}"
+DATABASE_NAME="${DATABASE_NAME%%\?*}"
+
+docker exec paygate-postgres-test psql -U paygate -d postgres -v ON_ERROR_STOP=1 \
+  -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${DATABASE_NAME}' AND pid <> pg_backend_pid();" >/dev/null
+docker exec paygate-postgres-test psql -U paygate -d postgres -v ON_ERROR_STOP=1 \
+  -c "DROP DATABASE IF EXISTS ${DATABASE_NAME};" >/dev/null
+docker exec paygate-postgres-test psql -U paygate -d postgres -v ON_ERROR_STOP=1 \
+  -c "CREATE DATABASE ${DATABASE_NAME} OWNER paygate;" >/dev/null
+
+MIGRATE_BIN="$(command -v migrate || true)"
+if [[ -z "${MIGRATE_BIN}" ]]; then
+  go install -tags 'postgres' github.com/golang-migrate/migrate/v4/cmd/migrate@v4.19.1
+  MIGRATE_BIN="$(go env GOPATH)/bin/migrate"
+fi
+"${MIGRATE_BIN}" -path ./migrations -database "${DATABASE_URL}" up >/dev/null

--- a/scripts/test/run_chaos_suite.sh
+++ b/scripts/test/run_chaos_suite.sh
@@ -6,7 +6,7 @@ API_PORT="${API_PORT:-38091}"
 API_BASE_URL="${API_BASE_URL:-http://127.0.0.1:${API_PORT}}"
 TOXIPROXY_NAME="${TOXIPROXY_NAME:-paygate-toxiproxy}"
 TOXIPROXY_API="${TOXIPROXY_API:-http://127.0.0.1:8474}"
-DEFAULT_DATABASE_URL="postgres://pay""gate:pay""gate@localhost:5435/paygate?sslmode=disable"
+DEFAULT_DATABASE_URL="postgres://pay""gate:pay""gate@localhost:5435/paygate_chaos?sslmode=disable"
 START_API="${START_API:-false}"
 API_PID=""
 API_LOG_FILE="${API_LOG_FILE:-/tmp/paygate-chaos-api.log}"
@@ -60,7 +60,7 @@ fi
 
 cd "${ROOT_DIR}"
 
-"${ROOT_DIR}/scripts/test/prepare_local_stack.sh"
+DATABASE_URL="${DATABASE_URL:-${DEFAULT_DATABASE_URL}}" "${ROOT_DIR}/scripts/test/prepare_local_stack.sh"
 
 docker rm -f "${TOXIPROXY_NAME}" >/dev/null 2>&1 || true
 docker run -d --name "${TOXIPROXY_NAME}" \

--- a/scripts/test/run_full_verification.sh
+++ b/scripts/test/run_full_verification.sh
@@ -5,6 +5,8 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 RUN_FUZZ_SMOKE="${RUN_FUZZ_SMOKE:-true}"
 RUN_LOAD_SMOKE="${RUN_LOAD_SMOKE:-false}"
 RUN_CHAOS="${RUN_CHAOS:-false}"
+FUZZ_GOMAXPROCS="${FUZZ_GOMAXPROCS:-2}"
+FUZZ_TIMEOUT="${FUZZ_TIMEOUT:-30s}"
 
 cd "${ROOT_DIR}"
 
@@ -13,9 +15,9 @@ go vet ./...
 go test -tags=integration ./tests/integration/...
 
 if [[ "${RUN_FUZZ_SMOKE}" == "true" ]]; then
-  go test ./internal/merchant -run=^$ -fuzz=FuzzSessionManagerParse -fuzztime=3s
-  go test ./internal/payout -run=^$ -fuzz=FuzzVerifyRailPayload -fuzztime=3s
-  go test ./internal/eventschema -run=^$ -fuzz=FuzzValidateDocument -fuzztime=3s
+  GOMAXPROCS="${FUZZ_GOMAXPROCS}" go test ./internal/merchant -run=^$ -fuzz=FuzzSessionManagerParse -fuzztime=3s -timeout="${FUZZ_TIMEOUT}"
+  GOMAXPROCS="${FUZZ_GOMAXPROCS}" go test ./internal/payout -run=^$ -fuzz=FuzzVerifyRailPayload -fuzztime=3s -timeout="${FUZZ_TIMEOUT}"
+  GOMAXPROCS="${FUZZ_GOMAXPROCS}" go test ./internal/eventschema -run=^$ -fuzz=FuzzValidateDocument -fuzztime=3s -timeout="${FUZZ_TIMEOUT}"
 fi
 
 (

--- a/scripts/test/run_load_smoke.sh
+++ b/scripts/test/run_load_smoke.sh
@@ -5,7 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 API_PORT="${API_PORT:-38090}"
 BASE_URL="${BASE_URL:-http://127.0.0.1:${API_PORT}}"
 LOAD_SCRIPT="${LOAD_SCRIPT:-tests/load/ci_smoke.js}"
-DEFAULT_DATABASE_URL="postgres://pay""gate:pay""gate@localhost:5435/paygate?sslmode=disable"
+DEFAULT_DATABASE_URL="postgres://pay""gate:pay""gate@localhost:5435/paygate_load?sslmode=disable"
 START_API="${START_API:-false}"
 API_PID=""
 API_LOG_FILE="${API_LOG_FILE:-/tmp/paygate-load-api.log}"
@@ -59,7 +59,7 @@ fi
 cd "${ROOT_DIR}"
 
 if [[ "${START_API}" == "true" ]]; then
-  "${ROOT_DIR}/scripts/test/prepare_local_stack.sh"
+  DATABASE_URL="${DATABASE_URL:-${DEFAULT_DATABASE_URL}}" "${ROOT_DIR}/scripts/test/prepare_local_stack.sh"
   env \
     PORT="${API_PORT}" \
     DATABASE_URL="${DATABASE_URL:-${DEFAULT_DATABASE_URL}}" \


### PR DESCRIPTION
## Summary
- fix payment attempt and payment persistence so routing metadata never violates not-null database constraints during live authorization flows
- isolate Playwright against its own Postgres/Redis stack and add a dedicated bootstrap script so browser E2E does not reset the live dev database
- harden full verification, load smoke, and chaos runners so fuzz smoke is deterministic and each heavy suite provisions its own database correctly
- remove obsolete compose-version noise from the isolated test stack

## Root causes fixed
- card authorization could return 500 because payment attempt inserts wrote null `provider`, `routing_reason`, and `attempted_providers` values into non-null columns
- Playwright global setup and API startup both pointed at the shared `paygate` database, so browser tests could clobber the running dev stack
- the full verification fuzz smoke was oversubscribed and flaky under a busy run
- load and chaos runners were preparing the wrong database before booting their suite-local API instances

## Validation
- `go test -count=1 ./...`
- `go vet ./...`
- `go test -count=1 -tags=integration ./tests/integration/...`
- `RUN_LOAD_SMOKE=true RUN_CHAOS=true ./scripts/test/run_full_verification.sh`
- manual live API flow: merchant -> webhook -> order -> card token -> authorize -> capture -> refund -> settlement -> beneficiary -> payout -> dispute
- live health checks: `/healthz`, `/readyz`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized test infrastructure configuration for improved isolation and maintainability
  * Updated test database setup scripts to use parameterized container names and database identifiers
  * Enhanced test runner scripts with configurable environment variables for fuzz testing and load testing scenarios

* **Tests**
  * Refined test database initialization and preparation workflows
  * Improved payment persistence handling for optional field management
  * Updated Docker Compose test configuration for better service port management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sanskarpan/PayGate/pull/558?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->