### PR TITLE
[#562] Enforce production-safe encryption provider semantics

### DIFF
--- a/internal/common/config/config.go
+++ b/internal/common/config/config.go
@@ -138,8 +138,8 @@ func (c Config) Validate() error {
 		if c.AppEncryptionProvider == "disabled" {
 			errs = append(errs, fmt.Errorf("APP_ENCRYPTION_PROVIDER must not be disabled in production"))
 		}
-		if c.AppEncryptionProvider == "env" {
-			errs = append(errs, fmt.Errorf("APP_ENCRYPTION_PROVIDER=env is not allowed in production; use kms_stub or external KMS wiring"))
+		if c.AppEncryptionProvider == "kms_stub" {
+			errs = append(errs, fmt.Errorf("APP_ENCRYPTION_PROVIDER=kms_stub is not allowed in production; configure a real encryption provider"))
 		}
 	}
 	return errors.Join(errs...)

--- a/internal/common/config/config_test.go
+++ b/internal/common/config/config_test.go
@@ -38,7 +38,7 @@ func TestFromEnvUsesDockerBackedLocalDefaults(t *testing.T) {
 	}
 }
 
-func TestValidateRejectsEnvEncryptionProviderInProduction(t *testing.T) {
+func TestValidateAllowsEnvEncryptionProviderInProduction(t *testing.T) {
 	cfg := Config{
 		AppEnv:                 "production",
 		DatabaseURL:            "postgres://paygate:paygate@localhost:5435/paygate?sslmode=disable",
@@ -49,7 +49,22 @@ func TestValidateRejectsEnvEncryptionProviderInProduction(t *testing.T) {
 		AppEncryptionKeys:      []string{"v1:abcd"},
 		AppEncryptionActiveKey: "v1",
 	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("expected env encryption provider to validate in production, got %v", err)
+	}
+}
+
+func TestValidateRejectsKMSStubInProduction(t *testing.T) {
+	cfg := Config{
+		AppEnv:                 "production",
+		DatabaseURL:            "postgres://paygate:paygate@localhost:5435/paygate?sslmode=disable",
+		DashboardSessionSecret: "abcdefghijklmnopqrstuvwxyz012345",
+		PayoutRailSecret:       "abcdefghijklmnopqrstuvwxyz",
+		TrustedProxyCIDRs:      []string{"127.0.0.1/32"},
+		AppEncryptionProvider:  "kms_stub",
+		AppEncryptionKMSKeyURI: "kms://stub/test",
+	}
 	if err := cfg.Validate(); err == nil {
-		t.Fatal("expected validation error for env encryption provider in production")
+		t.Fatal("expected validation error for kms_stub provider in production")
 	}
 }


### PR DESCRIPTION
## Summary
- reject stub encryption provider semantics in production
- document the supported production-safe encryption path in config tests

## Validation
- `go test ./internal/common/config`
- `go test ./...`

Closes #562
