### PR TITLE
[#587] Unblock repo-wide lint and integration checks for the PR stack

### DIFF
--- a/internal/billing/payment_link.go
+++ b/internal/billing/payment_link.go
@@ -2,7 +2,6 @@ package billing
 
 import (
 	"context"
-	"fmt"
 	"strings"
 	"time"
 
@@ -151,8 +150,4 @@ func (s *Service) refreshPaymentLinkStatus(ctx context.Context, link PaymentLink
 		return s.repo.UpdatePaymentLinkStatus(ctx, link.MerchantID, link.ID, PaymentLinkPaid)
 	}
 	return link, nil
-}
-
-func paymentLinkRedirectPath(link PaymentLink) string {
-	return fmt.Sprintf("/checkout?merchant_id=%s&order_id=%s&callback_url=%s", link.MerchantID, link.OrderID, link.CallbackURL)
 }

--- a/internal/billing/service.go
+++ b/internal/billing/service.go
@@ -2,6 +2,7 @@ package billing
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -439,7 +440,8 @@ func (s *Service) CreateSubscription(ctx context.Context, in CreateSubscriptionI
 	if in.CollectionMethod == "" {
 		in.CollectionMethod = CollectionMethodCard
 	}
-	if in.CollectionMethod == CollectionMethodCard {
+	switch in.CollectionMethod {
+	case CollectionMethodCard:
 		token, err := s.tokenSvc.GetCardToken(ctx, in.MerchantID, in.PaymentMethodTokenID)
 		if err != nil {
 			return Subscription{}, err
@@ -450,7 +452,7 @@ func (s *Service) CreateSubscription(ctx context.Context, in CreateSubscriptionI
 		if token.CustomerRef != "" && token.CustomerRef != customer.ID {
 			return Subscription{}, ErrCustomerTokenMismatch
 		}
-	} else if in.CollectionMethod == CollectionMethodUPIMandate {
+	case CollectionMethodUPIMandate:
 		mandate, err := s.repo.GetUPIMandate(ctx, in.MerchantID, in.UPIMandateID)
 		if err != nil {
 			return Subscription{}, err
@@ -614,9 +616,7 @@ func (s *Service) runSubscription(ctx context.Context, subscription Subscription
 		},
 	})
 	if err != nil {
-		nextAt, retryCount := subscriptionFailureSchedule(subscription)
-		_ = s.repo.MarkInvoiceAttempt(ctx, subscription.MerchantID, attempt.ID, InvoiceAttemptFailed, "", "", "ORDER_CREATE_FAILED", err.Error())
-		invoice, _ = s.repo.MarkInvoiceFailed(ctx, subscription.MerchantID, invoice.ID, "ORDER_CREATE_FAILED", err.Error(), nextAt, retryCount)
+		invoice, err = s.markSubscriptionInvoiceFailure(ctx, subscription, attempt.ID, invoice, "", "", "ORDER_CREATE_FAILED", err)
 		return invoice, payment.CaptureResult{}, err
 	}
 	_ = s.repo.MarkInvoiceAttempt(ctx, subscription.MerchantID, attempt.ID, InvoiceAttemptStarted, orderResult.ID, "", "", "")
@@ -624,16 +624,13 @@ func (s *Service) runSubscription(ctx context.Context, subscription Subscription
 	if subscription.CollectionMethod == CollectionMethodUPIMandate {
 		mandate, err := s.repo.GetUPIMandate(ctx, subscription.MerchantID, subscription.UPIMandateID)
 		if err != nil {
-			nextAt, retryCount := subscriptionFailureSchedule(subscription)
-			_ = s.repo.MarkInvoiceAttempt(ctx, subscription.MerchantID, attempt.ID, InvoiceAttemptFailed, orderResult.ID, "", "MANDATE_LOOKUP_FAILED", err.Error())
-			invoice, _ = s.repo.MarkInvoiceFailed(ctx, subscription.MerchantID, invoice.ID, "MANDATE_LOOKUP_FAILED", err.Error(), nextAt, retryCount)
+			invoice, err = s.markSubscriptionInvoiceFailure(ctx, subscription, attempt.ID, invoice, orderResult.ID, "", "MANDATE_LOOKUP_FAILED", err)
 			return invoice, payment.CaptureResult{}, err
 		}
 		if mandate.Status != UPIMandateActive {
-			nextAt, retryCount := subscriptionFailureSchedule(subscription)
-			_ = s.repo.MarkInvoiceAttempt(ctx, subscription.MerchantID, attempt.ID, InvoiceAttemptFailed, orderResult.ID, "", "MANDATE_NOT_ACTIVE", ErrUPIMandateNotActive.Error())
-			invoice, _ = s.repo.MarkInvoiceFailed(ctx, subscription.MerchantID, invoice.ID, "MANDATE_NOT_ACTIVE", ErrUPIMandateNotActive.Error(), nextAt, retryCount)
-			return invoice, payment.CaptureResult{}, ErrUPIMandateNotActive
+			err = ErrUPIMandateNotActive
+			invoice, err = s.markSubscriptionInvoiceFailure(ctx, subscription, attempt.ID, invoice, orderResult.ID, "", "MANDATE_NOT_ACTIVE", err)
+			return invoice, payment.CaptureResult{}, err
 		}
 		upiResult, err := s.paymentSvc.CreateUPIMandateCharge(ctx, payment.CreateUPIMandateChargeInput{
 			MerchantID:     subscription.MerchantID,
@@ -647,10 +644,10 @@ func (s *Service) runSubscription(ctx context.Context, subscription Subscription
 			PaymentID:      idgen.New("pay"),
 		})
 		if err != nil {
-			nextAt, retryCount := subscriptionFailureSchedule(subscription)
-			_ = s.repo.MarkInvoiceAttempt(ctx, subscription.MerchantID, attempt.ID, InvoiceAttemptFailed, orderResult.ID, "", "MANDATE_CHARGE_FAILED", err.Error())
-			_ = s.repo.RecordUPIMandateChargeResult(ctx, subscription.MerchantID, mandate.ID, MandateEventChargeErr, "", err.Error(), map[string]any{"invoice_id": invoice.ID, "subscription_id": subscription.ID})
-			invoice, _ = s.repo.MarkInvoiceFailed(ctx, subscription.MerchantID, invoice.ID, "MANDATE_CHARGE_FAILED", err.Error(), nextAt, retryCount)
+			if recordErr := s.repo.RecordUPIMandateChargeResult(ctx, subscription.MerchantID, mandate.ID, MandateEventChargeErr, "", err.Error(), map[string]any{"invoice_id": invoice.ID, "subscription_id": subscription.ID}); recordErr != nil {
+				err = errors.Join(err, fmt.Errorf("record mandate charge failure: %w", recordErr))
+			}
+			invoice, err = s.markSubscriptionInvoiceFailure(ctx, subscription, attempt.ID, invoice, orderResult.ID, "", "MANDATE_CHARGE_FAILED", err)
 			return invoice, payment.CaptureResult{}, err
 		}
 		captureResult = upiResult.CaptureResult
@@ -668,18 +665,16 @@ func (s *Service) runSubscription(ctx context.Context, subscription Subscription
 			PaymentID:            idgen.New("pay"),
 		})
 		if err != nil {
-			nextAt, retryCount := subscriptionFailureSchedule(subscription)
-			_ = s.repo.MarkInvoiceAttempt(ctx, subscription.MerchantID, attempt.ID, InvoiceAttemptFailed, orderResult.ID, "", "AUTH_FAILED", err.Error())
-			invoice, _ = s.repo.MarkInvoiceFailed(ctx, subscription.MerchantID, invoice.ID, "AUTH_FAILED", err.Error(), nextAt, retryCount)
+			invoice, err = s.markSubscriptionInvoiceFailure(ctx, subscription, attempt.ID, invoice, orderResult.ID, "", "AUTH_FAILED", err)
 			return invoice, payment.CaptureResult{}, err
 		}
 		_ = s.repo.MarkInvoiceAttempt(ctx, subscription.MerchantID, attempt.ID, InvoiceAttemptAuthorized, orderResult.ID, authResult.PaymentID, "", "")
 		captureResult, err = s.paymentSvc.CaptureForMerchant(ctx, subscription.MerchantID, authResult.PaymentID, subscription.Amount)
 		if err != nil {
-			_, _ = s.paymentSvc.ReverseAuthorization(ctx, subscription.MerchantID, authResult.PaymentID, "subscription capture failed")
-			nextAt, retryCount := subscriptionFailureSchedule(subscription)
-			_ = s.repo.MarkInvoiceAttempt(ctx, subscription.MerchantID, attempt.ID, InvoiceAttemptFailed, orderResult.ID, authResult.PaymentID, "CAPTURE_FAILED", err.Error())
-			invoice, _ = s.repo.MarkInvoiceFailed(ctx, subscription.MerchantID, invoice.ID, "CAPTURE_FAILED", err.Error(), nextAt, retryCount)
+			if _, reverseErr := s.paymentSvc.ReverseAuthorization(ctx, subscription.MerchantID, authResult.PaymentID, "subscription capture failed"); reverseErr != nil {
+				err = errors.Join(err, fmt.Errorf("reverse authorization after capture failure: %w", reverseErr))
+			}
+			invoice, err = s.markSubscriptionInvoiceFailure(ctx, subscription, attempt.ID, invoice, orderResult.ID, authResult.PaymentID, "CAPTURE_FAILED", err)
 			return invoice, payment.CaptureResult{}, err
 		}
 		_ = s.repo.MarkInvoiceAttempt(ctx, subscription.MerchantID, attempt.ID, InvoiceAttemptCaptured, orderResult.ID, captureResult.PaymentID, "", "")
@@ -697,4 +692,21 @@ func subscriptionFailureSchedule(subscription Subscription) (time.Time, int) {
 		return time.Now().UTC().Add(time.Duration(subscription.RetryIntervalHours) * time.Hour), retryCount
 	}
 	return nextPeriodStart(subscription.NextBillingAt, subscription.IntervalUnit, subscription.IntervalCount), 0
+}
+
+func (s *Service) markSubscriptionInvoiceFailure(ctx context.Context, subscription Subscription, attemptID string, invoice Invoice, orderID, paymentID, failureCode string, primaryErr error) (Invoice, error) {
+	nextAt, retryCount := subscriptionFailureSchedule(subscription)
+	var cleanupErrs []error
+	if err := s.repo.MarkInvoiceAttempt(ctx, subscription.MerchantID, attemptID, InvoiceAttemptFailed, orderID, paymentID, failureCode, primaryErr.Error()); err != nil {
+		cleanupErrs = append(cleanupErrs, fmt.Errorf("mark invoice attempt failed: %w", err))
+	}
+	failedInvoice, err := s.repo.MarkInvoiceFailed(ctx, subscription.MerchantID, invoice.ID, failureCode, primaryErr.Error(), nextAt, retryCount)
+	if err != nil {
+		cleanupErrs = append(cleanupErrs, fmt.Errorf("mark invoice failed: %w", err))
+		failedInvoice = invoice
+	}
+	if len(cleanupErrs) == 0 {
+		return failedInvoice, primaryErr
+	}
+	return failedInvoice, errors.Join(append([]error{primaryErr}, cleanupErrs...)...)
 }

--- a/internal/common/config/config_test.go
+++ b/internal/common/config/config_test.go
@@ -41,7 +41,7 @@ func TestFromEnvUsesDockerBackedLocalDefaults(t *testing.T) {
 func TestValidateAllowsEnvEncryptionProviderInProduction(t *testing.T) {
 	cfg := Config{
 		AppEnv:                 "production",
-		DatabaseURL:            "postgres://paygate:paygate@localhost:5435/paygate?sslmode=disable",
+		DatabaseURL:            "postgres://localhost:5435/paygate?sslmode=disable",
 		DashboardSessionSecret: "abcdefghijklmnopqrstuvwxyz012345",
 		PayoutRailSecret:       "abcdefghijklmnopqrstuvwxyz",
 		TrustedProxyCIDRs:      []string{"127.0.0.1/32"},
@@ -57,7 +57,7 @@ func TestValidateAllowsEnvEncryptionProviderInProduction(t *testing.T) {
 func TestValidateRejectsKMSStubInProduction(t *testing.T) {
 	cfg := Config{
 		AppEnv:                 "production",
-		DatabaseURL:            "postgres://paygate:paygate@localhost:5435/paygate?sslmode=disable",
+		DatabaseURL:            "postgres://localhost:5435/paygate?sslmode=disable",
 		DashboardSessionSecret: "abcdefghijklmnopqrstuvwxyz012345",
 		PayoutRailSecret:       "abcdefghijklmnopqrstuvwxyz",
 		TrustedProxyCIDRs:      []string{"127.0.0.1/32"},

--- a/internal/payment/handler.go
+++ b/internal/payment/handler.go
@@ -550,10 +550,11 @@ func presentUPIIntent(out UPIIntentResult, callbackURL string) map[string]any {
 	resp := present(out.CaptureResult, nil)
 	entity := "upi_intent_payment"
 	nextActionType := "upi_intent"
-	if out.FlowType == "qr" {
+	switch out.FlowType {
+	case "qr":
 		entity = "upi_qr_payment"
 		nextActionType = "upi_qr"
-	} else if out.FlowType == "mandate" {
+	case "mandate":
 		entity = "upi_mandate_payment"
 		nextActionType = "upi_mandate"
 	}

--- a/internal/saga/worker.go
+++ b/internal/saga/worker.go
@@ -3,6 +3,7 @@ package saga
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/sanskarpan/PayGate/internal/common/idgen"
@@ -34,7 +35,7 @@ func (w *Worker) Start(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			if err := w.drain(ctx, leaseOwner); err != nil && ctx.Err() == nil {
+			if err := w.drain(ctx, leaseOwner); err != nil && ctx.Err() == nil && !isClosedPoolError(err) {
 				w.logger.Error("saga worker drain failed", "error", err)
 			}
 		}
@@ -58,4 +59,8 @@ func (w *Worker) drain(ctx context.Context, leaseOwner string) error {
 			return nil
 		}
 	}
+}
+
+func isClosedPoolError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "closed pool")
 }

--- a/sdk/go/paygate/client.go
+++ b/sdk/go/paygate/client.go
@@ -69,6 +69,7 @@ type WebhookSubscription struct {
 	Events        []string `json:"events"`
 	Status        string   `json:"status"`
 	SignatureMode string   `json:"signature_mode"`
+	//nolint:gosec // webhook API returns a signing secret by design.
 	Secret        string   `json:"secret"`
 }
 

--- a/sdk/go/paygate/client_test.go
+++ b/sdk/go/paygate/client_test.go
@@ -57,11 +57,12 @@ func TestCreateCardTokenAndWebhookSubscription(t *testing.T) {
 				t.Fatalf("unexpected method %s", r.Method)
 			}
 			_ = json.NewEncoder(w).Encode(CardToken{ID: "ctok_123", Brand: "visa", Last4: "1111", PaymentTokenType: "single_use", Reusable: false})
-		case "/v1/webhooks":
-			if r.Method != http.MethodPost {
-				t.Fatalf("unexpected method %s", r.Method)
-			}
-			_ = json.NewEncoder(w).Encode(WebhookSubscription{ID: "wh_123", URL: "https://example.com/hook", Status: "active", SignatureMode: "compat"})
+			case "/v1/webhooks":
+				if r.Method != http.MethodPost {
+					t.Fatalf("unexpected method %s", r.Method)
+				}
+				//nolint:gosec // test fixture intentionally mirrors the webhook response shape.
+				_ = json.NewEncoder(w).Encode(WebhookSubscription{ID: "wh_123", URL: "https://example.com/hook", Status: "active", SignatureMode: "compat"})
 		default:
 			t.Fatalf("unexpected path %s", r.URL.Path)
 		}


### PR DESCRIPTION
Closes #587.

This PR removes the repo-wide lint blockers and integration teardown noise that kept the stacked UI/runtime PRs from becoming mergeable.

Validation:
- golangci-lint run --timeout=5m
- go test ./...
- go vet ./...
- go test -count=1 -tags=integration ./tests/integration/...