### PR TITLE
[#563] Harden dashboard session cookie and redirect handling

### DIFF
--- a/internal/merchant/handler.go
+++ b/internal/merchant/handler.go
@@ -306,6 +306,7 @@ func (h *Handler) dashboardLogin(w http.ResponseWriter, r *http.Request) {
 		Value:    token,
 		Path:     "/",
 		HttpOnly: true,
+		Secure:   shouldUseSecureDashboardCookie(r),
 		SameSite: http.SameSiteLaxMode,
 		MaxAge:   int(h.svc.DashboardSessionTTL().Seconds()),
 	})
@@ -324,15 +325,13 @@ func (h *Handler) dashboardLogin(w http.ResponseWriter, r *http.Request) {
 }
 
 func (h *Handler) dashboardLogout(w http.ResponseWriter, r *http.Request) {
-	redirectTo := r.URL.Query().Get("redirect_to")
-	if redirectTo == "" {
-		redirectTo = "/"
-	}
+	redirectTo := normalizeDashboardRedirect(r.URL.Query().Get("redirect_to"), "/")
 	http.SetCookie(w, &http.Cookie{
 		Name:     DashboardSessionCookieName,
 		Value:    "",
 		Path:     "/",
 		HttpOnly: true,
+		Secure:   shouldUseSecureDashboardCookie(r),
 		SameSite: http.SameSiteLaxMode,
 		MaxAge:   -1,
 	})
@@ -754,16 +753,40 @@ func decodeDashboardLoginRequest(r *http.Request) (dashboardLoginRequest, string
 		if redirectTo == "" {
 			redirectTo = r.FormValue("redirect_to")
 		}
-		if redirectTo == "" {
-			redirectTo = "/orders"
-		}
-		if _, err := url.ParseRequestURI(redirectTo); err != nil {
-			redirectTo = "/orders"
-		}
+		redirectTo = normalizeDashboardRedirect(redirectTo, "/orders")
 		return dashboardLoginRequest{
 			MerchantID: r.FormValue("merchant_id"),
 			Email:      r.FormValue("email"),
 			Password:   r.FormValue("password"),
 		}, redirectTo, true, nil
 	}
+}
+
+func normalizeDashboardRedirect(raw, fallback string) string {
+	if raw == "" {
+		return fallback
+	}
+	if !strings.HasPrefix(raw, "/") || strings.HasPrefix(raw, "//") {
+		return fallback
+	}
+	if _, err := url.ParseRequestURI(raw); err != nil {
+		return fallback
+	}
+	return raw
+}
+
+func shouldUseSecureDashboardCookie(r *http.Request) bool {
+	if r.TLS != nil {
+		return true
+	}
+	if strings.EqualFold(strings.TrimSpace(r.Header.Get("X-Forwarded-Proto")), "https") {
+		return true
+	}
+	for _, part := range strings.Split(r.Header.Get("Forwarded"), ";") {
+		part = strings.TrimSpace(strings.ToLower(part))
+		if part == "proto=https" {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/merchant/handler_test.go
+++ b/internal/merchant/handler_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
 
@@ -77,5 +78,65 @@ func TestCreateAPIKeyAllowsAdminAuth(t *testing.T) {
 
 	if rr.Code != http.StatusCreated {
 		t.Fatalf("expected 201, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestDashboardLoginRejectsUnsafeRedirectAndSetsSecureCookieForHTTPS(t *testing.T) {
+	repo := newFakeRepo()
+	svc := NewService(repo, WithSessionSecret("abcdefghijklmnopqrstuvwxyz012345"))
+	merchantRecord, err := svc.CreateMerchant(context.Background(), CreateMerchantInput{Name: "Acme", Email: "owner@acme.com", BusinessType: "company"})
+	if err != nil {
+		t.Fatalf("create merchant: %v", err)
+	}
+	if _, err := svc.BootstrapMerchantUser(context.Background(), merchantRecord.ID, BootstrapMerchantUserInput{
+		Email:    "owner@acme.com",
+		Password: "strong-password-123",
+	}); err != nil {
+		t.Fatalf("bootstrap user: %v", err)
+	}
+	h := NewHandler(svc)
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	form := "merchant_id=" + merchantRecord.ID + "&email=owner%40acme.com&password=strong-password-123&redirect_to=https://evil.example"
+	req := httptest.NewRequest(http.MethodPost, "/v1/dashboard/login", strings.NewReader(form))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("X-Forwarded-Proto", "https")
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if got := rr.Header().Get("Location"); got != "/orders" {
+		t.Fatalf("expected fallback redirect, got %q", got)
+	}
+	cookies := rr.Result().Cookies()
+	if len(cookies) == 0 {
+		t.Fatal("expected session cookie to be set")
+	}
+	if !cookies[0].Secure {
+		t.Fatal("expected dashboard session cookie to be secure for https requests")
+	}
+}
+
+func TestDashboardLogoutRejectsUnsafeRedirect(t *testing.T) {
+	repo := newFakeRepo()
+	svc := NewService(repo)
+	h := NewHandler(svc)
+
+	mux := http.NewServeMux()
+	h.RegisterRoutes(mux)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/dashboard/logout?redirect_to=//evil.example", nil)
+	rr := httptest.NewRecorder()
+	mux.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusSeeOther {
+		t.Fatalf("expected 303, got %d", rr.Code)
+	}
+	if got := rr.Header().Get("Location"); got != "/" {
+		t.Fatalf("expected safe fallback redirect, got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary
- harden dashboard session cookies for https flows
- normalize login and logout redirect handling to remove open redirects

## Validation
- `go test ./internal/merchant`
- `go test -count=1 -tags=integration ./tests/integration/... -run 'TestIntegrationRBAC'`

Closes #563
