### PR TITLE
[#565] Clean race and contract test alignment after hardening

### DIFF
--- a/internal/eventschema/contract_test.go
+++ b/internal/eventschema/contract_test.go
@@ -136,8 +136,28 @@ func (r *contractWebhookRepo) CreateDeliveryAttempt(_ context.Context, attempt w
 	r.attempts = append(r.attempts, attempt)
 	return attempt, nil
 }
-func (r *contractWebhookRepo) UpdateDeliveryAttempt(context.Context, string, webhook.DeliveryStatus, int, string, string, *string, int) (webhook.WebhookDeliveryAttempt, error) {
-	panic("not used")
+func (r *contractWebhookRepo) ReserveDeliveryAttempt(_ context.Context, attempt webhook.WebhookDeliveryAttempt) (webhook.WebhookDeliveryAttempt, error) {
+	for _, existing := range r.attempts {
+		if existing.EventID == attempt.EventID && existing.SubscriptionID == attempt.SubscriptionID {
+			return webhook.WebhookDeliveryAttempt{}, webhook.ErrDeliveryAlreadyReserved
+		}
+	}
+	r.attempts = append(r.attempts, attempt)
+	return attempt, nil
+}
+func (r *contractWebhookRepo) UpdateDeliveryAttempt(_ context.Context, id string, status webhook.DeliveryStatus, responseCode int, responseBody, errorMessage string, _ *string, attemptNumber int) (webhook.WebhookDeliveryAttempt, error) {
+	for i := range r.attempts {
+		if r.attempts[i].ID != id {
+			continue
+		}
+		r.attempts[i].Status = status
+		r.attempts[i].ResponseCode = responseCode
+		r.attempts[i].ResponseBody = responseBody
+		r.attempts[i].ErrorMessage = errorMessage
+		r.attempts[i].AttemptNumber = attemptNumber
+		return r.attempts[i], nil
+	}
+	return webhook.WebhookDeliveryAttempt{}, webhook.ErrDeliveryAttemptNotFound
 }
 func (r *contractWebhookRepo) ListDeliveryAttempts(context.Context, string, string) ([]webhook.WebhookDeliveryAttempt, error) {
 	return r.attempts, nil

--- a/internal/payment/sweeper_test.go
+++ b/internal/payment/sweeper_test.go
@@ -2,11 +2,13 @@ package payment
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 )
 
 type fakeRepo struct {
+	mu           sync.Mutex
 	autoCalled   bool
 	expireCalled bool
 }
@@ -105,11 +107,15 @@ func (f *fakeRepo) ListPayments(context.Context, ListFilter) (ListResult, error)
 	return ListResult{}, nil
 }
 func (f *fakeRepo) AutoCaptureDue(context.Context) (int64, error) {
+	f.mu.Lock()
 	f.autoCalled = true
+	f.mu.Unlock()
 	return 0, nil
 }
 func (f *fakeRepo) ExpireAuthorizationWindow(context.Context, time.Duration) (int64, error) {
+	f.mu.Lock()
 	f.expireCalled = true
+	f.mu.Unlock()
 	return 0, nil
 }
 
@@ -121,6 +127,8 @@ func TestSweeperInvokesRepo(t *testing.T) {
 	go s.Start(ctx)
 	time.Sleep(25 * time.Millisecond)
 	cancel()
+	repo.mu.Lock()
+	defer repo.mu.Unlock()
 	if !repo.autoCalled || !repo.expireCalled {
 		t.Fatalf("expected sweeper to invoke both paths, auto=%v expire=%v", repo.autoCalled, repo.expireCalled)
 	}


### PR DESCRIPTION
## Summary
- make the payment sweeper test fake race-safe
- align event schema webhook contract tests with the reservation-based repository contract

## Validation
- `go test -race ./internal/payment ./internal/webhook ./internal/merchant`
- `go test ./internal/eventschema ./internal/payment`

Closes #565
