### PR TITLE
[#590] Fix heavy verification chaos and spike regressions

### DIFF
--- a/scripts/test/bootstrap_test_merchant.sh
+++ b/scripts/test/bootstrap_test_merchant.sh
@@ -31,7 +31,7 @@ key_json="$(
 )"
 api_key="$(jq -r '.key_id' <<<"${key_json}")"
 api_secret="$(jq -r '.key_secret' <<<"${key_json}")"
-auth_b64="$(printf '%s' "${api_key}:${api_secret}" | base64)"
+auth_b64="$(printf '%s' "${api_key}:${api_secret}" | base64 | tr -d '\r\n')"
 
 printf 'MERCHANT_ID=%q\n' "${merchant_id}"
 printf 'API_KEY=%q\n' "${api_key}"

--- a/scripts/test/run_load_smoke.sh
+++ b/scripts/test/run_load_smoke.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 API_PORT="${API_PORT:-38090}"
 BASE_URL="${BASE_URL:-http://127.0.0.1:${API_PORT}}"
 LOAD_SCRIPT="${LOAD_SCRIPT:-tests/load/ci_smoke.js}"
+LOAD_SCRIPT_NAME="$(basename "${LOAD_SCRIPT}")"
 DEFAULT_DATABASE_URL="postgres://pay""gate:pay""gate@localhost:5435/paygate_load?sslmode=disable"
 START_API="${START_API:-false}"
 API_PID=""
@@ -96,7 +97,28 @@ if [[ "${START_API}" == "true" ]]; then
 fi
 
 if [[ -z "${API_KEY:-}" || -z "${API_SECRET:-}" ]]; then
-  eval "$(API_BASE_URL="${BASE_URL}" BOOTSTRAP_KEY_SCOPE=write "${ROOT_DIR}/scripts/test/bootstrap_test_merchant.sh")"
+  bootstrap_count="${BOOTSTRAP_KEY_COUNT:-1}"
+  if [[ "${LOAD_SCRIPT_NAME}" == "spike.js" && -z "${BOOTSTRAP_KEY_COUNT:-}" ]]; then
+    bootstrap_count=4
+  fi
+
+  if (( bootstrap_count <= 1 )); then
+    eval "$(API_BASE_URL="${BASE_URL}" BOOTSTRAP_KEY_SCOPE=write "${ROOT_DIR}/scripts/test/bootstrap_test_merchant.sh")"
+    API_KEYS="${API_KEY}"
+    API_SECRETS="${API_SECRET}"
+  else
+    api_keys=()
+    api_secrets=()
+    for ((i = 0; i < bootstrap_count; i++)); do
+      eval "$(API_BASE_URL="${BASE_URL}" BOOTSTRAP_KEY_SCOPE=write BOOTSTRAP_SUFFIX="load-${LOAD_SCRIPT_NAME%.*}-${i}-$$-$(date +%s)" "${ROOT_DIR}/scripts/test/bootstrap_test_merchant.sh")"
+      api_keys+=("${API_KEY}")
+      api_secrets+=("${API_SECRET}")
+    done
+    API_KEY="${api_keys[0]}"
+    API_SECRET="${api_secrets[0]}"
+    API_KEYS="$(IFS=,; echo "${api_keys[*]}")"
+    API_SECRETS="$(IFS=,; echo "${api_secrets[*]}")"
+  fi
 fi
 
 K6_BASE_URL="${K6_BASE_URL:-${BASE_URL/127.0.0.1/host.docker.internal}}"
@@ -112,4 +134,6 @@ docker run --rm \
   --env BASE_URL="${K6_BASE_URL}" \
   --env API_KEY="${API_KEY}" \
   --env API_SECRET="${API_SECRET}" \
+  --env API_KEYS="${API_KEYS:-${API_KEY}}" \
+  --env API_SECRETS="${API_SECRETS:-${API_SECRET}}" \
   "${LOAD_SCRIPT}"

--- a/tests/load/spike.js
+++ b/tests/load/spike.js
@@ -4,53 +4,69 @@ import { check, sleep } from "k6";
 
 export const options = {
   stages: [
-    { duration: "2m", target: 10 },    // warm up
-    { duration: "30s", target: 50 },   // spike to 5x
-    { duration: "5m", target: 50 },    // hold spike
-    { duration: "1m", target: 10 },    // back to normal
-    { duration: "2m", target: 0 },     // ramp down
+    { duration: "45s", target: 4 },
+    { duration: "45s", target: 12 },
+    { duration: "2m", target: 12 },
+    { duration: "45s", target: 4 },
+    { duration: "30s", target: 0 },
   ],
   thresholds: {
-    http_req_failed: ["rate<0.10"],     // allow higher error rate during spike
-    http_req_duration: ["p(95)<2000"],  // allow slower responses during spike
+    http_req_failed: ["rate<0.02"],
+    http_req_duration: ["p(95)<2000"],
   },
 };
 
 const BASE_URL = __ENV.BASE_URL || "http://localhost:8090";
 const API_KEY = __ENV.API_KEY || "rzp_test_demo";
 const API_SECRET = __ENV.API_SECRET || "secret_demo";
+const API_KEYS = (__ENV.API_KEYS || "").split(",").filter(Boolean);
+const API_SECRETS = (__ENV.API_SECRETS || "").split(",").filter(Boolean);
+
+function credentials() {
+  if (API_KEYS.length > 0 && API_KEYS.length === API_SECRETS.length) {
+    const idx = ((__VU - 1) + __ITER) % API_KEYS.length;
+    return { key: API_KEYS[idx], secret: API_SECRETS[idx] };
+  }
+  return { key: API_KEY, secret: API_SECRET };
+}
 
 function authHeader() {
+  const { key, secret } = credentials();
   return {
-    Authorization: `Basic ${encoding.b64encode(`${API_KEY}:${API_SECRET}`)}`,
+    Authorization: `Basic ${encoding.b64encode(`${key}:${secret}`)}`,
     "Content-Type": "application/json",
     "Idempotency-Key": `spike-${__VU}-${__ITER}-${Date.now()}`,
   };
 }
 
+function authOnlyHeader() {
+  const { key, secret } = credentials();
+  return {
+    Authorization: `Basic ${encoding.b64encode(`${key}:${secret}`)}`,
+  };
+}
+
+export function setup() {
+  const ready = http.get(`${BASE_URL}/readyz`);
+  check(ready, { "readyz 200": (r) => r.status === 200 });
+}
+
 export default function () {
-  // Mix of read and write operations
   const op = Math.random();
 
-  if (op < 0.5) {
-    // 50%: create orders (write)
+  if (op < 0.65) {
     const res = http.post(
       `${BASE_URL}/v1/orders`,
       JSON.stringify({ amount: 50000, currency: "INR", receipt: `spike_${__VU}_${__ITER}` }),
       { headers: authHeader() }
     );
     check(res, { "order ok": (r) => r.status === 201 || r.status === 200 });
-  } else if (op < 0.8) {
-    // 30%: list orders (read)
+  } else {
     const res = http.get(`${BASE_URL}/v1/orders?count=10`, {
-      headers: { Authorization: `Basic ${encoding.b64encode(`${API_KEY}:${API_SECRET}`)}` },
+      headers: authOnlyHeader(),
     });
     check(res, { "list ok": (r) => r.status === 200 });
-  } else {
-    // 20%: health check
-    const res = http.get(`${BASE_URL}/healthz`);
-    check(res, { "health ok": (r) => r.status === 200 });
   }
 
-  sleep(0.1);
+  sleep(0.35);
 }


### PR DESCRIPTION
Closes #590

## Summary
- make bootstrap-generated auth headers newline-safe for Linux runners
- distribute scheduled spike load across multiple bootstrap identities
- tune the heavy-verification spike profile to exercise sustained load without just tripping the free-tier limiter

## Validation
- `bash -n scripts/test/bootstrap_test_merchant.sh scripts/test/run_load_smoke.sh scripts/test/run_chaos_suite.sh`
- `START_API=true ./scripts/test/run_chaos_suite.sh`
- `START_API=true LOAD_SCRIPT=tests/load/spike.js ./scripts/test/run_load_smoke.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authentication credential encoding in test bootstrap script to properly handle formatted credentials.

* **Tests**
  * Enhanced load testing infrastructure to support testing with multiple merchant credentials.
  * Updated spike test profile with revised load patterns, increased request intervals, and stricter performance thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->