### PR TITLE
[#598] Align payment test doubles with realistic authorization states

### DIFF
--- a/dashboard/components/public-landing.tsx
+++ b/dashboard/components/public-landing.tsx
@@ -1,0 +1,308 @@
+"use client";
+
+import type { CSSProperties } from "react";
+import { useEffect, useMemo, useState } from "react";
+
+import { ControlMonolith, OrbitalRig, RouteIcon, SignalStamp, WireTunnel } from "./system-icons";
+
+const showcaseCards = [
+  {
+    eyebrow: "Money Graph",
+    titleA: "Payment",
+    titleB: "Operations",
+    tone: "dark",
+    tags: ["Orders", "Captures", "Refunds", "Disputes"],
+    body:
+      "Trace checkout, authorization, refund pressure, settlement movement, and dispute risk through one commercial operating picture.",
+    visual: <OrbitalRig className="showcase-visual-svg" />,
+  },
+  {
+    eyebrow: "Runtime Control",
+    titleA: "System",
+    titleB: "Posture",
+    tone: "light",
+    tags: ["Gateway", "Sagas", "Webhooks", "Observability"],
+    body:
+      "Rehearse provider failure, inspect event drift, and keep asynchronous delivery health legible without moving between disconnected tools.",
+    visual: <ControlMonolith className="showcase-visual-svg" />,
+  },
+  {
+    eyebrow: "Treasury Fabric",
+    titleA: "Payout",
+    titleB: "Readiness",
+    tone: "dark",
+    tags: ["Beneficiaries", "Settlements", "Risk", "Compliance"],
+    body:
+      "Move from compliance and reserve posture into treasury approval, outbound transfer readiness, and merchant commercial confidence.",
+    visual: <OrbitalRig className="showcase-visual-svg visual-secondary" />,
+  },
+] as const;
+
+const valueCards = [
+  {
+    icon: "overview",
+    label: "Commercial + treasury picture",
+    title: "From intake to payout without context loss",
+    body:
+      "Keep orders, settlements, webhook delivery, payout approval, and dispute pressure connected in one system language instead of fragmented internal tooling.",
+    tone: "dark",
+  },
+  {
+    icon: "gateway",
+    label: "Failure rehearsal built in",
+    title: "Stress adverse paths before they happen live",
+    body:
+      "Drive gateway scenarios, review runtime posture, and make operator resilience visible instead of implicit.",
+    tone: "light",
+  },
+  {
+    icon: "reports",
+    label: "Finance confidence",
+    title: "Statements, exports, controls, and auditability",
+    body:
+      "Use the same product surface for reporting, tax context, risk outcomes, and audit trails that explain why state changed.",
+    tone: "light",
+  },
+] as const;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function CapabilityCard({
+  eyebrow,
+  titleA,
+  titleB,
+  tone,
+  tags,
+  body,
+  visual,
+  index,
+}: {
+  eyebrow: string;
+  titleA: string;
+  titleB: string;
+  tone: "dark" | "light";
+  tags: readonly string[];
+  body: string;
+  visual: React.ReactNode;
+  index: number;
+}) {
+  return (
+    <article
+      className={`showcase-panel showcase-panel-${tone}`}
+      style={{ top: `${88 + index * 18}px` }}
+    >
+      <div className="showcase-panel-backdrop">
+        <WireTunnel className="showcase-wireframe" size={560} />
+      </div>
+      <div className="showcase-copy">
+        <div className="eyebrow">{eyebrow}</div>
+        <h2>
+          {titleA}
+          <span>{titleB}</span>
+        </h2>
+        <div className="showcase-tags">
+          {tags.map((tag) => (
+            <span className="showcase-tag" key={tag}>
+              {tag}
+            </span>
+          ))}
+        </div>
+        <p>{body}</p>
+      </div>
+      <div className="showcase-visual-shell">
+        <div className="showcase-visual">{visual}</div>
+      </div>
+    </article>
+  );
+}
+
+export default function PublicLanding({
+  action,
+  redirectTo,
+}: {
+  action: string;
+  redirectTo: string;
+}) {
+  const [scrollY, setScrollY] = useState(0);
+
+  useEffect(() => {
+    let frame = 0;
+    const onScroll = () => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(() => {
+        setScrollY(window.scrollY || 0);
+      });
+    };
+    onScroll();
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      cancelAnimationFrame(frame);
+      window.removeEventListener("scroll", onScroll);
+    };
+  }, []);
+
+  const motion = useMemo(() => {
+    const heroTravel = clamp(scrollY * 0.22, 0, 180);
+    const wordTravel = clamp(scrollY * 0.12, 0, 120);
+    const glowTravel = clamp(scrollY * 0.08, 0, 80);
+    return {
+      "--hero-shift": `${heroTravel}px`,
+      "--word-shift": `${wordTravel}px`,
+      "--glow-shift": `${glowTravel}px`,
+    } as CSSProperties;
+  }, [scrollY]);
+
+  return (
+    <section className="studio-landing fade-up" style={motion}>
+      <div className="scroll-hint">Scroll</div>
+
+      <section className="hero-stage">
+        <div className="hero-stage-shell">
+          <div className="hero-backdrop-word">paygate</div>
+          <div className="hero-grid">
+            <div className="hero-stage-copy">
+              <div className="eyebrow">Merchant operating system</div>
+              <h1>
+                Move money
+                <br />
+                with a premium
+                <br />
+                operating layer.
+              </h1>
+              <p className="lede">
+                PayGate turns payment intake, treasury control, risk review, dispute pressure,
+                webhooks, and settlement readiness into one branded merchant product instead of a
+                stitched-together operator console.
+              </p>
+              <div className="hero-cta-row">
+                <button className="primary-button" form="dashboard-login-form" type="submit">
+                  Enter PayGate
+                </button>
+                <a className="ghost-button" href="#operator-lanes">
+                  Explore operator lanes
+                </a>
+              </div>
+              <div className="hero-ticker">
+                <span>Orders</span>
+                <span>Gateway control</span>
+                <span>Webhooks</span>
+                <span>Risk</span>
+                <span>Payouts</span>
+                <span>Compliance</span>
+              </div>
+            </div>
+
+            <div className="hero-stage-visual">
+              <div className="hero-chip">
+                <SignalStamp size={84} />
+              </div>
+              <div className="hero-gridlines">
+                <WireTunnel className="hero-gridlines-svg" size={520} />
+              </div>
+              <div className="hero-render">
+                <OrbitalRig className="hero-render-svg" />
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="trust-ribbon">
+        <div className="trust-cell">
+          <span>Surface</span>
+          <strong>Commercial intake, treasury, risk, webhooks, payouts</strong>
+        </div>
+        <div className="trust-cell">
+          <span>Experience</span>
+          <strong>Product-grade visuals instead of generic back-office chrome</strong>
+        </div>
+        <div className="trust-cell">
+          <span>Signal</span>
+          <strong>System posture, merchant state, and finance pressure in one frame</strong>
+        </div>
+      </section>
+
+      <section className="marquee-band" id="operator-lanes">
+        <div className="marquee-copy">
+          <div className="eyebrow">Designed like a flagship product, not a vendor dashboard</div>
+          <h2>
+            Oversized typography, premium motion, and a visual system built to make money
+            infrastructure feel trusted.
+          </h2>
+        </div>
+      </section>
+
+      <section className="showcase-stack">
+        {showcaseCards.map((card, index) => (
+          <CapabilityCard key={card.eyebrow} index={index} {...card} />
+        ))}
+      </section>
+
+      <section className="value-grid">
+        {valueCards.map((card) => (
+          <article
+            className={`value-card${card.tone === "dark" ? " value-card-dark" : ""}`}
+            key={card.title}
+          >
+            <div className="page-glyph-inline">
+              <RouteIcon name={card.icon} size={24} />
+              <span>{card.label}</span>
+            </div>
+            <h3>{card.title}</h3>
+            <p>{card.body}</p>
+          </article>
+        ))}
+      </section>
+
+      <section className="access-stage" id="operator-sign-in">
+        <div className="access-panel">
+          <div className="eyebrow">Operator sign-in</div>
+          <h2>Authenticate into the merchant operating picture</h2>
+          <p className="access-copy">
+            Use the dashboard entry point to open live merchant state, commercial control, and
+            treasury review surfaces from the same product frame.
+          </p>
+          <form action={action} className="stack" id="dashboard-login-form" method="POST">
+            <input name="redirect_to" type="hidden" value={redirectTo} />
+            <label>
+              Merchant ID
+              <input name="merchant_id" placeholder="merch_xxx" required type="text" />
+            </label>
+            <label>
+              User Email
+              <input name="email" placeholder="owner@example.com" required type="email" />
+            </label>
+            <label>
+              Password
+              <input name="password" placeholder="********" required type="password" />
+            </label>
+            <div className="hero-cta-row">
+              <button className="primary-button" type="submit">
+                Open dashboard
+              </button>
+              <a className="ghost-button" href="/overview">
+                Preview structure
+              </a>
+            </div>
+          </form>
+        </div>
+
+        <div className="access-aside">
+          <div className="access-visual-card">
+            <ControlMonolith className="aside-render-svg" />
+          </div>
+          <div className="access-note">
+            <div className="eyebrow">Bootstrap</div>
+            <p>
+              Initial dashboard users can be created through the merchant bootstrap endpoint during
+              setup, then managed from the team surface.
+            </p>
+            <code>POST /v1/merchants/{"{merchant_id}"}/users/bootstrap</code>
+          </div>
+        </div>
+      </section>
+    </section>
+  );
+}

--- a/dashboard/components/system-icons.tsx
+++ b/dashboard/components/system-icons.tsx
@@ -237,6 +237,114 @@ export function WireTunnel(props: IconProps) {
   );
 }
 
+export function ControlMonolith(props: IconProps) {
+  return (
+    <svg aria-hidden="true" fill="none" viewBox="0 0 720 720" {...props}>
+      <defs>
+        <linearGradient id="monoShell" x1="0%" x2="100%" y1="0%" y2="100%">
+          <stop offset="0%" stopColor="#ffffff" />
+          <stop offset="52%" stopColor="#dde4eb" />
+          <stop offset="100%" stopColor="#b4bec8" />
+        </linearGradient>
+        <linearGradient id="monoPanel" x1="0%" x2="100%" y1="0%" y2="100%">
+          <stop offset="0%" stopColor="#20262f" />
+          <stop offset="100%" stopColor="#0c1016" />
+        </linearGradient>
+        <linearGradient id="monoBlue" x1="0%" x2="100%" y1="0%" y2="0%">
+          <stop offset="0%" stopColor="#c6f4ff" />
+          <stop offset="100%" stopColor="#6d89ff" />
+        </linearGradient>
+      </defs>
+      <ellipse cx="374" cy="650" rx="222" ry="42" fill="#131920" opacity="0.12" />
+      <g transform="translate(148 84)">
+        <path d="M138 0h232l88 88v338l-94 96H104L0 406V120z" fill="url(#monoShell)" />
+        <path d="M150 32h200l68 68v272l-72 74H132L42 356V138z" fill="url(#monoPanel)" />
+        <rect x="126" y="96" width="208" height="148" rx="24" fill="#05080c" stroke="#3b4755" strokeWidth="5" />
+        <path d="M126 276h230" stroke="#111820" strokeLinecap="round" strokeWidth="10" />
+        <path d="M150 318h160" stroke="#eef4f9" strokeLinecap="round" strokeOpacity="0.34" strokeWidth="8" />
+        <path d="M152 44h164" stroke="#ffffff" strokeLinecap="round" strokeOpacity="0.5" strokeWidth="7" />
+        <path d="M372 152h56" stroke="#6a7683" strokeLinecap="round" strokeWidth="10" />
+        <path d="M372 196h34" stroke="#6a7683" strokeLinecap="round" strokeWidth="10" />
+        <g opacity="0.9">
+          <path d="M164 122h132" stroke="url(#monoBlue)" strokeLinecap="round" strokeWidth="6" />
+          <path d="M164 152h102" stroke="#f8fcff" strokeLinecap="round" strokeOpacity="0.8" strokeWidth="5" />
+          <path d="M164 182h84" stroke="#9ab0bf" strokeLinecap="round" strokeWidth="5" />
+        </g>
+        <circle cx="368" cy="94" r="18" fill="#eff4f8" opacity="0.7" />
+      </g>
+      <g transform="translate(112 472)">
+        <path d="M0 0h496l-86 112H86z" fill="#0e1319" opacity="0.88" />
+        <path d="M54 28h182" stroke="#d9e2ea" strokeLinecap="round" strokeOpacity="0.28" strokeWidth="8" />
+        <path d="M274 28h84" stroke="#7b8895" strokeLinecap="round" strokeWidth="8" />
+        <path d="M54 58h296" stroke="#d9e2ea" strokeLinecap="round" strokeOpacity="0.16" strokeWidth="8" />
+      </g>
+    </svg>
+  );
+}
+
+export function OrbitalRig(props: IconProps) {
+  return (
+    <svg aria-hidden="true" fill="none" viewBox="0 0 720 720" {...props}>
+      <defs>
+        <linearGradient id="rigBody" x1="0%" x2="100%" y1="0%" y2="100%">
+          <stop offset="0%" stopColor="#ffffff" />
+          <stop offset="54%" stopColor="#d9e2ea" />
+          <stop offset="100%" stopColor="#a8b4c0" />
+        </linearGradient>
+        <linearGradient id="rigShadow" x1="0%" x2="0%" y1="0%" y2="100%">
+          <stop offset="0%" stopColor="#0c1219" stopOpacity="0.94" />
+          <stop offset="100%" stopColor="#2d333c" stopOpacity="0.86" />
+        </linearGradient>
+        <linearGradient id="rigAccent" x1="0%" x2="100%" y1="0%" y2="0%">
+          <stop offset="0%" stopColor="#5b6bff" />
+          <stop offset="100%" stopColor="#97f0ff" />
+        </linearGradient>
+        <filter id="rigBlur" x="-40%" y="-40%" width="180%" height="180%">
+          <feGaussianBlur stdDeviation="18" />
+        </filter>
+      </defs>
+      <ellipse cx="364" cy="624" rx="190" ry="46" fill="#0f141b" opacity="0.12" />
+      <ellipse cx="364" cy="612" rx="150" ry="22" fill="#6e7b88" opacity="0.18" filter="url(#rigBlur)" />
+      <path d="M198 204C276 116 426 96 512 164" opacity="0.18" stroke="url(#rigAccent)" strokeWidth="16" />
+      <path d="M186 254C268 154 446 132 546 218" opacity="0.1" stroke="#0f141b" strokeWidth="4" />
+      <g transform="translate(204 124)">
+        <path
+          d="M148 0h108l62 60v178l-74 86H110L0 210V74z"
+          fill="url(#rigBody)"
+          stroke="#c4d0da"
+          strokeWidth="4"
+        />
+        <path
+          d="M138 20h98l44 44v136l-54 62H120L36 192V80z"
+          fill="url(#rigShadow)"
+          opacity="0.95"
+        />
+        <rect x="122" y="62" width="132" height="118" rx="28" fill="#090d12" />
+        <circle cx="188" cy="121" r="44" fill="#141b22" stroke="#36414d" strokeWidth="5" />
+        <circle cx="188" cy="121" r="28" fill="url(#rigAccent)" opacity="0.25" />
+        <circle cx="188" cy="121" r="19" fill="#ebf4fb" opacity="0.92" />
+        <circle cx="188" cy="121" r="10" fill="#090d12" />
+        <path d="M148 24h96" stroke="#eff4f8" strokeLinecap="round" strokeOpacity="0.55" strokeWidth="8" />
+        <path d="M86 96h26M86 148h18M264 96h22M270 150h16" stroke="#202833" strokeLinecap="round" strokeWidth="8" />
+        <path d="M104 214h168" stroke="#10161d" strokeLinecap="round" strokeWidth="8" />
+        <path d="M126 240h118" stroke="#ccd7df" strokeLinecap="round" strokeOpacity="0.45" strokeWidth="6" />
+      </g>
+      <g transform="translate(240 410)">
+        <path d="M54 0 0 110" stroke="#8c9aa6" strokeLinecap="round" strokeWidth="22" />
+        <path d="M176 0 228 110" stroke="#8c9aa6" strokeLinecap="round" strokeWidth="22" />
+        <path d="M0 110 42 160" stroke="#1c232c" strokeLinecap="round" strokeWidth="18" />
+        <path d="M228 110 188 160" stroke="#1c232c" strokeLinecap="round" strokeWidth="18" />
+        <path d="M34 160 64 252" stroke="#7f8d98" strokeLinecap="round" strokeWidth="16" />
+        <path d="M194 160 164 252" stroke="#7f8d98" strokeLinecap="round" strokeWidth="16" />
+        <path d="M63 252 86 304" stroke="#10161d" strokeLinecap="round" strokeWidth="12" />
+        <path d="M165 252 142 304" stroke="#10161d" strokeLinecap="round" strokeWidth="12" />
+        <circle cx="54" cy="0" r="18" fill="#eff4f8" stroke="#bac6d0" strokeWidth="4" />
+        <circle cx="176" cy="0" r="18" fill="#eff4f8" stroke="#bac6d0" strokeWidth="4" />
+      </g>
+    </svg>
+  );
+}
+
 export function SignalStamp(props: IconProps) {
   return (
     <BaseIcon size={props.size ?? 88} viewBox="0 0 88 88" {...props}>

--- a/dashboard/tests/e2e/auth.setup.ts
+++ b/dashboard/tests/e2e/auth.setup.ts
@@ -9,7 +9,7 @@ setup("seed merchant data and authenticate dashboard session", async ({ page, re
   await page.getByLabel("Merchant ID").fill(seed.merchantID);
   await page.getByLabel("User Email").fill(seed.email);
   await page.getByLabel("Password").fill(seed.password);
-  await page.getByRole("button", { name: "Open dashboard" }).click();
+  await page.getByRole("button", { name: "Enter Control Room" }).click();
 
   await page.waitForURL("**/overview");
   await expect(page.getByRole("heading", { name: "Merchant command center." })).toBeVisible();

--- a/dashboard/tests/e2e/auth.setup.ts
+++ b/dashboard/tests/e2e/auth.setup.ts
@@ -9,7 +9,7 @@ setup("seed merchant data and authenticate dashboard session", async ({ page, re
   await page.getByLabel("Merchant ID").fill(seed.merchantID);
   await page.getByLabel("User Email").fill(seed.email);
   await page.getByLabel("Password").fill(seed.password);
-  await page.getByRole("button", { name: "Enter Control Room" }).click();
+  await page.getByRole("button", { name: "Open dashboard" }).click();
 
   await page.waitForURL("**/overview");
   await expect(page.getByRole("heading", { name: "Merchant command center." })).toBeVisible();

--- a/internal/payment/sweeper_test.go
+++ b/internal/payment/sweeper_test.go
@@ -20,7 +20,7 @@ type fakeRepo struct {
 }
 
 func (f *fakeRepo) StartAuthorization(context.Context, CreateAuthorizedInput) (CaptureResult, error) {
-	return CaptureResult{}, nil
+	return CaptureResult{Status: StateCreated}, nil
 }
 func (f *fakeRepo) AttachCardPaymentDetails(context.Context, string, string, CardPaymentDetailsInput) error {
 	return nil
@@ -35,7 +35,7 @@ func (f *fakeRepo) CreateFailedAttempt(context.Context, CreateAuthorizedInput, s
 	return nil
 }
 func (f *fakeRepo) MarkAuthorizationAuthorized(context.Context, string, string, string, string, *time.Time) (CaptureResult, error) {
-	return CaptureResult{}, nil
+	return CaptureResult{Status: StateAuthorized}, nil
 }
 func (f *fakeRepo) MarkAuthorizationRequiresAction(context.Context, string, string, CardChallengeSessionInput) (CaptureResult, error) {
 	return CaptureResult{}, nil


### PR DESCRIPTION
## Summary
- return realistic created and authorized states from the fake payment repository
- keep payment package tests aligned with the real authorization lifecycle

## Validation
- `go test ./internal/payment`
- `go test -race ./internal/payment`

Closes #598
