### PR TITLE
[#593][#594] Surface recurring billing failures and log non-fatal bookkeeping drift

### DIFF
--- a/internal/billing/service.go
+++ b/internal/billing/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -20,10 +21,17 @@ type Service struct {
 	paymentSvc *payment.Service
 	tokenSvc   *tokenization.Service
 	vpaVerify  *upiverify.Service
+	logger     *slog.Logger
 }
 
 func NewService(repo Repository, orderSvc *order.Service, paymentSvc *payment.Service, tokenSvc *tokenization.Service, opts ...func(*Service)) *Service {
-	svc := &Service{repo: repo, orderSvc: orderSvc, paymentSvc: paymentSvc, tokenSvc: tokenSvc}
+	svc := &Service{
+		repo:       repo,
+		orderSvc:   orderSvc,
+		paymentSvc: paymentSvc,
+		tokenSvc:   tokenSvc,
+		logger:     slog.Default(),
+	}
 	for _, opt := range opts {
 		opt(svc)
 	}
@@ -33,6 +41,14 @@ func NewService(repo Repository, orderSvc *order.Service, paymentSvc *payment.Se
 func WithVPAVerifier(verifier *upiverify.Service) func(*Service) {
 	return func(s *Service) {
 		s.vpaVerify = verifier
+	}
+}
+
+func WithLogger(logger *slog.Logger) func(*Service) {
+	return func(s *Service) {
+		if logger != nil {
+			s.logger = logger
+		}
 	}
 }
 
@@ -563,13 +579,19 @@ func (s *Service) RunDueSubscriptions(ctx context.Context, limit int) ([]Invoice
 		return nil, err
 	}
 	var invoices []Invoice
+	var runErrs []error
 	for _, subscription := range due {
 		invoice, _, err := s.runSubscription(ctx, subscription)
 		if err == nil {
 			invoices = append(invoices, invoice)
+			continue
 		}
+		runErrs = append(runErrs, fmt.Errorf("run subscription %s: %w", subscription.ID, err))
 	}
-	return invoices, nil
+	if len(runErrs) == 0 {
+		return invoices, nil
+	}
+	return invoices, errors.Join(runErrs...)
 }
 
 func (s *Service) runSubscription(ctx context.Context, subscription Subscription) (Invoice, payment.CaptureResult, error) {
@@ -619,7 +641,7 @@ func (s *Service) runSubscription(ctx context.Context, subscription Subscription
 		invoice, err = s.markSubscriptionInvoiceFailure(ctx, subscription, attempt.ID, invoice, "", "", "ORDER_CREATE_FAILED", err)
 		return invoice, payment.CaptureResult{}, err
 	}
-	_ = s.repo.MarkInvoiceAttempt(ctx, subscription.MerchantID, attempt.ID, InvoiceAttemptStarted, orderResult.ID, "", "", "")
+	s.recordInvoiceAttemptNonFatal(ctx, subscription, attempt.ID, InvoiceAttemptStarted, orderResult.ID, "", "", "")
 	var captureResult payment.CaptureResult
 	if subscription.CollectionMethod == CollectionMethodUPIMandate {
 		mandate, err := s.repo.GetUPIMandate(ctx, subscription.MerchantID, subscription.UPIMandateID)
@@ -651,8 +673,8 @@ func (s *Service) runSubscription(ctx context.Context, subscription Subscription
 			return invoice, payment.CaptureResult{}, err
 		}
 		captureResult = upiResult.CaptureResult
-		_ = s.repo.MarkInvoiceAttempt(ctx, subscription.MerchantID, attempt.ID, InvoiceAttemptCaptured, orderResult.ID, captureResult.PaymentID, "", "")
-		_ = s.repo.RecordUPIMandateChargeResult(ctx, subscription.MerchantID, mandate.ID, MandateEventChargeOK, captureResult.PaymentID, "", map[string]any{"invoice_id": invoice.ID, "subscription_id": subscription.ID})
+		s.recordInvoiceAttemptNonFatal(ctx, subscription, attempt.ID, InvoiceAttemptCaptured, orderResult.ID, captureResult.PaymentID, "", "")
+		s.recordMandateChargeResultNonFatal(ctx, subscription, mandate.ID, MandateEventChargeOK, captureResult.PaymentID, "", map[string]any{"invoice_id": invoice.ID, "subscription_id": subscription.ID})
 	} else {
 		authResult, err := s.paymentSvc.Authorize(ctx, payment.AuthorizeInput{
 			MerchantID:           subscription.MerchantID,
@@ -668,7 +690,7 @@ func (s *Service) runSubscription(ctx context.Context, subscription Subscription
 			invoice, err = s.markSubscriptionInvoiceFailure(ctx, subscription, attempt.ID, invoice, orderResult.ID, "", "AUTH_FAILED", err)
 			return invoice, payment.CaptureResult{}, err
 		}
-		_ = s.repo.MarkInvoiceAttempt(ctx, subscription.MerchantID, attempt.ID, InvoiceAttemptAuthorized, orderResult.ID, authResult.PaymentID, "", "")
+		s.recordInvoiceAttemptNonFatal(ctx, subscription, attempt.ID, InvoiceAttemptAuthorized, orderResult.ID, authResult.PaymentID, "", "")
 		captureResult, err = s.paymentSvc.CaptureForMerchant(ctx, subscription.MerchantID, authResult.PaymentID, subscription.Amount)
 		if err != nil {
 			if _, reverseErr := s.paymentSvc.ReverseAuthorization(ctx, subscription.MerchantID, authResult.PaymentID, "subscription capture failed"); reverseErr != nil {
@@ -677,7 +699,7 @@ func (s *Service) runSubscription(ctx context.Context, subscription Subscription
 			invoice, err = s.markSubscriptionInvoiceFailure(ctx, subscription, attempt.ID, invoice, orderResult.ID, authResult.PaymentID, "CAPTURE_FAILED", err)
 			return invoice, payment.CaptureResult{}, err
 		}
-		_ = s.repo.MarkInvoiceAttempt(ctx, subscription.MerchantID, attempt.ID, InvoiceAttemptCaptured, orderResult.ID, captureResult.PaymentID, "", "")
+		s.recordInvoiceAttemptNonFatal(ctx, subscription, attempt.ID, InvoiceAttemptCaptured, orderResult.ID, captureResult.PaymentID, "", "")
 	}
 	invoice, err = s.repo.MarkInvoicePaid(ctx, subscription.MerchantID, invoice.ID, orderResult.ID, captureResult.PaymentID, periodEnd)
 	if err != nil {
@@ -709,4 +731,29 @@ func (s *Service) markSubscriptionInvoiceFailure(ctx context.Context, subscripti
 		return failedInvoice, primaryErr
 	}
 	return failedInvoice, errors.Join(append([]error{primaryErr}, cleanupErrs...)...)
+}
+
+func (s *Service) recordInvoiceAttemptNonFatal(ctx context.Context, subscription Subscription, attemptID string, status InvoiceAttemptStatus, orderID, paymentID, failureCode, failureMessage string) {
+	if err := s.repo.MarkInvoiceAttempt(ctx, subscription.MerchantID, attemptID, status, orderID, paymentID, failureCode, failureMessage); err != nil {
+		s.logger.WarnContext(ctx, "billing attempt bookkeeping failed",
+			"merchant_id", subscription.MerchantID,
+			"subscription_id", subscription.ID,
+			"attempt_id", attemptID,
+			"status", status,
+			"error", err,
+		)
+	}
+}
+
+func (s *Service) recordMandateChargeResultNonFatal(ctx context.Context, subscription Subscription, mandateID string, eventType UPIMandateEventType, paymentID, reason string, metadata map[string]any) {
+	if err := s.repo.RecordUPIMandateChargeResult(ctx, subscription.MerchantID, mandateID, eventType, paymentID, reason, metadata); err != nil {
+		s.logger.WarnContext(ctx, "billing mandate charge bookkeeping failed",
+			"merchant_id", subscription.MerchantID,
+			"subscription_id", subscription.ID,
+			"mandate_id", mandateID,
+			"event_type", eventType,
+			"payment_id", paymentID,
+			"error", err,
+		)
+	}
 }


### PR DESCRIPTION
## Summary
- return joined errors from due-subscription execution instead of silently swallowing failures
- add structured warning logs for non-fatal recurring billing bookkeeping writes
- keep successful money-movement semantics unchanged

## Validation
- `go test ./internal/payment ./internal/billing`
- `go test -race ./internal/payment ./internal/billing`
- `go vet ./internal/payment ./internal/billing`

Closes #593
Closes #594
