### PR TITLE
[#560][#561] Harden webhook delivery concurrency and SSRF validation

### DIFF
--- a/internal/webhook/domain.go
+++ b/internal/webhook/domain.go
@@ -52,8 +52,9 @@ const RotateSecretGracePeriod = 24 * time.Hour
 var (
 	ErrSubscriptionNotFound    = errors.New("webhook subscription not found")
 	ErrDeliveryAttemptNotFound = errors.New("webhook delivery attempt not found")
+	ErrDeliveryAlreadyReserved = errors.New("webhook delivery already reserved")
 	ErrInvalidTransition       = errors.New("invalid subscription state transition")
-	ErrInvalidURL              = errors.New("webhook URL must use https scheme")
+	ErrInvalidURL              = errors.New("webhook URL must use an allowed scheme and resolve to a permitted host")
 	ErrNoEvents                = errors.New("at least one event type must be specified")
 	ErrInvalidSignatureMode    = errors.New("invalid webhook signature mode")
 )

--- a/internal/webhook/postgres.go
+++ b/internal/webhook/postgres.go
@@ -6,9 +6,11 @@ import (
 	"encoding/hex"
 	"errors"
 	"net"
+	"net/netip"
 	neturl "net/url"
 	"time"
 
+	"github.com/jackc/pgconn"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/sanskarpan/PayGate/internal/common/idgen"
@@ -249,6 +251,34 @@ VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
 		attempt.AttemptNumber, attempt.NextRetryAt, attempt.CancelledAt,
 	)
 	if err != nil {
+		return WebhookDeliveryAttempt{}, err
+	}
+	return attempt, nil
+}
+
+func (r *PostgresRepository) ReserveDeliveryAttempt(ctx context.Context, attempt WebhookDeliveryAttempt) (WebhookDeliveryAttempt, error) {
+	if attempt.ID == "" {
+		attempt.ID = idgen.New("wdl")
+	}
+	attempt.Status = DeliveryPending
+	attempt.AttemptNumber = 1
+	attempt.NextRetryAt = nil
+	attempt.CancelledAt = nil
+
+	_, err := r.db.Exec(ctx, `
+INSERT INTO paygate_webhooks.webhook_delivery_attempts
+    (id, event_id, event_type, subscription_id, merchant_id, status, request_url, request_body,
+     response_code, response_body, error_message, cancel_reason, attempt_number, next_retry_at, cancelled_at)
+VALUES ($1, $2, $3, $4, $5, 'pending', $6, $7, NULL, '', '', NULL, 1, NULL, NULL)
+`,
+		attempt.ID, attempt.EventID, attempt.EventType, attempt.SubscriptionID, attempt.MerchantID,
+		attempt.RequestURL, attempt.RequestBody,
+	)
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return WebhookDeliveryAttempt{}, ErrDeliveryAlreadyReserved
+		}
 		return WebhookDeliveryAttempt{}, err
 	}
 	return attempt, nil
@@ -497,17 +527,60 @@ func validateSubscriptionURL(raw string) error {
 	if err != nil || parsed.Host == "" {
 		return ErrInvalidURL
 	}
-	if parsed.Scheme == "https" {
-		return nil
-	}
-	if parsed.Scheme != "http" {
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
 		return ErrInvalidURL
 	}
 
-	host := parsed.Hostname()
-	ip := net.ParseIP(host)
-	if host == "localhost" || (ip != nil && ip.IsLoopback()) {
+	addrs, err := resolveWebhookHost(parsed.Hostname())
+	if err != nil || len(addrs) == 0 {
+		return ErrInvalidURL
+	}
+	if parsed.Scheme == "http" {
+		for _, addr := range addrs {
+			if !addr.IsLoopback() {
+				return ErrInvalidURL
+			}
+		}
 		return nil
 	}
-	return ErrInvalidURL
+
+	for _, addr := range addrs {
+		if isBlockedWebhookAddr(addr) {
+			return ErrInvalidURL
+		}
+	}
+	return nil
+}
+
+func resolveWebhookHost(host string) ([]netip.Addr, error) {
+	if host == "" {
+		return nil, ErrInvalidURL
+	}
+	if ip, err := netip.ParseAddr(host); err == nil {
+		return []netip.Addr{ip.Unmap()}, nil
+	}
+	ips, err := net.LookupIP(host)
+	if err != nil {
+		return nil, err
+	}
+	addrs := make([]netip.Addr, 0, len(ips))
+	for _, ip := range ips {
+		addr, ok := netip.AddrFromSlice(ip)
+		if ok {
+			addrs = append(addrs, addr.Unmap())
+		}
+	}
+	return addrs, nil
+}
+
+func isBlockedWebhookAddr(addr netip.Addr) bool {
+	addr = addr.Unmap()
+	if addr.IsLoopback() || addr.IsPrivate() || addr.IsMulticast() || addr.IsUnspecified() ||
+		addr.IsLinkLocalUnicast() || addr.IsLinkLocalMulticast() {
+		return true
+	}
+	if prefix, err := netip.ParsePrefix("100.64.0.0/10"); err == nil && prefix.Contains(addr) {
+		return true
+	}
+	return false
 }

--- a/internal/webhook/postgres_test.go
+++ b/internal/webhook/postgres_test.go
@@ -1,0 +1,34 @@
+package webhook
+
+import "testing"
+
+func TestValidateSubscriptionURLRejectsPrivateHTTPSHosts(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{
+		"https://127.0.0.1/webhook",
+		"https://10.0.0.5/webhook",
+		"https://192.168.1.10/webhook",
+		"https://172.16.0.10/webhook",
+		"https://169.254.169.254/latest/meta-data",
+		"https://100.64.1.2/hook",
+	} {
+		if err := validateSubscriptionURL(raw); err == nil {
+			t.Fatalf("expected private https webhook URL %q to be rejected", raw)
+		}
+	}
+}
+
+func TestValidateSubscriptionURLAllowsOnlyLoopbackHTTP(t *testing.T) {
+	t.Parallel()
+
+	if err := validateSubscriptionURL("http://127.0.0.1:8080/hook"); err != nil {
+		t.Fatalf("expected loopback http URL to be allowed, got %v", err)
+	}
+	if err := validateSubscriptionURL("http://localhost:8080/hook"); err != nil {
+		t.Fatalf("expected localhost http URL to be allowed, got %v", err)
+	}
+	if err := validateSubscriptionURL("http://10.0.0.5/hook"); err == nil {
+		t.Fatal("expected non-loopback http URL to be rejected")
+	}
+}

--- a/internal/webhook/repository.go
+++ b/internal/webhook/repository.go
@@ -16,6 +16,7 @@ type Repository interface {
 	FindActiveSubscriptions(ctx context.Context, merchantID, eventType string) ([]WebhookSubscription, error)
 
 	// Delivery attempt recording
+	ReserveDeliveryAttempt(ctx context.Context, attempt WebhookDeliveryAttempt) (WebhookDeliveryAttempt, error)
 	CreateDeliveryAttempt(ctx context.Context, attempt WebhookDeliveryAttempt) (WebhookDeliveryAttempt, error)
 	UpdateDeliveryAttempt(ctx context.Context, id string, status DeliveryStatus, responseCode int, responseBody, errMsg string, nextRetryAt *string, attemptNumber int) (WebhookDeliveryAttempt, error)
 	ListDeliveryAttempts(ctx context.Context, merchantID, subscriptionID string) ([]WebhookDeliveryAttempt, error)

--- a/internal/webhook/service.go
+++ b/internal/webhook/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -109,13 +110,19 @@ func (s *Service) DeliverEvent(ctx context.Context, eventID, merchantID, eventTy
 			}
 		}
 
-		// Skip if already delivered to this subscription (idempotency).
-		delivered, err := s.repo.IsDelivered(ctx, eventID, sub.ID)
-		if err != nil {
-			return err
-		}
-		if delivered {
+		attempt, err := s.repo.ReserveDeliveryAttempt(ctx, WebhookDeliveryAttempt{
+			EventID:        eventID,
+			EventType:      eventType,
+			SubscriptionID: sub.ID,
+			MerchantID:     merchantID,
+			RequestURL:     sub.URL,
+			RequestBody:    body,
+		})
+		if errors.Is(err, ErrDeliveryAlreadyReserved) {
 			continue
+		}
+		if err != nil {
+			return fmt.Errorf("reserve delivery attempt: %w", err)
 		}
 
 		result := s.deliverer.Deliver(ctx, sub.URL, sub.Secret, eventType, body, sub.SignatureMode)
@@ -126,28 +133,25 @@ func (s *Service) DeliverEvent(ctx context.Context, eventID, merchantID, eventTy
 		}
 		metrics.WebhookSignatureDeliveriesTotal.WithLabelValues(string(sub.SignatureMode), string(status)).Inc()
 
-		attempt := WebhookDeliveryAttempt{
-			EventID:        eventID,
-			EventType:      eventType,
-			SubscriptionID: sub.ID,
-			MerchantID:     merchantID,
-			Status:         status,
-			RequestURL:     sub.URL,
-			RequestBody:    body,
-			ResponseCode:   result.StatusCode,
-			ResponseBody:   result.ResponseBody,
-			ErrorMessage:   result.Error,
-			AttemptNumber:  1,
-		}
-
+		attempt.Status = status
+		attempt.ResponseCode = result.StatusCode
+		attempt.ResponseBody = result.ResponseBody
+		attempt.ErrorMessage = result.Error
 		if status == DeliveryFailed {
 			delay := RetryDelay(2)
 			nextRetry := time.Now().Add(delay)
 			attempt.NextRetryAt = &nextRetry
 		}
 
-		if _, err := s.repo.CreateDeliveryAttempt(ctx, attempt); err != nil {
-			return fmt.Errorf("record delivery attempt: %w", err)
+		var nextRetryAt *string
+		if attempt.NextRetryAt != nil {
+			value := attempt.NextRetryAt.Format(time.RFC3339)
+			nextRetryAt = &value
+		}
+		if _, err := s.repo.UpdateDeliveryAttempt(
+			ctx, attempt.ID, status, result.StatusCode, result.ResponseBody, result.Error, nextRetryAt, 1,
+		); err != nil {
+			return fmt.Errorf("finalize delivery attempt: %w", err)
 		}
 
 		// Persist the dedup fingerprint in Redis so subsequent consumers can

--- a/migrations/000052_harden_webhook_delivery_dedup.down.sql
+++ b/migrations/000052_harden_webhook_delivery_dedup.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS paygate_webhooks.idx_webhook_deliveries_event_subscription;

--- a/migrations/000052_harden_webhook_delivery_dedup.up.sql
+++ b/migrations/000052_harden_webhook_delivery_dedup.up.sql
@@ -1,0 +1,15 @@
+WITH ranked AS (
+    SELECT id,
+           ROW_NUMBER() OVER (
+               PARTITION BY event_id, subscription_id
+               ORDER BY created_at DESC, id DESC
+           ) AS rn
+    FROM paygate_webhooks.webhook_delivery_attempts
+)
+DELETE FROM paygate_webhooks.webhook_delivery_attempts attempt
+USING ranked
+WHERE attempt.id = ranked.id
+  AND ranked.rn > 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_webhook_deliveries_event_subscription
+    ON paygate_webhooks.webhook_delivery_attempts (event_id, subscription_id);

--- a/tests/integration/webhook_integration_test.go
+++ b/tests/integration/webhook_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/sanskarpan/PayGate/internal/merchant"
@@ -299,6 +300,81 @@ func TestIntegrationWebhookIdempotentDelivery(t *testing.T) {
 	// Mock server should have been called exactly once.
 	if deliveryCount != 1 {
 		t.Fatalf("expected 1 delivery (idempotent), got %d", deliveryCount)
+	}
+}
+
+func TestIntegrationWebhookConcurrentDeliveryReservesSingleAttempt(t *testing.T) {
+	db := testDB(t)
+	defer db.Close()
+
+	ctx := context.Background()
+	_, merchantSvc, _, _ := buildGatewayMux(db)
+	createdMerchant, err := merchantSvc.CreateMerchant(ctx, merchant.CreateMerchantInput{
+		Name: "Concurrent Webhook Merchant", Email: "webhook-concurrent@test.com", BusinessType: "company",
+	})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+
+	received := make(chan struct{}, 4)
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received <- struct{}{}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockServer.Close()
+
+	webhookRepo := webhook.NewPostgresRepository(db)
+	webhookSvc := webhook.NewService(webhookRepo)
+	sub, err := webhookSvc.CreateSubscription(ctx, webhook.CreateInput{
+		MerchantID: createdMerchant.ID,
+		URL:        mockServer.URL,
+		Events:     []string{"payment.captured"},
+	})
+	if err != nil {
+		t.Fatalf("create subscription: %v", err)
+	}
+
+	payload := map[string]any{
+		"event_type": "payment.captured",
+		"payment_id": "pay_concurrent",
+	}
+	eventID := "evt_concurrent_delivery"
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 2)
+	for i := 0; i < 2; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs <- webhookSvc.DeliverEvent(ctx, eventID, createdMerchant.ID, "payment.captured", payload)
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("concurrent deliver event: %v", err)
+		}
+	}
+
+	close(received)
+	count := 0
+	for range received {
+		count++
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one outbound delivery, got %d", count)
+	}
+
+	attempts, err := webhookSvc.ListDeliveryAttempts(ctx, createdMerchant.ID, sub.ID)
+	if err != nil {
+		t.Fatalf("list delivery attempts: %v", err)
+	}
+	if len(attempts) != 1 {
+		t.Fatalf("expected exactly one delivery attempt, got %d", len(attempts))
+	}
+	if attempts[0].Status != webhook.DeliverySucceeded {
+		t.Fatalf("expected succeeded attempt, got %s", attempts[0].Status)
 	}
 }
 


### PR DESCRIPTION
## Summary
- reserve webhook deliveries before outbound send
- add schema-backed deduplication for initial delivery attempts
- reject private-host webhook destinations and cover the validation path

## Validation
- `go test ./internal/webhook`
- `go test -count=1 -tags=integration ./tests/integration/... -run 'TestIntegrationWebhook|TestIntegrationSecurityHardening|TestIntegrationAudit|TestIntegrationRisk'`

Closes #560
Closes #561


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added webhook delivery attempt reservation to prevent duplicate deliveries when concurrent events occur.

* **Improvements**
  * Hardened webhook URL validation to enforce stricter IP-based rules: HTTP requests only allowed to loopback addresses; HTTPS requests rejected for private and reserved IP ranges.

* **Bug Fixes**
  * Fixed potential duplicate webhook deliveries for concurrent delivery attempts to the same event.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sanskarpan/PayGate/pull/566?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->