### PR TITLE
[#564] Bound detached audit and risk side effects

### DIFF
--- a/internal/audit/service.go
+++ b/internal/audit/service.go
@@ -3,6 +3,7 @@ package audit
 import (
 	"context"
 	"log/slog"
+	"time"
 )
 
 // Service records audit events and exposes the query API.
@@ -11,13 +12,38 @@ import (
 type Service struct {
 	repo   Repository
 	logger *slog.Logger
+
+	asyncSem     chan struct{}
+	asyncTimeout time.Duration
 }
 
-func NewService(repo Repository, logger *slog.Logger) *Service {
+type Option func(*Service)
+
+func WithAsyncConfig(limit int, timeout time.Duration) Option {
+	return func(s *Service) {
+		if limit > 0 {
+			s.asyncSem = make(chan struct{}, limit)
+		}
+		if timeout > 0 {
+			s.asyncTimeout = timeout
+		}
+	}
+}
+
+func NewService(repo Repository, logger *slog.Logger, opts ...Option) *Service {
 	if logger == nil {
 		logger = slog.Default()
 	}
-	return &Service{repo: repo, logger: logger}
+	svc := &Service{
+		repo:         repo,
+		logger:       logger,
+		asyncSem:     make(chan struct{}, 64),
+		asyncTimeout: 5 * time.Second,
+	}
+	for _, opt := range opts {
+		opt(svc)
+	}
+	return svc
 }
 
 // Record creates an audit log entry asynchronously.
@@ -25,10 +51,25 @@ func NewService(repo Repository, logger *slog.Logger) *Service {
 // A detached context is used so that HTTP request cancellation does not
 // prevent the audit entry from being persisted.
 func (s *Service) Record(ctx context.Context, in RecordInput) {
+	select {
+	case s.asyncSem <- struct{}{}:
+	default:
+		s.logger.Warn("audit record dropped because async queue is full",
+			"action", in.Action,
+			"resource_type", in.ResourceType,
+			"resource_id", in.ResourceID,
+		)
+		return
+	}
+
 	// Detach from the request context: the HTTP handler may return (and thus
 	// cancel ctx) before this goroutine runs its INSERT.
 	detached := context.WithoutCancel(ctx)
 	go func() {
+		defer func() { <-s.asyncSem }()
+		timeoutCtx, cancel := context.WithTimeout(detached, s.asyncTimeout)
+		defer cancel()
+
 		l := Log{
 			MerchantID:    in.MerchantID,
 			ActorID:       in.ActorID,
@@ -41,7 +82,7 @@ func (s *Service) Record(ctx context.Context, in RecordInput) {
 			IPAddress:     in.IPAddress,
 			CorrelationID: in.CorrelationID,
 		}
-		if _, err := s.repo.Create(detached, l); err != nil {
+		if _, err := s.repo.Create(timeoutCtx, l); err != nil {
 			s.logger.Error("audit record failed",
 				"action", in.Action,
 				"resource_type", in.ResourceType,

--- a/internal/audit/service_test.go
+++ b/internal/audit/service_test.go
@@ -1,0 +1,63 @@
+package audit
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+type blockingRepo struct {
+	mu      sync.Mutex
+	calls   int
+	release chan struct{}
+}
+
+func (r *blockingRepo) Create(ctx context.Context, log Log) (Log, error) {
+	r.mu.Lock()
+	r.calls++
+	r.mu.Unlock()
+	select {
+	case <-r.release:
+	case <-ctx.Done():
+		return Log{}, ctx.Err()
+	}
+	return log, nil
+}
+
+func (r *blockingRepo) List(context.Context, ListInput) ([]Log, error) {
+	return nil, nil
+}
+
+func TestRecordDropsWhenAsyncQueueIsFull(t *testing.T) {
+	t.Parallel()
+
+	repo := &blockingRepo{release: make(chan struct{})}
+	svc := NewService(repo, nil, WithAsyncConfig(1, time.Second))
+
+	svc.Record(context.Background(), RecordInput{MerchantID: "merch_1", Action: "first"})
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		repo.mu.Lock()
+		calls := repo.calls
+		repo.mu.Unlock()
+		if calls == 1 {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("expected first async audit record to start")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	svc.Record(context.Background(), RecordInput{MerchantID: "merch_1", Action: "second"})
+	time.Sleep(50 * time.Millisecond)
+
+	repo.mu.Lock()
+	defer repo.mu.Unlock()
+	if repo.calls != 1 {
+		t.Fatalf("expected second audit record to be dropped when queue is full, got %d calls", repo.calls)
+	}
+	close(repo.release)
+}

--- a/internal/risk/service.go
+++ b/internal/risk/service.go
@@ -3,6 +3,7 @@ package risk
 import (
 	"context"
 	"log/slog"
+	"time"
 
 	"github.com/sanskarpan/PayGate/internal/payment"
 )
@@ -14,6 +15,9 @@ type Service struct {
 	alertFn          AlertFunc
 	payments         *payment.Service
 	reserveEscalator func(ctx context.Context, ev RiskEvent) error
+
+	asyncSem     chan struct{}
+	asyncTimeout time.Duration
 }
 
 // WithAlertFunc returns a functional option that sets the alert function on the Service.
@@ -27,7 +31,12 @@ func NewService(repo Repository, logger *slog.Logger, opts ...func(*Service)) *S
 	if logger == nil {
 		logger = slog.Default()
 	}
-	svc := &Service{repo: repo, logger: logger}
+	svc := &Service{
+		repo:         repo,
+		logger:       logger,
+		asyncSem:     make(chan struct{}, 32),
+		asyncTimeout: 5 * time.Second,
+	}
 	for _, opt := range opts {
 		opt(svc)
 	}
@@ -43,6 +52,17 @@ func WithPaymentService(payments *payment.Service) func(*Service) {
 func WithReserveEscalator(fn func(ctx context.Context, ev RiskEvent) error) func(*Service) {
 	return func(s *Service) {
 		s.reserveEscalator = fn
+	}
+}
+
+func WithAsyncConfig(limit int, timeout time.Duration) func(*Service) {
+	return func(s *Service) {
+		if limit > 0 {
+			s.asyncSem = make(chan struct{}, limit)
+		}
+		if timeout > 0 {
+			s.asyncTimeout = timeout
+		}
 	}
 }
 
@@ -129,21 +149,41 @@ func (s *Service) EvaluatePayment(ctx context.Context, in EvalInput) (RiskEvent,
 			"rules", result.TriggeredRules,
 		)
 		if s.alertFn != nil {
-			// Use a context that carries trace/values from ctx but is not
-			// cancelled when the HTTP request completes, so the alert can
-			// finish its own I/O independently.
-			go s.alertFn(context.WithoutCancel(ctx), ev)
+			s.runAsync(context.WithoutCancel(ctx), "risk alert", ev, func(asyncCtx context.Context) error {
+				s.alertFn(asyncCtx, ev)
+				return nil
+			})
 		}
 		if s.reserveEscalator != nil && shouldEscalateReserve(ev) {
-			go func() {
-				if err := s.reserveEscalator(context.WithoutCancel(ctx), ev); err != nil {
-					s.logger.Warn("reserve escalation callback failed", "merchant_id", ev.MerchantID, "payment_id", ev.PaymentID, "error", err)
-				}
-			}()
+			s.runAsync(context.WithoutCancel(ctx), "reserve escalation", ev, func(asyncCtx context.Context) error {
+				return s.reserveEscalator(asyncCtx, ev)
+			})
 		}
 	}
 
 	return ev, nil
+}
+
+func (s *Service) runAsync(ctx context.Context, operation string, ev RiskEvent, fn func(context.Context) error) {
+	select {
+	case s.asyncSem <- struct{}{}:
+	default:
+		s.logger.Warn("risk async callback dropped because queue is full",
+			"operation", operation,
+			"merchant_id", ev.MerchantID,
+			"payment_id", ev.PaymentID,
+		)
+		return
+	}
+
+	go func() {
+		defer func() { <-s.asyncSem }()
+		timeoutCtx, cancel := context.WithTimeout(ctx, s.asyncTimeout)
+		defer cancel()
+		if err := fn(timeoutCtx); err != nil {
+			s.logger.Warn(operation+" failed", "merchant_id", ev.MerchantID, "payment_id", ev.PaymentID, "error", err)
+		}
+	}()
 }
 
 func shouldEscalateReserve(ev RiskEvent) bool {

--- a/internal/risk/service_async_test.go
+++ b/internal/risk/service_async_test.go
@@ -1,0 +1,42 @@
+package risk
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRunAsyncDropsWhenQueueIsFull(t *testing.T) {
+	t.Parallel()
+
+	svc := NewService(nil, nil, WithAsyncConfig(1, time.Second))
+	var calls atomic.Int32
+	release := make(chan struct{})
+	ev := RiskEvent{MerchantID: "merch_1", PaymentID: "pay_1"}
+
+	svc.runAsync(context.Background(), "first", ev, func(ctx context.Context) error {
+		calls.Add(1)
+		<-release
+		return nil
+	})
+
+	deadline := time.Now().Add(time.Second)
+	for calls.Load() != 1 {
+		if time.Now().After(deadline) {
+			t.Fatal("expected first async callback to start")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	svc.runAsync(context.Background(), "second", ev, func(ctx context.Context) error {
+		calls.Add(1)
+		return nil
+	})
+	time.Sleep(50 * time.Millisecond)
+
+	if calls.Load() != 1 {
+		t.Fatalf("expected second async callback to be dropped when queue is full, got %d calls", calls.Load())
+	}
+	close(release)
+}


### PR DESCRIPTION
## Summary
- bound detached audit work with queueing and timeouts
- bound detached risk callbacks with queueing and timeouts
- add queue saturation regression coverage

## Validation
- `go test ./internal/audit ./internal/risk`
- `go test ./...`

Closes #564
